### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ CPPSRC:=$(wildcard *.$(CPPEXT))
 CPPOBJ:=$(patsubst %.o,$(BINDIR)/%.o,$(CPPSRC:.$(CPPEXT)=.o))
 OUT:=$(BINDIR)/$(OUTNAME)
 
-.PHONY: all clean documentation library template upload _force_look release develop
+.PHONY: all clean documentation library template flash upload upload-legacy _force_look release develop
 
 # default version just uses the latest tag
 VERSION := `git describe --abbrev=0`

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,13 @@ clean:
 
 # Uploads program to device
 upload: all
+	$(FLASH)
+
+# Alias to upload, more consistent with our terminology
+flash: upload
+
+# Uploads program to device using legacy uniflasher JAR file
+upload-legacy: all
 	$(UPLOAD)
 
 # Phony force-look target

--- a/common.mk
+++ b/common.mk
@@ -19,6 +19,8 @@ MCUPREPARE=$(OBJCOPY) $(OUT) -O binary $(BINDIR)/$(OUTBIN)
 SIZEFLAGS=
 # Uploads program using java
 UPLOAD=@java -jar firmware/uniflash.jar vex $(BINDIR)/$(OUTBIN)
+# Flashes program using the PROS CLI flash command
+FLASH=pros flash -f $(BINDIR)/$(OUTBIN)
 
 # Advanced options
 ASMEXT=s

--- a/template/Makefile
+++ b/template/Makefile
@@ -33,6 +33,13 @@ clean:
 
 # Uploads program to device
 upload: all
+	$(FLASH)
+
+# Alias to upload, more consistent with our terminology
+flash: upload
+
+# Uploads program to device using legacy uniflasher JAR file
+upload-legacy: all
 	$(UPLOAD)
 
 # Phony force-look target

--- a/template/Makefile
+++ b/template/Makefile
@@ -21,7 +21,7 @@ CPPSRC:=$(wildcard *.$(CPPEXT))
 CPPOBJ:=$(patsubst %.o,$(BINDIR)/%.o,$(CPPSRC:.$(CPPEXT)=.o))
 OUT:=$(BINDIR)/$(OUTNAME)
 
-.PHONY: all clean upload _force_look
+.PHONY: all clean flash upload upload-legacy _force_look
 
 # By default, compile program
 all: $(BINDIR) $(OUT)

--- a/template/common.mk
+++ b/template/common.mk
@@ -21,6 +21,8 @@ MCUPREPARE=$(OBJCOPY) $(OUT) -O binary $(BINDIR)/$(OUTBIN)
 SIZEFLAGS=
 # Uploads program using java
 UPLOAD=@java -jar firmware/uniflash.jar vex $(BINDIR)/$(OUTBIN)
+# Flashes program using the PROS CLI flash command
+FLASH=pros flash -f $(BINDIR)/$(OUTBIN)
 
 # Advanced options
 ASMEXT=s


### PR DESCRIPTION
Modernizing the Makefile!

`pros make upload` will now use `pros flash` to upload binaries.
`pros make flash` is an alias to `pros make upload`.
`pros make upload-legacy` will upload binaries using the uniflasher.