### PR TITLE
Fix links at the bottom of README (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Drop us a line
 
 ### I think I found a bug!
 We maintain GitHub repositories for the three major components of the PROS ecosystem:
-- The Command Line Interface (cli) at purduesigbots/pros-cli
-- The Atom plugin at purduesigbots/pros-atom
-- The kernel (purduesigbots/pros)
+- The Command Line Interface (cli) at [purduesigbots/pros-cli](github.com/purduesigbots/pros-cli)
+- The Atom plugin at [purduesigbots/pros-atom](github.com/purduesigbots/pros-atom)
+- The kernel [here](github.com/purduesigbots/pros)
 
 If you find a problem with our documentation or tutorials, we have a repository for that, too, at [purduesigbots/pros-docs](github.com/purduesigbots/pros-docs).


### PR DESCRIPTION
I feel like I keep doing this, but for some reason attempting to hotlink our repos à la `purduesigbots/pros` doesn't work [anymore], so I'm changing them to absolute links for absolute consistency