### PR TITLE
👷‍♂️ Re-order make execution after updating build number

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,6 @@ jobs:
     displayName: Install CLI
   - bash: |
       make template
-      make
       mkdir -p artifacts
       cp template/*.zip artifacts
     displayName: Build template
@@ -33,6 +32,9 @@ jobs:
       echo "##vso[build.UpdateBuildNumber]`cat version`"
       echo "##vso[task.setvariable variable=KernelVersion]`cat version`"
     displayName: Update Build Number
+  - bash: |
+      make
+    displayName: Build binaries
   - task: PublishPipelineArtifact@0
     inputs:
       targetPath: artifacts

--- a/version.py
+++ b/version.py
@@ -1,16 +1,21 @@
 from __future__ import print_function
 import subprocess
 import io
+import os
 
 try:
     v = subprocess.check_output(['git', 'describe', '--dirty', '--abbrev']).decode().strip()
     if '-' in v:
         bv = v[:v.index('-')]
         bv = bv[:bv.rindex('.') + 1] + str(int(bv[bv.rindex('.') + 1:]) + 1)
-        sempre = 'dirty' if v.endswith('-dirty') else 'commit'
-        pippre = 'alpha' if v.endswith('-dirty') else 'pre'
-        build = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode().strip()
-        number_since = subprocess.check_output(['git', 'rev-list', v[:v.index('-')] + '..HEAD', '--count']).decode().strip()
+        if os.environ.get('System.PullRequest.PullRequestId', None):
+            sempre = 'pr'
+            build = os.environ.get('System.PullRequest.PullRequestId')
+        else:
+            sempre = 'dirty' if v.endswith('-dirty') else 'commit'
+            # pippre = 'alpha' if v.endswith('-dirty') else 'pre'
+            build = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode().strip()
+            # number_since = subprocess.check_output(['git', 'rev-list', v[:v.index('-')] + '..HEAD', '--count']).decode().strip()
         semver = bv + '-' + sempre + '+' + build
     else:
         semver = v

--- a/version.py
+++ b/version.py
@@ -8,15 +8,15 @@ try:
     if '-' in v:
         bv = v[:v.index('-')]
         bv = bv[:bv.rindex('.') + 1] + str(int(bv[bv.rindex('.') + 1:]) + 1)
-        print(os.environ)
-        if os.environ.get('System.PullRequest.PullRequestId', None):
-            sempre = 'pr'
-            build = os.environ.get('System.PullRequest.PullRequestId')
+        if os.environ.get('SYSTEM_PULLREQUEST_PULLREQUESTNUMBER', None):  # for Azure Pipelines PR builder
+            sempre = 'pr{}'.format(os.environ.get('SYSTEM_PULLREQUEST_PULLREQUESTNUMBER'))
+            build = os.environ.get('BUILD_BUILDID')
         else:
             sempre = 'dirty' if v.endswith('-dirty') else 'commit'
             # pippre = 'alpha' if v.endswith('-dirty') else 'pre'
             build = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode().strip()
-            # number_since = subprocess.check_output(['git', 'rev-list', v[:v.index('-')] + '..HEAD', '--count']).decode().strip()
+            number_since = subprocess.check_output(['git', 'rev-list', v[:v.index('-')] + '..HEAD', '--count']).decode().strip()
+            build = "{}+{}".format(number_since, build)
         semver = bv + '-' + sempre + '+' + build
     else:
         semver = v

--- a/version.py
+++ b/version.py
@@ -8,6 +8,7 @@ try:
     if '-' in v:
         bv = v[:v.index('-')]
         bv = bv[:bv.rindex('.') + 1] + str(int(bv[bv.rindex('.') + 1:]) + 1)
+        print(os.environ)
         if os.environ.get('System.PullRequest.PullRequestId', None):
             sempre = 'pr'
             build = os.environ.get('System.PullRequest.PullRequestId')


### PR DESCRIPTION
#### Summary:
```
make template
make
```
would cause the version to be updated to a dirty commit version, which would then get set as the build number (despite being a commit build)

This change does
```
make template
(Update Build number)
make
```

#### Motivation:
So that we don't see a dirty version

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
- [x] Look at Pipeline build number
![image](https://user-images.githubusercontent.com/5461357/52889533-70220a80-314e-11e9-9972-1342bb7303a2.png)
