### PR TITLE
Add C++ compatability with FILE symbol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ template/src/*
 !template/src/Makefile
 template/include
 template/firmware
+.vscode/

--- a/include/API.h
+++ b/include/API.h
@@ -748,7 +748,7 @@ typedef int PROS_FILE;
 /**
  * For convenience, FILE is defined as PROS_FILE if it wasn't already defined. This provides 
  * backwards compatability with PROS, but also allows libraries such as newlib to be incorporated
- * into PROS projects. If you're not using C++/newlib, you can use FILE as previously
+ * into PROS projects. If you're not using C++/newlib, you can disregard this and just use FILE.
  */
 #define FILE PROS_FILE
 #endif

--- a/include/API.h
+++ b/include/API.h
@@ -736,12 +736,16 @@ bool i2cWrite(uint8_t addr, uint8_t *data, uint16_t count);
 bool i2cWriteRegister(uint8_t addr, uint8_t reg, uint16_t value);
 
 /**
- * FILE is an integer referring to a stream for the standard I/O functions.
+ * PROS_FILE is an integer referring to a stream for the standard I/O functions.
  *
- * FILE * is the standard library method of referring to a file pointer, even though there is
+ * PROS_FILE * is the standard library method of referring to a file pointer, even though there is
  * actually nothing there.
  */
-typedef int FILE;
+typedef int PROS_FILE;
+
+#ifndef FILE
+#define FILE PROS_FILE
+#endif
 /**
  * Bit mask for usartInit() for 8 data bits (typical)
  */
@@ -791,7 +795,7 @@ typedef int FILE;
  * @param flags a bit mask combination of the SERIAL_* flags specifying parity, stop, and data
  * bits
  */
-void usartInit(FILE *usart, unsigned int baud, unsigned int flags);
+void usartInit(PROS_FILE *usart, unsigned int baud, unsigned int flags);
 /**
  * Disables the specified USART interface.
  *
@@ -801,26 +805,26 @@ void usartInit(FILE *usart, unsigned int baud, unsigned int flags);
  *
  * @param usart the port to close, either "uart1" or "uart2"
  */
-void usartShutdown(FILE *usart);
+void usartShutdown(PROS_FILE *usart);
 
 // -------------------- Character input and output --------------------
 
 /**
  * The standard output stream uses the PC debug terminal.
  */
-#define stdout ((FILE *)3)
+#define stdout ((PROS_FILE *)3)
 /**
  * The standard input stream uses the PC debug terminal.
  */
-#define stdin ((FILE *)3)
+#define stdin ((PROS_FILE *)3)
 /**
  * UART 1 on the Cortex; must be opened first using usartInit().
  */
-#define uart1 ((FILE *)1)
+#define uart1 ((PROS_FILE *)1)
 /**
  * UART 2 on the Cortex; must be opened first using usartInit().
  */
-#define uart2 ((FILE *)2)
+#define uart2 ((PROS_FILE *)2)
 
 #ifndef EOF
 /**
@@ -857,7 +861,7 @@ void usartShutdown(FILE *usart);
  *
  * @param stream the file descriptor to close from fopen()
  */
-void fclose(FILE *stream);
+void fclose(PROS_FILE *stream);
 /**
  * Returns the number of characters that can be read without blocking (the number of
  * characters available) from the specified stream. This only works for communication ports and
@@ -870,7 +874,7 @@ void fclose(FILE *stream);
  * @return the number of characters which meet this criterion; if this number cannot be
  * determined, returns 0
  */
-int fcount(FILE *stream);
+int fcount(PROS_FILE *stream);
 /**
  * Delete the specified file if it exists and is not currently open.
  *
@@ -889,7 +893,7 @@ int fdelete(const char *file);
  * @param stream the channel to check (stdin, uart1, uart2, or an open file in Read mode)
  * @return 0 if the stream is not at EOF, or 1 otherwise.
  */
-int feof(FILE *stream);
+int feof(PROS_FILE *stream);
 /**
  * Flushes the data on the specified file channel open in Write mode. This function has no
  * effect on a communication port or a file in Read mode, as these streams are always flushed as
@@ -901,7 +905,7 @@ int feof(FILE *stream);
  * @param stream the channel to flush (an open file in Write mode)
  * @return 0 if the data was successfully flushed, EOF otherwise
  */
-int fflush(FILE *stream);
+int fflush(PROS_FILE *stream);
 /**
  * Reads and returns one character from the specified stream, blocking until complete.
  *
@@ -910,7 +914,7 @@ int fflush(FILE *stream);
  * @param stream the stream to read (stdin, uart1, uart2, or an open file in Read mode)
  * @return the next character from 0 to 255, or -1 if no character can be read
  */
-int fgetc(FILE *stream);
+int fgetc(PROS_FILE *stream);
 /**
  * Reads a string from the specified stream, storing the characters into the memory at str.
  * Characters will be read until the specified limit is reached, a new line is found, or the
@@ -925,7 +929,7 @@ int fgetc(FILE *stream);
  * @param stream the channel to read (stdin, uart1, uart2, or an open file in Read mode)
  * @return str, or NULL if zero characters could be read
  */
-char* fgets(char *str, int num, FILE *stream);
+char* fgets(char *str, int num, PROS_FILE *stream);
 /**
  * Opens the given file in the specified mode. The file name is truncated to eight characters.
  * Only four files can be in use simultaneously in any given time, with at most one of those
@@ -949,7 +953,7 @@ char* fgets(char *str, int num, FILE *stream);
  * @param mode the file mode
  * @return a file descriptor pointing to the new file, or NULL if the file could not be opened
  */
-FILE * fopen(const char *file, const char *mode);
+PROS_FILE * fopen(const char *file, const char *mode);
 /**
  * Prints the simple string to the specified stream.
  *
@@ -959,7 +963,7 @@ FILE * fopen(const char *file, const char *mode);
  * @param string the string to write
  * @param stream the stream to write (stdout, uart1, uart2, or an open file in Write mode)
  */
-void fprint(const char *string, FILE *stream);
+void fprint(const char *string, PROS_FILE *stream);
 /**
  * Writes one character to the specified stream.
  *
@@ -969,7 +973,7 @@ void fprint(const char *string, FILE *stream);
  * @param stream the stream to write (stdout, uart1, uart2, or an open file in Write mode)
  * @return the character written
  */
-int fputc(int value, FILE *stream);
+int fputc(int value, PROS_FILE *stream);
 /**
  * Behaves the same as the "fprint" function, and appends a trailing newline ("\n").
  *
@@ -979,7 +983,7 @@ int fputc(int value, FILE *stream);
  * @param stream the stream to write (stdout, uart1, uart2, or an open file in Write mode)
  * @return the number of characters written, excluding the new line
  */
-int fputs(const char *string, FILE *stream);
+int fputs(const char *string, PROS_FILE *stream);
 /**
  * Reads data from a stream into memory. Returns the number of bytes thus read.
  *
@@ -991,7 +995,7 @@ int fputs(const char *string, FILE *stream);
  * @param stream the stream to read (stdout, uart1, uart2, or an open file in Read mode)
  * @return the number of bytes successfully read
  */
-size_t fread(void *ptr, size_t size, size_t count, FILE *stream);
+size_t fread(void *ptr, size_t size, size_t count, PROS_FILE *stream);
 /**
  * Seeks within a file open in Read mode. This function will fail when used on a file in Write
  * mode or on any communications port.
@@ -1001,7 +1005,7 @@ size_t fread(void *ptr, size_t size, size_t count, FILE *stream);
  * @param origin the reference location for offset: SEEK_CUR, SEEK_SET, or SEEK_END
  * @return 0 if the seek was successful, or 1 otherwise
  */
-int fseek(FILE *stream, long int offset, int origin);
+int fseek(PROS_FILE *stream, long int offset, int origin);
 /**
  * Returns the current position of the stream. This function works on files in either Read or
  * Write mode, but will fail on communications ports.
@@ -1009,7 +1013,7 @@ int fseek(FILE *stream, long int offset, int origin);
  * @param stream the stream to check
  * @return the offset of the stream, or -1 if the offset could not be determined
  */
-long int ftell(FILE *stream);
+long int ftell(PROS_FILE *stream);
 /**
  * Writes data from memory to a stream. Returns the number of bytes thus written.
  *
@@ -1021,7 +1025,7 @@ long int ftell(FILE *stream);
  * @param stream the stream to write (stdout, uart1, uart2, or an open file in Write mode)
  * @return the number of bytes successfully written
  */
-size_t fwrite(const void *ptr, size_t size, size_t count, FILE *stream);
+size_t fwrite(const void *ptr, size_t size, size_t count, PROS_FILE *stream);
 /**
  * Reads and returns one character from "stdin", which is the PC debug terminal.
  *
@@ -1084,7 +1088,7 @@ int puts(const char *string);
  * @param formatString the format string as specified above
  * @return the number of characters written
  */
-int fprintf(FILE *stream, const char *formatString, ...);
+int fprintf(PROS_FILE *stream, const char *formatString, ...);
 /**
  * Prints the formatted string to the debug stream (the PC terminal).
  *
@@ -1138,7 +1142,7 @@ int sprintf(char *buffer, const char *formatString, ...);
  *
  * @param lcdPort the LCD to clear, either uart1 or uart2
  */
-void lcdClear(FILE *lcdPort);
+void lcdClear(PROS_FILE *lcdPort);
 /**
  * Initializes the LCD port, but does not change the text or settings.
  *
@@ -1147,7 +1151,7 @@ void lcdClear(FILE *lcdPort);
  *
  * @param lcdPort the LCD to initialize, either uart1 or uart2
  */
-void lcdInit(FILE *lcdPort);
+void lcdInit(PROS_FILE *lcdPort);
 /**
  * Prints the formatted string to the attached LCD.
  *
@@ -1160,9 +1164,9 @@ void lcdInit(FILE *lcdPort);
  * @param formatString the format string as specified in fprintf()
  */
 #ifdef DOXYGEN
-void lcdPrint(FILE *lcdPort, unsigned char line, const char *formatString, ...);
+void lcdPrint(PROS_FILE *lcdPort, unsigned char line, const char *formatString, ...);
 #else
-void __attribute__ ((format (printf, 3, 4))) lcdPrint(FILE *lcdPort, unsigned char line,
+void __attribute__ ((format (printf, 3, 4))) lcdPrint(PROS_FILE *lcdPort, unsigned char line,
 	const char *formatString, ...);
 #endif
 /**
@@ -1174,7 +1178,7 @@ void __attribute__ ((format (printf, 3, 4))) lcdPrint(FILE *lcdPort, unsigned ch
  * @param lcdPort the LCD to poll, either uart1 or uart2
  * @return the buttons pressed as a bit mask
  */
-unsigned int lcdReadButtons(FILE *lcdPort);
+unsigned int lcdReadButtons(PROS_FILE *lcdPort);
 /**
  * Sets the specified LCD backlight to be on or off.
  *
@@ -1183,7 +1187,7 @@ unsigned int lcdReadButtons(FILE *lcdPort);
  * @param lcdPort the LCD to adjust, either uart1 or uart2
  * @param backlight true to turn the backlight on, or false to turn it off
  */
-void lcdSetBacklight(FILE *lcdPort, bool backlight);
+void lcdSetBacklight(PROS_FILE *lcdPort, bool backlight);
 /**
  * Prints the string buffer to the attached LCD.
  *
@@ -1195,13 +1199,13 @@ void lcdSetBacklight(FILE *lcdPort, bool backlight);
  * @param line the LCD line to write, either 1 or 2
  * @param buffer the string to write
  */
-void lcdSetText(FILE *lcdPort, unsigned char line, const char *buffer);
+void lcdSetText(PROS_FILE *lcdPort, unsigned char line, const char *buffer);
 /**
  * Shut down the specified LCD port.
  *
  * @param lcdPort the LCD to stop, either uart1 or uart2
  */
-void lcdShutdown(FILE *lcdPort);
+void lcdShutdown(PROS_FILE *lcdPort);
 
 // -------------------- Real-time scheduler functions --------------------
 /**

--- a/include/API.h
+++ b/include/API.h
@@ -743,9 +743,16 @@ bool i2cWriteRegister(uint8_t addr, uint8_t reg, uint16_t value);
  */
 typedef int PROS_FILE;
 
+
 #ifndef FILE
+/**
+ * For convenience, FILE is defined as PROS_FILE if it wasn't already defined. This provides 
+ * backwards compatability with PROS, but also allows libraries such as newlib to be incorporated
+ * into PROS projects. If you're not using C++/newlib, you can use FILE as previously
+ */
 #define FILE PROS_FILE
 #endif
+
 /**
  * Bit mask for usartInit() for 8 data bits (typical)
  */

--- a/include/comm.h
+++ b/include/comm.h
@@ -33,35 +33,35 @@ extern "C" {
 #endif
 
 // ---- "Standard" I/O definitions ----
-// FILE is an integer referring to a stream; we use (invalid) pointers for compability
-typedef int FILE;
+// PROS_FILE is an integer referring to a stream; we use (invalid) pointers for compability
+typedef int PROS_FILE;
 // Standard input and output streams use the PC debug terminal
-#define stdout ((FILE *)3)
-#define stdin ((FILE *)3)
+#define stdout ((PROS_FILE *)3)
+#define stdin ((PROS_FILE *)3)
 // UART 1 on the Cortex
-#define uart1 ((FILE *)1)
+#define uart1 ((PROS_FILE *)1)
 // UART 2 on the Cortex
-#define uart2 ((FILE *)2)
+#define uart2 ((PROS_FILE *)2)
 // Bonus UART port on the crystal output (TX only)
-#define uart3 ((FILE *)4)
+#define uart3 ((PROS_FILE *)4)
 
 // ---- Simple I/O routines ----
 // fcount - Return number of characters available to read on the specified stream
-int fcount(FILE *stream);
+int fcount(PROS_FILE *stream);
 // feof - Return 1 if the stream is at EOF, or 0 otherwise
-int feof(FILE *fd);
+int feof(PROS_FILE *fd);
 // fgetc - Reads and returns one character from the specified stream, blocking until complete
-int fgetc(FILE *stream);
+int fgetc(PROS_FILE *stream);
 // fgets - Read a string from the specified stream
-char* fgets(char *str, int num, FILE *stream);
+char* fgets(char *str, int num, PROS_FILE *stream);
 // fread - Read data from stream
-size_t fread(void *ptr, size_t size, size_t count, FILE *stream);
+size_t fread(void *ptr, size_t size, size_t count, PROS_FILE *stream);
 // fwrite - Write data to stream
-size_t fwrite(const void *ptr, size_t size, size_t count, FILE *stream);
+size_t fwrite(const void *ptr, size_t size, size_t count, PROS_FILE *stream);
 // getchar - Reads and returns one character from "stdin"
 int getchar();
 // fputc - Writes one character to the specified stream and returns the input value
-int fputc(int value, FILE *stream);
+int fputc(int value, PROS_FILE *stream);
 // putchar - Writes one character to "stdout" and returns the input value
 int putchar(int value);
 // print - Prints the simple string to debug terminal
@@ -69,9 +69,9 @@ void print(const char *string);
 // puts - Same as "print" function, with trailing newline
 int puts(const char *string);
 // fprint - Prints the simple string to the specified stream
-void fprint(const char *string, FILE *stream);
+void fprint(const char *string, PROS_FILE *stream);
 // fputs - Same as "fprint" function, with trailing newline
-int fputs(const char *string, FILE *stream);
+int fputs(const char *string, PROS_FILE *stream);
 
 // ---- Formatted I/O routines ----
 // WARNING: Use of the this family of functions requires at least 48 variables
@@ -81,7 +81,7 @@ int fputs(const char *string, FILE *stream);
 // printf - Prints the formatted string to the debug stream (the PC terminal)
 int printf(const char *formatString, ...);
 // fprintf - Prints the formatted string to the specified output stream
-int fprintf(FILE *stream, const char *formatString, ...);
+int fprintf(PROS_FILE *stream, const char *formatString, ...);
 // sprintf - Prints the formatted string to the string buffer, which must be big enough
 int sprintf(char *buffer, const char *formatString, ...);
 // snprintf - Prints the formatted string to the string buffer with the specified length limit
@@ -90,7 +90,7 @@ int snprintf(char *buffer, size_t limit, const char *formatString, ...);
 
 // Variadic macro variations of the above, which are only useful in a handful of cases
 // vfprintf - Prints the formatted string to the specified output stream
-int vfprintf(FILE *stream, const char *formatString, va_list arguments);
+int vfprintf(PROS_FILE *stream, const char *formatString, va_list arguments);
 // vsprintf - Prints the formatted string to a string buffer
 int vsprintf(char *buffer, const char *formatString, va_list arguments);
 // vsnprintf - Prints the formatted string to a string buffer with the given length limit
@@ -102,28 +102,28 @@ void usartBufferInit();
 // usartFlushBuffers - Clears the USART buffers
 void usartFlushBuffers();
 // usartInit - Initialize the specified USART interface with the given connection parameters
-void usartInit(FILE *usart, unsigned int baud, unsigned int flags);
+void usartInit(PROS_FILE *usart, unsigned int baud, unsigned int flags);
 // usartShutdown - Disable the specified USART interface
-void usartShutdown(FILE *usart);
+void usartShutdown(PROS_FILE *usart);
 
 // ---- LCD I/O routines ----
 // lcdClear - Clears the LCD screen on the specified port
-void lcdClear(FILE *lcdPort);
+void lcdClear(PROS_FILE *lcdPort);
 // lcdInit - Enables the LCD on the specified port
-void lcdInit(FILE *lcdPort);
+void lcdInit(PROS_FILE *lcdPort);
 // lcdPrint - Convenience method that performs snprintf() and then lcdSetText()
 void __attribute__ ((format (printf, 3, 4)))
-	lcdPrint(FILE *lcdPort, unsigned char line, const char *fmt, ...);
+	lcdPrint(PROS_FILE *lcdPort, unsigned char line, const char *fmt, ...);
 // lcdReadButtons - Reads the button status from the LCD display and returns the buttons
 // pressed as a bit mask
-unsigned int lcdReadButtons(FILE *lcdPort);
+unsigned int lcdReadButtons(PROS_FILE *lcdPort);
 // lcdSetBacklight - Turns the specified LCD backlight on or off
 // The backlight will not update until the next line is sent (maybe 15ms latency)
-void lcdSetBacklight(FILE *lcdPort, bool backlight);
+void lcdSetBacklight(PROS_FILE *lcdPort, bool backlight);
 // lcdSetText - Sets a line (1 or 2) of text on the LCD to the specified null-terminated string
-void lcdSetText(FILE *lcdPort, unsigned char line, const char *buffer);
+void lcdSetText(PROS_FILE *lcdPort, unsigned char line, const char *buffer);
 // lcdShutdown - Disable the LCD on the specified port
-void lcdShutdown(FILE *lcdPort);
+void lcdShutdown(PROS_FILE *lcdPort);
 
 // End C++ extern to C
 #ifdef __cplusplus

--- a/include/fs.h
+++ b/include/fs.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * @param fd the descriptor to close
  */
-void fclose(FILE *fd);
+void fclose(PROS_FILE *fd);
 /**
  * Delete the specified file if it exists and is not currently open.
  *
@@ -69,7 +69,7 @@ int fdelete(const char *file);
  * @param fd the channel to check
  * @return 0 if the file is not at EOF, or 1 otherwise.
  */
-int fsEof(FILE *fd);
+int fsEof(PROS_FILE *fd);
 /**
  * Flushes the data on the specified file channel.
  *
@@ -77,7 +77,7 @@ int fsEof(FILE *fd);
  * @return 0 if the data was successfully written out to Flash, EOF otherwise
  * The file data is still invalid until properly closed!
  */
-int fflush(FILE *fd);
+int fflush(PROS_FILE *fd);
 /**
  * Returns the number of bytes left in the file until EOF. Only applies to files open for
  * Read mode.
@@ -85,7 +85,7 @@ int fflush(FILE *fd);
  * @param fd the file channel to check
  * @return the number of bytes left, or 0 if this value could not be determined
  */
-uint32_t fsLeft(FILE *fd);
+uint32_t fsLeft(PROS_FILE *fd);
 /**
  * fopen() function for file system
  *
@@ -93,7 +93,7 @@ uint32_t fsLeft(FILE *fd);
  * @param mode the file mode
  * @return a pointer to file data, or NULL if the file could not be opened
  */
-FILE * fopen(const char *file, const char *mode);
+PROS_FILE * fopen(const char *file, const char *mode);
 /**
  * fread() function for file system
  *
@@ -101,7 +101,7 @@ FILE * fopen(const char *file, const char *mode);
  * @return the next byte in the file, or EOF if no byte can be read (end of file, in write
  * mode...)
  */
-int fsRead(FILE *fd);
+int fsRead(PROS_FILE *fd);
 /**
  * Scans the file system and builds a RAM structure describing the files
  * currently on the file system and the free space available.
@@ -117,14 +117,14 @@ void fsScan(bool trim);
  * @param origin the reference location for offset: SEEK_CUR, SEEK_SET, or SEEK_END
  * @return 0 if the seek was successful, or 1 otherwise
  */
-int fseek(FILE *fd, long int offset, int origin);
+int fseek(PROS_FILE *fd, long int offset, int origin);
 /**
  * ftell() function for file system
  *
  * @param fd the channel to check
  * @return the offset of the stream, or -1 if the offset could not be determined
  */
-long int ftell(FILE *fd);
+long int ftell(PROS_FILE *fd);
 /**
  * fwrite() function for file system
  *
@@ -132,7 +132,7 @@ long int ftell(FILE *fd);
  * @param value the byte to write
  * @return value if the byte was successfully written and EOF otherwise
  */
-int fsWrite(FILE *fd, int value);
+int fsWrite(PROS_FILE *fd, int value);
 
 #endif
 

--- a/src/comm.c
+++ b/src/comm.c
@@ -106,7 +106,7 @@ static void _waitForSpace(SerialPort_TypeDef* port) {
 }
 
 // fcount - Non-standard function to return estimated number of characters waiting on stream
-int fcount(FILE *stream) {
+int fcount(PROS_FILE *stream) {
 	uint32_t snew = (uint32_t)stream - 1;
 	if (snew < 3)
 		return (int)usartBufferCount(&usart[snew]);
@@ -119,7 +119,7 @@ int fcount(FILE *stream) {
 }
 
 // feof - Return 1 if the stream is at EOF, or 0 otherwise
-int feof(FILE *stream) {
+int feof(PROS_FILE *stream) {
 	uint32_t snew = (uint32_t)stream - 1;
 	if (snew < 3)
 		return (usartBufferCount(&usart[snew]) == 0) ? 1 : 0;
@@ -131,7 +131,7 @@ int feof(FILE *stream) {
 }
 
 // fgetc - Read a character from the specified stream
-int fgetc(FILE *stream) {
+int fgetc(PROS_FILE *stream) {
 	uint32_t snew = (uint32_t)stream - 1;
 	if (snew < 3) {
 		SerialPort_TypeDef *ser = &usart[snew];
@@ -149,7 +149,7 @@ int fgetc(FILE *stream) {
 }
 
 // fgets - Read a string from the specified stream
-char* fgets(char *str, int num, FILE *stream) {
+char* fgets(char *str, int num, PROS_FILE *stream) {
 	// Required by standard
 	char *ptr = str;
 	int value;
@@ -166,7 +166,7 @@ char* fgets(char *str, int num, FILE *stream) {
 }
 
 // fputc - Write a character to the specified stream
-int fputc(int value, FILE *stream) {
+int fputc(int value, PROS_FILE *stream) {
 	uint32_t snew = (uint32_t)stream - 1;
 	if (snew < 3) {
 		SerialPort_TypeDef *ser = &usart[snew];
@@ -192,7 +192,7 @@ int fputc(int value, FILE *stream) {
 }
 
 // fread - Read data from stream
-size_t fread(void *ptr, size_t size, size_t count, FILE *stream) {
+size_t fread(void *ptr, size_t size, size_t count, PROS_FILE *stream) {
 	char *memory = (char *)ptr;
 	size_t write = 0; int read;
 	for (uint32_t i = 0; i < (size * count); i++)
@@ -206,7 +206,7 @@ size_t fread(void *ptr, size_t size, size_t count, FILE *stream) {
 }
 
 // fwrite - Write data to stream
-size_t fwrite(const void *ptr, size_t size, size_t count, FILE *stream) {
+size_t fwrite(const void *ptr, size_t size, size_t count, PROS_FILE *stream) {
 	const char *memory = (const char *)ptr;
 	size_t write = 0;
 	for (uint32_t i = 0; i < (size * count); i++)
@@ -342,13 +342,13 @@ void ISR_USART3() {
 }
 
 // lcdClear - Clears the screen
-void lcdClear(FILE *lcdPort) {
+void lcdClear(PROS_FILE *lcdPort) {
 	lcdSetText(lcdPort, 1, "");
 	lcdSetText(lcdPort, 2, "");
 }
 
 // lcdInit - Enables the LCD on the specified port
-void lcdInit(FILE *lcdPort) {
+void lcdInit(PROS_FILE *lcdPort) {
 	// No flags = 8 N 1
 	if (lcdPort == uart1 || lcdPort == uart2) {
 		uint32_t idx = (uint32_t)lcdPort - 1;
@@ -361,7 +361,7 @@ void lcdInit(FILE *lcdPort) {
 }
 
 // lcdPrint - Convenience method that performs snprintf() and then lcdSetText()
-void lcdPrint(FILE *lcdPort, unsigned char line, const char *fmt, ...) {
+void lcdPrint(PROS_FILE *lcdPort, unsigned char line, const char *fmt, ...) {
 	char buffer[17];
 	// Pass to vsnprintf
 	va_list args;
@@ -375,7 +375,7 @@ void lcdPrint(FILE *lcdPort, unsigned char line, const char *fmt, ...) {
 
 // lcdReadButtons - Reads the button status from the LCD display and returns the buttons
 // pressed as a bit mask. Does not block, always returns the last button status
-unsigned int lcdReadButtons(FILE *lcdPort) {
+unsigned int lcdReadButtons(PROS_FILE *lcdPort) {
 	uint32_t port = (uint32_t)lcdPort - 1;
 	if (port < 2) {
 		if (lcd[port].flags & LCD_ACTIVE)
@@ -386,7 +386,7 @@ unsigned int lcdReadButtons(FILE *lcdPort) {
 
 // lcdSetBacklight - Turns the specified LCD backlight on or off
 // The backlight will not update until the next line is sent (maybe 15ms latency)
-void lcdSetBacklight(FILE *lcdPort, bool backlight) {
+void lcdSetBacklight(PROS_FILE *lcdPort, bool backlight) {
 	uint32_t port = (uint32_t)lcdPort - 1;
 	if (port < 2) {
 		if (backlight)
@@ -403,7 +403,7 @@ void _lcdDump(uint32_t lcdIndex) {
 	uint8_t flags = lcd[lcdIndex].flags, total;
 	if (flags & LCD_ACTIVE) {
 		// Concoct the port
-		FILE *lcdPort = (FILE*)(lcdIndex + 1);
+		PROS_FILE *lcdPort = (PROS_FILE*)(lcdIndex + 1);
 		char value, *ptr = &(lcd[lcdIndex].screen[0]);
 		// Set line (alternating order)
 		if (flags & LCD_ROW_2) {
@@ -444,7 +444,7 @@ void _lcdDump(uint32_t lcdIndex) {
 // lcdSetText - Sets a line (1 or 2) of text on the LCD to the specified null-terminated string
 // Up to 16 characters will actually be transmitted; this function is thread safe, but
 // concurrent access to the same line of the same LCD will cause garbage text to be displayed
-void lcdSetText(FILE *lcdPort, unsigned char line, const char *buffer) {
+void lcdSetText(PROS_FILE *lcdPort, unsigned char line, const char *buffer) {
 	// Blit to the buffer, automatically dumped on the idle task
 	uint32_t port = (uint32_t)lcdPort - 1, i;
 	line--;
@@ -463,7 +463,7 @@ void lcdSetText(FILE *lcdPort, unsigned char line, const char *buffer) {
 }
 
 // lcdShutdown - Disable the LCD on the specified port
-void lcdShutdown(FILE *lcdPort) {
+void lcdShutdown(PROS_FILE *lcdPort) {
 	if (lcdPort == uart1 || lcdPort == uart2) {
 		usartShutdown(lcdPort);
 		lcd[(uint32_t)lcdPort - 1].flags = 0;
@@ -510,7 +510,7 @@ void usartFlushBuffers() {
 
 // usartInit - Initialize the specified USART interface with the given connection parameters
 // The interface argument can be 1 or 2 to specify UART1 and UART2 respectively
-void usartInit(FILE *port, unsigned int baud, unsigned int flags) {
+void usartInit(PROS_FILE *port, unsigned int baud, unsigned int flags) {
 	// Determine correct USART
 	USART_TypeDef *base;
 	if (port == uart1)
@@ -545,7 +545,7 @@ void usartInit(FILE *port, unsigned int baud, unsigned int flags) {
 }
 
 // usartShutdown - Disable the specified USART interface
-void usartShutdown(FILE *usart) {
+void usartShutdown(PROS_FILE *usart) {
 	// Disable transmitter, receiver, clock, and interrupts
 	if (usart == uart1)
 		USART2->CR1 = (uint16_t)0;

--- a/src/fs.c
+++ b/src/fs.c
@@ -224,7 +224,7 @@ static void openForWriting(const char *file, uint32_t idx, uint32_t page) {
  *
  * @param fd the descriptor to close
  */
-void fclose(FILE *fd) {
+void fclose(PROS_FILE *fd) {
 	uint32_t idx = (uint32_t)fd - FILE_CHANNEL_1;
 	if (idx < MAX_FILES) {
 		// Index in bounds
@@ -293,7 +293,7 @@ int fdelete(const char *file) {
  * @param fd the channel to check
  * @return 0 if the file is not at EOF, or 1 otherwise.
  */
-int fsEof(FILE *fd) {
+int fsEof(PROS_FILE *fd) {
 	uint32_t idx = (uint32_t)fd - FILE_CHANNEL_1;
 	if (idx < MAX_FILES) {
 		// Index in bounds
@@ -312,7 +312,7 @@ int fsEof(FILE *fd) {
  * @return 0 if the data was successfully written out to Flash, EOF otherwise
  *     The file data is still invalid until properly closed!
  */
-int fflush(FILE *fd) {
+int fflush(PROS_FILE *fd) {
 	uint32_t idx = (uint32_t)fd - FILE_CHANNEL_1;
 	if (idx < MAX_FILES) {
 		// Index in bounds
@@ -365,7 +365,7 @@ int fflush(FILE *fd) {
  * @param fd the file channel to check
  * @return the number of bytes left, or 0 if this value could not be determined
  */
-uint32_t fsLeft(FILE *fd) {
+uint32_t fsLeft(PROS_FILE *fd) {
 	uint32_t idx = (uint32_t)fd - FILE_CHANNEL_1;
 	if (idx < MAX_FILES) {
 		// Index in bounds
@@ -384,7 +384,7 @@ uint32_t fsLeft(FILE *fd) {
  * @param mode the file mode
  * @return a pointer to file data, or NULL if the file could not be opened
  */
-FILE * fopen(const char *file, const char *mode) {
+PROS_FILE * fopen(const char *file, const char *mode) {
 	uint32_t i, page;
 	if (strcmp(mode, "r") == 0) {
 		// READ
@@ -397,7 +397,7 @@ FILE * fopen(const char *file, const char *mode) {
 				if (fs.files[i].flags == 0U) {
 					// Mine mine mine!
 					openForReading(i, page, len);
-					return (FILE *)(FILE_CHANNEL_1 + i);
+					return (PROS_FILE *)(FILE_CHANNEL_1 + i);
 				}
 			// Maximum file limit exceeded!
 		}
@@ -414,7 +414,7 @@ FILE * fopen(const char *file, const char *mode) {
 				if (flags == 0U) {
 					// Mine mine mine!
 					openForWriting(file, i, page);
-					return (FILE *)(FILE_CHANNEL_1 + i);
+					return (PROS_FILE *)(FILE_CHANNEL_1 + i);
 				} else if (flags & FILE_FLAG_WR)
 					// Only one write buffer
 					break;
@@ -431,7 +431,7 @@ FILE * fopen(const char *file, const char *mode) {
  * @return the next byte in the file, or EOF if no byte can be read (end of file, in write
  * mode...)
  */
-int fsRead(FILE *fd) {
+int fsRead(PROS_FILE *fd) {
 	uint32_t idx = (uint32_t)fd - FILE_CHANNEL_1;
 	if (idx < MAX_FILES) {
 		if (fs.files[idx].flags & FILE_FLAG_RD) {
@@ -525,7 +525,7 @@ void fsScan(bool trim) {
  * @param origin the reference location for offset: SEEK_CUR, SEEK_SET, or SEEK_END
  * @return 0 if the seek was successful, or 1 otherwise
  */
-int fseek(FILE *fd, long int offset, int origin) {
+int fseek(PROS_FILE *fd, long int offset, int origin) {
 	uint32_t idx = (uint32_t)fd - FILE_CHANNEL_1;
 	if (idx < MAX_FILES) {
 		if (fs.files[idx].flags & FILE_FLAG_RD) {
@@ -560,7 +560,7 @@ int fseek(FILE *fd, long int offset, int origin) {
  * @param fd the channel to check
  * @return the offset of the stream, or -1 if the offset could not be determined
  */
-long int ftell(FILE *fd) {
+long int ftell(PROS_FILE *fd) {
 	uint32_t idx = (uint32_t)fd - FILE_CHANNEL_1;
 	if (idx < MAX_FILES) {
 		if (fs.files[idx].flags != 0)
@@ -577,7 +577,7 @@ long int ftell(FILE *fd) {
  * @param value the byte to write
  * @return value if the byte was successfully written and EOF otherwise
  */
-int fsWrite(FILE *fd, int value) {
+int fsWrite(PROS_FILE *fd, int value) {
 	uint32_t idx = (uint32_t)fd - FILE_CHANNEL_1;
 	if (idx < MAX_FILES) {
 		if (fs.files[idx].flags & FILE_FLAG_WR) {
@@ -601,26 +601,26 @@ int fsWrite(FILE *fd, int value) {
 
 // Stub versions of important functions
 
-void fclose(FILE *fd) {
+void fclose(PROS_FILE *fd) {
 }
 
 int fdelete(const char *file) {
 	return 1;
 }
 
-int fflush(FILE *fd) {
+int fflush(PROS_FILE *fd) {
 	return EOF;
 }
 
-FILE * fopen(const char *file, const char *mode) {
+PROS_FILE * fopen(const char *file, const char *mode) {
 	return NULL;
 }
 
-int fseek(FILE *fd, long int offset, int origin) {
+int fseek(PROS_FILE *fd, long int offset, int origin) {
 	return 1;
 }
 
-long int ftell(FILE *fd) {
+long int ftell(PROS_FILE *fd) {
 	return -1L;
 }
 

--- a/src/printf.c
+++ b/src/printf.c
@@ -62,7 +62,7 @@ typedef struct {
 
 // Data for fprintf()
 typedef struct {
-	FILE *stream;
+	PROS_FILE *stream;
 	uint32_t count;
 } _fPrintfData;
 
@@ -462,7 +462,7 @@ static void format(void (*outputFn)(void*, char), void *data, const char *fmt, v
 
 // The next few functions do exactly as one might believe they should as declared in <stdio.h>
 
-void fprint(const char *str, FILE *stream) {
+void fprint(const char *str, PROS_FILE *stream) {
 	char c;
 	while ((c = *str++))
 		fputc(c, stream);
@@ -472,7 +472,7 @@ void print(const char *str) {
 	fprint(str, stdout);
 }
 
-int fputs(const char *str, FILE *stream) {
+int fputs(const char *str, PROS_FILE *stream) {
 	char c;
 	uint32_t count = 0;
 	while ((c = *str++)) {
@@ -488,7 +488,7 @@ int puts(const char *str) {
 	return fputs(str, stdout);
 }
 
-int vfprintf(FILE *stream, const char *fmt, va_list args) {
+int vfprintf(PROS_FILE *stream, const char *fmt, va_list args) {
 	_fPrintfData data;
 	data.stream = stream;
 	data.count = 0;
@@ -522,7 +522,7 @@ int vsnprintf(char *out, size_t size, const char *fmt, va_list args) {
 	return ret;
 }
 
-int fprintf(FILE *stream, const char *fmt, ...) {
+int fprintf(PROS_FILE *stream, const char *fmt, ...) {
 	va_list args;
 	int count;
 	va_start(args, fmt);


### PR DESCRIPTION
FILE was renamed to PROS_FILE. If the FILE symbol wasn't defined, then backwards compatability is maintained with #def'ing FILE to PROS_FILE.