### PR TITLE
🤦‍♀️ Dot between build ID and commit on Azure Pipelines

### DIFF
--- a/version.py
+++ b/version.py
@@ -16,7 +16,7 @@ try:
             # pippre = 'alpha' if v.endswith('-dirty') else 'pre'
             build = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode().strip()
             number_since = subprocess.check_output(['git', 'rev-list', v[:v.index('-')] + '..HEAD', '--count']).decode().strip()
-            build = "{}+{}".format(number_since, build)
+            build = "{}.{}".format(number_since, build)
         semver = bv + '-' + sempre + '+' + build
     else:
         semver = v

--- a/version.py
+++ b/version.py
@@ -17,7 +17,7 @@ try:
             build = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode().strip()
             number_since = subprocess.check_output(['git', 'rev-list', v[:v.index('-')] + '..HEAD', '--count']).decode().strip()
             build = "{}.{}".format(number_since, build)
-        semver = bv + '-' + sempre + '+' + build
+        semver = bv + '-' + sempre + '.' + build
     else:
         semver = v
 


### PR DESCRIPTION
#### Summary:
Need a "." between build number and commit, not a plus

#### Motivation:
Use non-tagged templates built by Azure

##### References (optional):
purduesigbots/pros-cli#66
purduesigbots/pros-cli#64

#### Test Plan:
- [x] Can fetch/use template built locally
- [x] Can fetch/use template built on Azure
