### PR TITLE
Added taskhandle for the watchdog in case one wishes to stop it and reset the cortex

### DIFF
--- a/include/API.h
+++ b/include/API.h
@@ -1587,6 +1587,10 @@ void waitUntil(unsigned long *previousWakeTime, const unsigned long time);
  */
 void watchdogInit();
 /**
+ * The Taskhandle used by the watchdog
+ */
+extern TaskHandle watchdogHandle;
+/**
  * Enables the Cortex to run the op control task in a standalone mode- no VEXnet connection required.
  *
  * This function should only be called once in initializeIO()

--- a/src/watchdog.c
+++ b/src/watchdog.c
@@ -17,6 +17,7 @@
 #include <task.h>
 
 static bool iwdgEnabled = false;
+TaskHandle watchdogHandle;
 
 // iwdgInit - Enables the watchdog
 void watchdogInit() {
@@ -49,5 +50,5 @@ void watchdogStart() {
 	IWDG->KR = 0xCCCC; // start the watchdog
 	_iwdgFeed(); // feed it once and start the task
 
-	taskCreate(_iwdgTask, TASK_MINIMAL_STACK_SIZE, NULL, TASK_PRIORITY_DEFAULT);
+	watchdogHandle = taskCreate(_iwdgTask, TASK_MINIMAL_STACK_SIZE, NULL, TASK_PRIORITY_DEFAULT);
 }


### PR DESCRIPTION
Enables restarting the cortex easier by `taskDelete(watchdogHandle)`, in case a team needs to implement a restart feature for any reason.