### PR TITLE
Correction of annotation errors in exposure

### DIFF
--- a/include/pros/vision.h
+++ b/include/pros/vision.h
@@ -267,7 +267,7 @@ vision_object_s_t vision_get_by_code(uint8_t port, const uint32_t size_id, const
  * \param port
  *        The V5 port number from 1-21
  *
- * \return The current exposure setting from [0,150], PROS_ERR if an error
+ * \return The current exposure setting from [0,100], PROS_ERR if an error
  * occurred
  */
 int32_t vision_get_exposure(uint8_t port);
@@ -463,7 +463,7 @@ int32_t vision_set_auto_white_balance(uint8_t port, const uint8_t enable);
  * \param port
  *        The V5 port number from 1-21
  * \param percent
- *        The new exposure setting from [0,150]
+ *        The new exposure setting from [0,100]
  *
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.

--- a/include/pros/vision.hpp
+++ b/include/pros/vision.hpp
@@ -173,7 +173,7 @@ class Vision {
 	 * reached:
 	 * EACCES - Another resource is currently trying to access the port.
 	 *
-	 * \return The current exposure parameter from [0,150],
+	 * \return The current exposure parameter from [0,100],
 	 * PROS_ERR if an error occurred
 	 */
 	std::int32_t get_exposure(void) const;
@@ -327,7 +327,7 @@ class Vision {
 	 * EACCES - Another resource is currently trying to access the port.
 	 *
 	 * \param percent
-	 *        The new exposure setting from [0,150].
+	 *        The new exposure setting from [0,100].
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.


### PR DESCRIPTION
Signed-off-by: 3038922 <31612534@qq.com>

#### Summary:
<!-- Provide a concise description of your changes -->
It's just a revision of the notes. My students found it.
#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [ ] test item
```
int32_t vision_set_exposure(uint8_t port, const uint8_t percent) {
	claim_port(port - 1, E_DEVICE_VISION);
	// This translation comes from VEX to match the brightness represented in vision utility
	vexDeviceVisionBrightnessSet(device->device_info, (((int)((percent * 100) + 50)) / 255));
	return_port(port - 1, 1);
}
```
if percent ==100
((100 *100)+50)/255=  39
I'm not sure if this is correct.
