### PR TITLE
🐛 Add LLEMU read buttons nullcheck

### DIFF
--- a/src/display/llemu.c
+++ b/src/display/llemu.c
@@ -300,5 +300,9 @@ bool lcd_register_btn2_cb(lcd_btn_cb_fn_t cb) {
 }
 
 uint8_t lcd_read_buttons(void) {
+	if (!lcd_is_initialized()) {
+		errno = ENXIO;
+		return 0;
+	}
 	return _lcd_read_buttons(_llemu_lcd);
 }


### PR DESCRIPTION
#### Summary:
Someone wrote LLEMU overnight and didn't sleep. So he forgot to add `nullcheck` in method `lcd_read_buttons`.

#### Motivation:
Add it.

##### References (optional):
Closes #106 

#### Test Plan:
- [x] try to use `pros::lcd::read_buttons()` before initialize the GUI
- [x] try to use `pros::c::lcd_read_buttons()` before initialize the GUI
