### PR TITLE
🐛 Refactor task_notify_when_deleting to support task_to_notify dying before target_task

### DIFF
--- a/include/pros/apix.h
+++ b/include/pros/apix.h
@@ -60,8 +60,6 @@ bool task_abort_delay(task_t task);
  * task_notify_ext(task_to_notify, value, action, NULL) when target_task is
  * deleted.
  *
- * NOTE: This facility does not support the case when task_to_notify
- *       dies before target_task
  *
  * \param target_task
  *				The task being watched for deletion

--- a/include/rtos/FreeRTOSConfig.h
+++ b/include/rtos/FreeRTOSConfig.h
@@ -141,7 +141,7 @@
 #define configUSE_NEWLIB_REENTRANT              1
 #define configSTACK_DEPTH_TYPE                  size_t
 
-#define configNUM_THREAD_LOCAL_STORAGE_POINTERS 1
+#define configNUM_THREAD_LOCAL_STORAGE_POINTERS 2
 
 /* Include the query-heap CLI command to query the free heap space. */
 #define configINCLUDE_QUERY_HEAP_COMMAND        1

--- a/src/rtos/task_notify_when_deleting.c
+++ b/src/rtos/task_notify_when_deleting.c
@@ -46,6 +46,10 @@ static struct notify_delete_action* _find_task(linked_list_s_t* ll, task_t task)
   return args.found_action;
 }
 
+void task_notify_when_deleting_init() {
+  task_notify_when_deleting_mutex = mutex_create_static(&task_notify_when_deleting_mutex_buf);
+}
+
 void task_notify_when_deleting(task_t target_task, task_t task_to_notify,
                                uint32_t value, notify_action_e_t notify_action) {
   task_to_notify = (task_to_notify == NULL) ? pxCurrentTCB : task_to_notify;
@@ -57,9 +61,8 @@ void task_notify_when_deleting(task_t target_task, task_t task_to_notify,
     return;
   }
 
-  // lazily initialize mutex
   if (task_notify_when_deleting_mutex == NULL) {
-    task_notify_when_deleting_mutex = mutex_create_static(&task_notify_when_deleting_mutex_buf);
+    task_notify_when_deleting_mutex = mutex_create();
   }
   mutex_take(task_notify_when_deleting_mutex, TIMEOUT_MAX);
 

--- a/src/rtos/task_notify_when_deleting.c
+++ b/src/rtos/task_notify_when_deleting.c
@@ -63,7 +63,7 @@ void task_notify_when_deleting(task_t target_task, task_t task_to_notify,
     ll_node_s_t* it = subscriptions_ll->head;
     bool found = false;
     while (it != NULL && !found) {
-      found = it->payload.data == task_to_notify;
+      found = it->payload.data == target_task;
       it = it->next;
     }
     if (!found) {

--- a/src/rtos/task_notify_when_deleting.c
+++ b/src/rtos/task_notify_when_deleting.c
@@ -126,11 +126,6 @@ static void unsubscribe_hook_cb(ll_node_s_t* node, void* task_to_remove) {
   linked_list_s_t* subscriptions_list = pvTaskGetThreadLocalStoragePointer(subscription, SUBSCRIBERS_TLSP_IDX);
   if (subscriptions_list != NULL) {
     linked_list_remove_data(subscriptions_list, task_to_remove);
-    // cleanup the list if we've removed its last member
-    if (subscriptions_list->head == NULL) {
-      linked_list_free(subscriptions_list);
-      vTaskSetThreadLocalStoragePointer(subscription, SUBSCRIBERS_TLSP_IDX, NULL);
-    }
   }
 }
 
@@ -148,6 +143,8 @@ void task_notify_when_deleting_hook(task_t task) {
   linked_list_s_t* ll = pvTaskGetThreadLocalStoragePointer(task, SUBSCRIPTIONS_TLSP_IDX);
   if (ll != NULL) {
     linked_list_foreach(ll, unsubscribe_hook_cb, task);
+    linked_list_free(ll);
+    vTaskSetThreadLocalStoragePointer(task, SUBSCRIPTIONS_TLSP_IDX, NULL);
   }
   // notify subscribed tasks of this task's deletion
   ll = pvTaskGetThreadLocalStoragePointer(task, SUBSCRIBERS_TLSP_IDX);

--- a/src/rtos/task_notify_when_deleting.c
+++ b/src/rtos/task_notify_when_deleting.c
@@ -124,12 +124,13 @@ static void unsubscribe_hook_cb(ll_node_s_t* node, void* task_to_remove) {
   task_t subscription = node->payload.data;
 
   linked_list_s_t* subscriptions_list = pvTaskGetThreadLocalStoragePointer(subscription, SUBSCRIBERS_TLSP_IDX);
-  linked_list_remove_data(subscriptions_list, task_to_remove);
-
-  // cleanup the list if we've removed its last member
-  if (subscriptions_list->head == NULL) {
-    linked_list_free(subscriptions_list);
-    vTaskSetThreadLocalStoragePointer(subscription, SUBSCRIBERS_TLSP_IDX, NULL);
+  if (subscriptions_list != NULL) {
+    linked_list_remove_data(subscriptions_list, task_to_remove);
+    // cleanup the list if we've removed its last member
+    if (subscriptions_list->head == NULL) {
+      linked_list_free(subscriptions_list);
+      vTaskSetThreadLocalStoragePointer(subscription, SUBSCRIBERS_TLSP_IDX, NULL);
+    }
   }
 }
 

--- a/src/rtos/task_notify_when_deleting.c
+++ b/src/rtos/task_notify_when_deleting.c
@@ -61,9 +61,6 @@ void task_notify_when_deleting(task_t target_task, task_t task_to_notify,
     return;
   }
 
-  if (task_notify_when_deleting_mutex == NULL) {
-    task_notify_when_deleting_mutex = mutex_create();
-  }
   mutex_take(task_notify_when_deleting_mutex, TIMEOUT_MAX);
 
   // task_to_notify maintains a list of the tasks whose deletion it cares about.

--- a/src/rtos/task_notify_when_deleting.c
+++ b/src/rtos/task_notify_when_deleting.c
@@ -46,10 +46,6 @@ static struct notify_delete_action* _find_task(linked_list_s_t* ll, task_t task)
   return args.found_action;
 }
 
-void task_notify_when_deleting_init() {
-  task_notify_when_deleting_mutex = mutex_create_static(&task_notify_when_deleting_mutex_buf);
-}
-
 void task_notify_when_deleting(task_t target_task, task_t task_to_notify,
                                uint32_t value, notify_action_e_t notify_action) {
   task_to_notify = (task_to_notify == NULL) ? pxCurrentTCB : task_to_notify;
@@ -61,8 +57,9 @@ void task_notify_when_deleting(task_t target_task, task_t task_to_notify,
     return;
   }
 
+  // lazily initialize mutex
   if (task_notify_when_deleting_mutex == NULL) {
-    task_notify_when_deleting_mutex = mutex_create();
+    task_notify_when_deleting_mutex = mutex_create_static(&task_notify_when_deleting_mutex_buf);
   }
   mutex_take(task_notify_when_deleting_mutex, TIMEOUT_MAX);
 

--- a/src/system/rtos_hooks.c
+++ b/src/system/rtos_hooks.c
@@ -44,6 +44,9 @@ void rtos_initialize() {
 	portDISABLE_INTERRUPTS();
 
 	vPortInstallFreeRTOSVectorTable();
+
+	void task_notify_when_deleting_init();
+	task_notify_when_deleting_init();
 }
 
 extern void FreeRTOS_Tick_Handler(void);

--- a/src/system/rtos_hooks.c
+++ b/src/system/rtos_hooks.c
@@ -44,9 +44,6 @@ void rtos_initialize() {
 	portDISABLE_INTERRUPTS();
 
 	vPortInstallFreeRTOSVectorTable();
-
-	void task_notify_when_deleting_init();
-	task_notify_when_deleting_init();
 }
 
 extern void FreeRTOS_Tick_Handler(void);


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
- Increments `configNUM_THREAD_LOCAL_STORAGE_POINTERS` again
- Adds another linked list to thread local storage that will keep track of the tasks to whose death events `task_to_notify` is subscribed
- When a task dies, the `task_delete_hook` now iterates through the task's list of subscriptions and removes references to itself from the subscriptions' lists of subscribers

#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
Previously, the case in which `task_to_notify` dies before `target_task` was undefined behavior, because `target_task` would attempt to notify `task_to_notify` even if it's already been cleaned up. The naive solution of checking the `task_to_notify`'s state directly would not have worked because in certain cases (as with the competition tasks), the TCB can be reused.

More information regarding the motivation behind this change can be found at #86, OkapiLib/OkapiLib#249, and OkapiLib/OkapiLib#321

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
Closes #86 

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->
- [x] execute test plan in src/tests/task_notify_when_deleting.c (regression test)
(the following are adapted from https://github.com/purduesigbots/pros/pull/100#issuecomment-461282903. thanks @Octogonapus)
- [x] delete `task_to_notify` and then delete `target_task`, verify nothing goes horrendously wrong
- [x] repeat previous test with OkapiLib where an internal task is the `task_to_notify`