### PR TITLE
✨ Add LLEMU text align function

### DIFF
--- a/include/pros/llemu.h
+++ b/include/pros/llemu.h
@@ -52,6 +52,16 @@ typedef struct lcd_s {
 	                               // multitouch support)
 } lcd_s_t;
 
+typedef enum lcd_text_align_e {
+	E_LCD_TEXT_ALIGN_LEFT = 0,
+	E_LCD_TEXT_ALIGN_CENTER = 1,
+	E_LCD_TEXT_ALIGN_RIGHT = 2
+} lcd_text_align_e_t;
+
+#define ALIGN_LEFT pros::E_LCD_TEXT_ALIGN_LEFT 
+#define ALIGN_CENTER pros::E_LCD_TEXT_ALIGN_CENTER
+#define ALIGN_RIGHT pros::E_LCD_TEXT_ALIGN_RIGHT
+
 #ifdef __cplusplus
 namespace c {
 #endif
@@ -123,6 +133,24 @@ bool lcd_print(int16_t line, const char* fmt, ...);
  * errno values as specified above.
  */
 bool lcd_set_text(int16_t line, const char* text);
+
+/**
+ * Set text align type on the emulated three-button LCD screen.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * ENXIO  - The LCD has not been initialized. Call lcd_initialize() first.
+ * EINVAL - The line number specified is not in the range [0-7]
+ *
+ * \param line
+ *        The line on which to set align type [0-7]
+ * \param align
+ *        The align type
+ *
+ * \return True if the operation was successful, or false otherwise, setting
+ * errno values as specified above.
+ */
+bool lcd_set_text_align(int16_t line, lcd_text_align_e_t align);
 
 /**
  * Clears the contents of the emulated three-button LCD screen.

--- a/include/pros/llemu.h
+++ b/include/pros/llemu.h
@@ -58,9 +58,15 @@ typedef enum lcd_text_align_e {
 	E_LCD_TEXT_ALIGN_RIGHT = 2
 } lcd_text_align_e_t;
 
+#ifdef __cplusplus
 #define ALIGN_LEFT pros::E_LCD_TEXT_ALIGN_LEFT 
 #define ALIGN_CENTER pros::E_LCD_TEXT_ALIGN_CENTER
 #define ALIGN_RIGHT pros::E_LCD_TEXT_ALIGN_RIGHT
+#else
+#define ALIGN_LEFT E_LCD_TEXT_ALIGN_LEFT 
+#define ALIGN_CENTER E_LCD_TEXT_ALIGN_CENTER
+#define ALIGN_RIGHT E_LCD_TEXT_ALIGN_RIGHT
+#endif
 
 #ifdef __cplusplus
 namespace c {

--- a/include/pros/llemu.hpp
+++ b/include/pros/llemu.hpp
@@ -115,6 +115,24 @@ bool print(std::int16_t line, const char* fmt, Params... args) {
 bool set_text(std::int16_t line, std::string text);
 
 /**
+ * Set text align type on the emulated three-button LCD screen.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * ENXIO  - The LCD has not been initialized. Call lcd_initialize() first.
+ * EINVAL - The line number specified is not in the range [0-7]
+ *
+ * \param line
+ *        The line on which to set align type [0-7]
+ * \param align
+ *        The align type
+ *
+ * \return True if the operation was successful, or false otherwise, setting
+ * errno values as specified above.
+ */
+bool set_text_align(std::int16_t line, lcd_text_align_e_t align);
+
+/**
  * Clears the contents of the emulated three-button LCD screen.
  *
  * This function uses the following values of errno when an error state is

--- a/src/display/llemu.c
+++ b/src/display/llemu.c
@@ -172,6 +172,21 @@ bool _lcd_set_text(lv_obj_t* lcd_dummy, int16_t line, const char* text) {
 	return _lcd_print(lcd_dummy, line, "%s", text);
 }
 
+bool _lcd_set_text_align(lv_obj_t* lcd_dummy, int16_t line, lcd_text_align_e_t align) {
+	if (line < 0 || line > 7) {
+		errno = EINVAL;
+		return false;
+	}
+	//0 = left, 1 = center, 2 = right(supported in LVGL 5.2)
+	if (align < 0 || align > 2) {
+		errno = EINVAL;
+		return false;
+	}
+	lcd_s_t* lcd = lv_obj_get_ext_attr(lcd_dummy);
+	lv_label_set_align(lcd->lcd_text[line], (lv_label_align_t)align);
+	return true;
+}
+
 void _lcd_clear(lv_obj_t* lcd_dummy) {
 	lcd_s_t* lcd = lv_obj_get_ext_attr(lcd_dummy);
 	// delete children of screen (this is fine because when we print, we just
@@ -253,6 +268,14 @@ bool lcd_set_text(int16_t line, const char* text) {
 		return false;
 	}
 	return _lcd_set_text(_llemu_lcd, line, text);
+}
+
+bool lcd_set_text_align(int16_t line, lcd_text_align_e_t align) {
+	if (!lcd_is_initialized()) {
+		errno = ENXIO;
+		return false;
+	}
+	return _lcd_set_text_align(_llemu_lcd, line, align);
 }
 
 bool lcd_clear(void) {

--- a/src/display/llemu.cpp
+++ b/src/display/llemu.cpp
@@ -31,6 +31,9 @@ bool shutdown(void) {
 bool set_text(std::int16_t line, std::string text) {
 	return lcd_set_text(line, text.c_str());
 }
+bool set_text_align(std::int16_t line, lcd_text_align_e_t align) {
+	return lcd_set_text_align(line, align);
+}
 bool clear(void) {
 	return lcd_clear();
 }


### PR DESCRIPTION
#### Summary:
Someone is very busy. So I help him to add this feature. 

You can now use `pros::lcd::set_text_align` or `pros::c::lcd_set_text_align` to change the align type on the LLEMU. You can choose `ALIGN_LEFT`, `ALIGN_CENTER` or `ALIGN_RIGHT`. 

Since LVGL added `align right` support on version 5.2 and @HotelCalifornia said he will support LVGL 5.3 on the `milestone 3.1.7`, this feature needs to release after(on) "3.1.7". Otherwise, `ALIGN_RIGHT` doesn't make any effect.

#### Motivation:
Add it

##### References (optional):
 closes #93 

#### Test Plan:
Ah... try it yourself, official.
- [x] Compiles ( 😏)
- [x] Call `pros::lcd::set_text_align` with all align types and Macro
- [x] Call `pros::c::lcd_set_text_align` with all align types and Macro
