### PR TITLE
📝 Update Copyright info to current year

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -49,7 +49,7 @@ These should be placed at the very start of a file.
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/api.h
+++ b/include/api.h
@@ -8,7 +8,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/common/cobs.h
+++ b/include/common/cobs.h
@@ -5,7 +5,7 @@
  *
  * See common/cobs.c for discussion
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/common/gid.h
+++ b/include/common/gid.h
@@ -5,7 +5,7 @@
  *
  * See common/gid.c for discussion
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/common/linkedlist.h
+++ b/include/common/linkedlist.h
@@ -6,7 +6,7 @@
  * This file defines a linked list implementation that operates on the FreeRTOS
  * heap, and is able to generically store function pointers and data
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/common/set.h
+++ b/include/common/set.h
@@ -5,7 +5,7 @@
  *
  * See common/set.c for discussion
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/common/string.h
+++ b/include/common/string.h
@@ -5,7 +5,7 @@
  *
  * See common/string.c for discussion
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/kapi.h
+++ b/include/kapi.h
@@ -8,7 +8,7 @@
  * creation of statically allocated FreeRTOS primitives like tasks, semaphores,
  * and queues.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/main.h
+++ b/include/main.h
@@ -4,7 +4,7 @@
  * Contains common definitions and header files used throughout your PROS
  * project.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/adi.h
+++ b/include/pros/adi.h
@@ -8,7 +8,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -8,7 +8,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/api_legacy.h
+++ b/include/pros/api_legacy.h
@@ -10,7 +10,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/apix.h
+++ b/include/pros/apix.h
@@ -12,7 +12,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/colors.h
+++ b/include/pros/colors.h
@@ -6,7 +6,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2018 Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019 Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/llemu.h
+++ b/include/pros/llemu.h
@@ -13,7 +13,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/llemu.hpp
+++ b/include/pros/llemu.hpp
@@ -13,7 +13,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/misc.h
+++ b/include/pros/misc.h
@@ -10,7 +10,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reservered.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/misc.hpp
+++ b/include/pros/misc.hpp
@@ -10,7 +10,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reservered.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/motors.h
+++ b/include/pros/motors.h
@@ -9,7 +9,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/rtos.h
+++ b/include/pros/rtos.h
@@ -10,7 +10,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -10,7 +10,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/vision.h
+++ b/include/pros/vision.h
@@ -9,7 +9,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/vision.hpp
+++ b/include/pros/vision.hpp
@@ -9,7 +9,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/system/dev/banners.h
+++ b/include/system/dev/banners.h
@@ -7,7 +7,7 @@
  *
  * See system/dev/serial_daemon.c for discussion
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/system/dev/dev.h
+++ b/include/system/dev/dev.h
@@ -3,7 +3,7 @@
  *
  * Generic Serial Device driver header
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/system/dev/ser.h
+++ b/include/system/dev/ser.h
@@ -5,7 +5,7 @@
  *
  * See system/dev/ser_driver.c and system/dev/ser_daemon.c for discussion
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/system/dev/usd.h
+++ b/include/system/dev/usd.h
@@ -5,7 +5,7 @@
  *
  * See system/dev/usd_driver.c for discussion
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/system/dev/vfs.h
+++ b/include/system/dev/vfs.h
@@ -5,7 +5,7 @@
  *
  * See system/dev/vfs.c for discussion
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/system/optimizers.h
+++ b/include/system/optimizers.h
@@ -5,7 +5,7 @@
  *
  * Probably shouldn't use anything from this header
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/vdml/registry.h
+++ b/include/vdml/registry.h
@@ -4,7 +4,7 @@
  * This file contains the standard header info for the VDML (Vex Data Management
  * Layer) registry.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/vdml/vdml.h
+++ b/include/vdml/vdml.h
@@ -4,7 +4,7 @@
  * This file contains all types and functions used throughout multiple VDML
  * (Vex Data Management Layer) files.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/common/cobs.c
+++ b/src/common/cobs.c
@@ -6,7 +6,7 @@
  * Contains an implementation of Consistent Overhead Byte Stuffing, adapted from
  * https://github.com/jacquesf/COBS-Consistent-Overhead-Byte-Stuffing
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/common/gid.c
+++ b/src/common/gid.c
@@ -6,7 +6,7 @@
  * Contains an implementation to efficiently assign globally unique IDs
  * e.g. to assign entries in a global table
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/common/linkedlist.c
+++ b/src/common/linkedlist.c
@@ -6,7 +6,7 @@
  * This file defines a linked list implementation that operates on the FreeRTOS
  * heap, and is able to generically store function pointers and data
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/common/set.c
+++ b/src/common/set.c
@@ -5,7 +5,7 @@
  * It's used to check which streams are enabled in ser_driver for the moment,
  * but also has list_contains which may be useful in other contexts.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/common/string.c
+++ b/src/common/string.c
@@ -4,7 +4,7 @@
  * Contains extra string functions useful for PROS and kstrdup/kstrndup which
  * use the kernel heap instead of the user heap
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/devices/battery.c
+++ b/src/devices/battery.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 Battery.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/devices/battery.cpp
+++ b/src/devices/battery.cpp
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 Battery.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 Controller.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/devices/controller.cpp
+++ b/src/devices/controller.cpp
@@ -4,7 +4,7 @@
  * Contains functions for interacting with the V5 Controller, as well as the
  * competition control functions.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/devices/registry.c
+++ b/src/devices/registry.c
@@ -5,7 +5,7 @@
  * what devices are in use on the V5. Therefore, in order to use V5 devices with
  * PROS, they must be registered and deregistered using the registry.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml.c
+++ b/src/devices/vdml.c
@@ -6,7 +6,7 @@
  * VDML ensures thread saftey for operations on smart devices by maintaining
  * an array of RTOS Mutexes and implementing functions to take and give them.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_adi.c
+++ b/src/devices/vdml_adi.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 ADI.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 ADI.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_motors.c
+++ b/src/devices/vdml_motors.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 Motors.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 Motors.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_vision.c
+++ b/src/devices/vdml_vision.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 Vision Sensor.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_vision.cpp
+++ b/src/devices/vdml_vision.cpp
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 Vision Sensor.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/display/display.c
+++ b/src/display/display.c
@@ -3,7 +3,7 @@
  *
  * Main source code for interacting with the V5 Brain's LCD screen.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/display/error.c
+++ b/src/display/error.c
@@ -4,7 +4,7 @@
  * Error display handling. Prints an error message to the screen when the kernel
  * is put in an error state.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/display/llemu.c
+++ b/src/display/llemu.c
@@ -7,7 +7,7 @@
  * VEX LCD, containing a set of functions that facilitate the use of a software-
  * emulated version of the classic VEX LCD module.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/display/llemu.cpp
+++ b/src/display/llemu.cpp
@@ -7,7 +7,7 @@
  * VEX LCD, containing a set of functions that facilitate the use of a software-
  * emulated version of the classic VEX LCD module.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/rtos/rtos.cpp
+++ b/src/rtos/rtos.cpp
@@ -6,7 +6,7 @@
  *
  * See https://pros.cs.purdue.edu/v5/tutorials/multitasking.html to learn more.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/cpp_support.cpp
+++ b/src/system/cpp_support.cpp
@@ -3,7 +3,7 @@
  *
  * C++ support hooks
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/dev/dev_driver.c
+++ b/src/system/dev/dev_driver.c
@@ -6,7 +6,7 @@
  * Contains the driver for writing to any smart port with no regard to the
  * device on the other end.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/dev/ser_daemon.c
+++ b/src/system/dev/ser_daemon.c
@@ -7,7 +7,7 @@
  * characters and responding to any kernel commands (like printing the banner or
  * enabling COBS)
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/dev/ser_driver.c
+++ b/src/system/dev/ser_driver.c
@@ -6,7 +6,7 @@
  * Contains the driver for communicating over the serial line. The serial driver
  * is responsible for shipping out all data.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/dev/usd_driver.c
+++ b/src/system/dev/usd_driver.c
@@ -3,7 +3,7 @@
  *
  * Contains the driver for writing files to the microSD card.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/dev/vfs.c
+++ b/src/system/dev/vfs.c
@@ -13,7 +13,7 @@
  * fileno. A file number maps to a driver and driver argument, which would be
  * whatever metadata the driver needs to open the file
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/main.c
+++ b/src/system/main.c
@@ -5,7 +5,7 @@
  * code. Our main() initializes data structures and starts the FreeRTOS
  * scheduler.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/newlib_stubs.c
+++ b/src/system/newlib_stubs.c
@@ -6,7 +6,7 @@
  * Contains the various methods needed to enable standard C library support
  * through the use of the Arm-distributed implementation of newlib.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/rtos_hooks.c
+++ b/src/system/rtos_hooks.c
@@ -6,7 +6,7 @@
  * FreeRTOS requires some porting to each platform to handle certain tasks. This
  * file contains the various methods required to be implemented for FreeRTOS.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/system_daemon.c
+++ b/src/system/system_daemon.c
@@ -3,7 +3,7 @@
  *
  * Competition control daemon responsible for invoking the user tasks.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/tests/adi.cpp
+++ b/src/tests/adi.cpp
@@ -6,7 +6,7 @@
  * NOTE: There should also be a call to the constructor for the gyroscope object
  * in initialize() for calibration to occur before the opcontrol code.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/tests/gyro.c
+++ b/src/tests/gyro.c
@@ -6,7 +6,7 @@
  * NOTE: There should also be a call to the constructor for the gyroscope object
  * in initialize() for calibration to occur before the opcontrol code.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/tests/gyro.cpp
+++ b/src/tests/gyro.cpp
@@ -6,7 +6,7 @@
  * NOTE: There should also be a call to the constructor for the gyroscope object
  * in initialize() for calibration to occur before the opcontrol code.
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/tests/rtos_function_linking.c
+++ b/src/tests/rtos_function_linking.c
@@ -5,7 +5,7 @@
  *
  * Do not actually run this test - just make sure it compiles
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/tests/simple_names.c
+++ b/src/tests/simple_names.c
@@ -5,7 +5,7 @@
  *
  * Do not actually run this test - just make sure it compiles
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/tests/simple_names.cpp
+++ b/src/tests/simple_names.cpp
@@ -5,7 +5,7 @@
  *
  * Do not actually run this test - just make sure it compiles
  *
- * Copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public


### PR DESCRIPTION
#### Summary:
Continue the SIGBots copyright into 2019.

#### Motivation:
It's now 2019.
