### PR TITLE
Fix broken fault reporting

### DIFF
--- a/src/kernel.c
+++ b/src/kernel.c
@@ -49,7 +49,7 @@ void __attribute__((noreturn)) _exit(int status) {
 	}
 	// Dump message
 	if ((unsigned int)status < 5U) {
-		buffer = (const char *)&errorMessages[status];
+		buffer = errorMessages[status];
 		while ((c = *buffer++) != 0) {
 			while (!(USART1->SR & USART_SR_TXE));
 			USART1->DR = c;

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -29,8 +29,8 @@ extern volatile uint32_t _clockLowRes;
 // Error messages for _exit
 // Since SDIV by 0 is configured not to fault, no divide by 0 can occur here
 static const char * const errorMessages[] = {
-	"Segmentation fault", "Segmentation fault", "Illegal instruction",
-	"Stack overflow", "System task failure"
+	"Segmentation fault\n", "Segmentation fault\n", "Illegal instruction\n",
+	"Stack overflow\n", "System task failure\n"
 };
 static const char * const crashMessage =
 	"\r\nThe VEX Cortex has stopped working!\r\nError cause: ";


### PR DESCRIPTION
Before the faults would show up as an invalid string, now they work

example code:

```
void operatorControl() {
    printf("Hello, World!\n");
    printf("I have a good idea, lets cause a segfault!\n");
    delay(5000);
    volatile int x = *((int*) 0xFFFFFFFF) = 69;
    delay(5000);
    printf("I survived! %d\n", x);

    while (1) {
        delay(20);
    }
}
```

before:

```
Powered by PROS 2.11.0

PROS (C)2011-2014 Purdue ACM SIGBOTS
This program has ABSOLUTELY NO WARRANTY, not even an implied
warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Hello, World!
I have a good idea, lets cause a segfault!

The VEX Cortex has stopped working!
Error cause:
```

after:

```
Powered by PROS 2.11.0

PROS (C)2011-2014 Purdue ACM SIGBOTS
This program has ABSOLUTELY NO WARRANTY, not even an implied
warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Hello, World!
I have a good idea, lets cause a segfault!

The VEX Cortex has stopped working!
Error cause: Segmentation faul
```

kinda.. the last character isn't coming through

explanation:
    errorMessages[status] is of type const char*
    &errorMessages[status] gets a reference to the temp variable used to store the const char*
    (const char*) bypasses type safety so this mistake causes no compiler errors
    the raw bytes of the pointer to errorMessages[status] are sent to USART instead of the contents of errorMessages[status]
