### PR TITLE
Small makefile change for linking multiple libraries together

### DIFF
--- a/template/Makefile
+++ b/template/Makefile
@@ -57,7 +57,7 @@ $(BINDIR):
 # Compile program
 $(OUT): $(SUBDIRS) $(ASMOBJ) $(COBJ) $(CPPOBJ)
 	@echo LN $(BINDIR)/*.o $(LIBRARIES) to $@
-	@$(CC) $(LDFLAGS) $(BINDIR)/*.o $(LIBRARIES) -o $@
+	@$(CC) $(LDFLAGS) $(BINDIR)/*.o -Wl,--start-group $(LIBRARIES) -Wl,--end-group -o $@
 	@$(MCUPREFIX)size $(SIZEFLAGS) $(OUT)
 	$(MCUPREPARE)
 


### PR DESCRIPTION
In the case were you have multiple libraries and one depends on the other, it is possible for them to be linked in an incorrect order such that undefined reference errors occur.  

This change tells the linker to pass through all the libraries a second time so that order won't matter.