### PR TITLE
Fix archive compilation for kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,12 @@ template: clean-template library
 	$Dprosv5 c create-template $(TEMPLATE_DIR) kernel $(shell cat $(ROOT)/version) --system "./**/*" --user "src/opcontrol.{c,cpp,cc}" --user "src/initialize.{cpp,c,cc}" --user "src/autonomous.{cpp,c,cc}" --user "include/main.{hpp,h,hh}" --user "Makefile" --target v5 --output bin/output.bin
 
 LIBV5RTS_EXTRACTION_DIR=$(BINDIR)/libv5rts
-$(LIBAR): $(call GETALLOBJ,$(EXCLUDE_SRCDIRS) $(EXCLUDE_FROM_LIB)) $(EXTRA_LIB_DEPS)
+$(LIBAR): $(call GETALLOBJ,$(EXCLUDE_SRC_FROM_LIB)) $(EXTRA_LIB_DEPS)
 	$(VV)mkdir -p $(LIBV5RTS_EXTRACTION_DIR)
 	@echo -n "Extracting libv5rts "
 	$(call test_output,$Dcd $(LIBV5RTS_EXTRACTION_DIR) && $(AR) x ../../$(PATCHED_SDK),$(DONE_STRING))
 	$(eval LIBV5RTS_OBJECTS := $(shell $(AR) t $(PATCHED_SDK)))
 	@echo -n "Creating $@ "
-	$(call test_output,$D$(AR) rcs $@ $(addprefix $(LIBV5RTS_EXTRACTION_DIR)/, $(LIBV5RTS_OBJECTS)) $(filter-out $(EXTRA_LIB_DEPS),$^),$(DONE_STRING))
-	# @echo -n "Stripping non-public symbols "
-	# $(call test_output,$D$(OBJCOPY) -S -D -g --strip-unneeded --keep-symbols public_symbols.txt $@,$(DONE_STRING))
+	$(call test_output,$D$(AR) rcs $@ $(addprefix $(LIBV5RTS_EXTRACTION_DIR)/, $(LIBV5RTS_OBJECTS)) $(call GETALLOBJ,$(EXCLUDE_SRC_FROM_LIB)),$(DONE_STRING))
+# @echo -n "Stripping non-public symbols "
+# $(call test_output,$D$(OBJCOPY) -S -D -g --strip-unneeded --keep-symbols public_symbols.txt $@,$(DONE_STRING))


### PR DESCRIPTION
#### Summary:
- Fix the Makefile to use the right variable for what we want included in the archive
- Comments don't get echo'd when building

#### Motivation:
It's an annoying warning and console print

##### References (optional):
None

#### Test Plan:
- [x] Comment went away when compiling
- [x] No more warnings about including api.h and libv5rts.patched.a
