### PR TITLE
Don't include timestamp in cold image

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -197,6 +197,7 @@ $(COLD_BIN): $(COLD_ELF)
 	$(call test_output,$D$(OBJCOPY) $< -O binary -R .hot_init $@,$(DONE_STRING))
 
 $(COLD_ELF): $(LIBRARIES)
+	$(VV)mkdir -p $(dir $@)
 	@echo -n "Creating cold package with $(ARCHIVE_TEXT_LIST) "
 	$(call test_output,$D$(LD) $(LDFLAGS) $(call wlprefix,--gc-keep-exported --whole-archive $^ -lstdc++ --no-whole-archive) $(call wlprefix,-T$(FWDIR)/v5.ld $(LNK_FLAGS) -o $@),$(OK_STRING))
 	@echo -n "Stripping cold package "

--- a/common.mk
+++ b/common.mk
@@ -197,9 +197,8 @@ $(COLD_BIN): $(COLD_ELF)
 	$(call test_output,$D$(OBJCOPY) $< -O binary -R .hot_init $@,$(DONE_STRING))
 
 $(COLD_ELF): $(LIBRARIES)
-	$(call _pros_ld_timestamp)
 	@echo -n "Creating cold package with $(ARCHIVE_TEXT_LIST) "
-	$(call test_output,$D$(LD) $(LDFLAGS) $(LDTIMEOBJ) $(call wlprefix,--gc-keep-exported --whole-archive $^ -lstdc++ --no-whole-archive) $(call wlprefix,-T$(FWDIR)/v5.ld $(LNK_FLAGS) -o $@),$(OK_STRING))
+	$(call test_output,$D$(LD) $(LDFLAGS) $(call wlprefix,--gc-keep-exported --whole-archive $^ -lstdc++ --no-whole-archive) $(call wlprefix,-T$(FWDIR)/v5.ld $(LNK_FLAGS) -o $@),$(OK_STRING))
 	@echo -n "Stripping cold package "
 	$(call test_output,$D$(OBJCOPY) --strip-symbol=install_hot_table --strip-symbol=__libc_init_array --strip-symbol=_PROS_COMPILE_DIRECTORY --strip-symbol=_PROS_COMPILE_TIMESTAMP $@ $@, $(DONE_STRING))
 	@echo Section sizes:


### PR DESCRIPTION
#### Summary:
Remove timestamp compilation from cold ELF

#### Motivation:
If you have multiple projects with the same set of libraries (e.g. same hash) but the cold ELF was compiled at different times, then the CRCs won't match even though the relevant symbols are equivalent.

##### References (optional):

#### Test Plan:
- [x] Still compiles
- [x] Create two projects, compile cold ELFs independently, and CRCs should still match
  - Validated by me and @jcgrif