### PR TITLE
GitHub docs updates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to PROS
 
-:tada: :+1: :steam_locomotive: Thanks for taking the time to contribute :steam_locomotive: :+1: :tada:
+:tada: :+1: :steam_locomotive: Thanks for taking the time to contribute! :steam_locomotive: :+1: :tada:
 
 **Did you find a bug?**
 - **Before opening an issue, make sure you are in the right repository!**

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,8 +1,14 @@
 # Contributing to PROS
 
-:tada: :+1: :steam_locomotive: Thanks for taking the time to contribute :steam_locomotive: :+1: :tada:
+:tada: :+1: :steam_locomotive: Thanks for taking the time to contribute@ :steam_locomotive: :+1: :tada:
 
 **Did you find a bug?**
+- **Before opening an issue, make sure you are in the right repository!**
+  purduesigbots maintains four repositories related to PROS:
+  - [purduesigbots/pros](https://github.com/purduesigbots/pros): the repository containing the source code for the kernel the user-facing API. Issues should be opened here if they affect the code you write (e.g., "I would like to be able to do X with PROS," or "when I call <PROS function> X doesn't work as I expect")
+  - [purduesigbots/pros-cli](https://github.com/purduesigbots/pros-cli): the repository containing the source code for the command line interface (CLI). Issues should be opened here if they concern the PROS CLI (e.g., problems with commands like `pros make`), as well as project creation and management.
+  - [purduesigbots/pros-atom](https://github.com/purduesigbots/pros-atom): the repository containing the source code for the Atom package. Issues should be opened here if they concern the coding experience within Atom (e.g., "there is no button to do X," or "the linter is spamming my interface with errors").
+  - [purduesigbots/pros-docs](https://github.com/purduesigbots/pros-docs): the repository containing the source code for [our documentation website](https://pros.cs.purdue.edu). Issues should be opened here if they concern available documentation (e.g., "there is not guide on using <PROS feature>," or "the documentation says to do X, but only Y works")
 - **Verify the bug lies in PROS.** We receive quite a few reports that are due to bugs in user code, not the kernel.
 - Ensure the bug wasn't already reported by searching GitHub [issues](https://github.com/purduesigbots/pros/issues)
 - If you're unable to find an issue, [open](https://github.com/purduesigbots/pros/issues/new) a new one.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to PROS
 
-:tada: :+1: :steam_locomotive: Thanks for taking the time to contribute@ :steam_locomotive: :+1: :tada:
+:tada: :+1: :steam_locomotive: Thanks for taking the time to contribute :steam_locomotive: :+1: :tada:
 
 **Did you find a bug?**
 - **Before opening an issue, make sure you are in the right repository!**

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can develop code on Windows, OS X, or Linux. Code is compiled using GCC and 
 The PROS team develops a plugin for Atom to making developing projects in PROS the best possible experience. The highly customizable editor designed for the 21st century enables students to learn how to code in a modern environment.
 
 ### Cool, how do I get it?
-Pay a visit to our website, [pros.cs.purdue.edu](pros.cs.purdue.edu), to download our latest installer or view installation instructions for your preferred platform.
+Pay a visit to our website, [pros.cs.purdue.edu](https://pros.cs.purdue.edu), to download our latest installer or view installation instructions for your preferred platform.
 
 ### How do I use it?
 We have a number of resources available on our website, including

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Drop us a line
 
 ### I think I found a bug!
 We maintain GitHub repositories for the three major components of the PROS ecosystem:
-- The Command Line Interface (cli) at [purduesigbots/pros-cli](github.com/purduesigbots/pros-cli)
-- The Atom plugin at [purduesigbots/pros-atom](github.com/purduesigbots/pros-atom)
-- The kernel [here](github.com/purduesigbots/pros)
+- The Command Line Interface (cli) at [purduesigbots/pros-cli](https://github.com/purduesigbots/pros-cli)
+- The Atom plugin at [purduesigbots/pros-atom](https://github.com/purduesigbots/pros-atom)
+- The kernel [here](https://github.com/purduesigbots/pros)
 
 If you find a problem with our documentation or tutorials, we have a repository for that, too, at purduesigbots/pros-docs.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We have a number of resources available on our website, including
 Drop us a line
 - at pros_development@cs.purdue.edu 
 - on the [VEX Forum](https://www.vexforum.com/index.php/)
-- on VEX Teams of the World Discord
+- on [VEX Teams of the World Discord](https://discord.gg/xddjWGj)
 
 ### I think I found a bug!
 We maintain GitHub repositories for the three major components of the PROS ecosystem:


### PR DESCRIPTION
Add information about our various repositories in the contribution guidelines.
These can be basically dropped in to the same file in our other repositories.

Seeking input on my examples of issues that should be opened in each repo, as I think they're a little lame.