### PR TITLE
🐛 Fix COLD_LIBRARIES variable assignment

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -12,7 +12,7 @@ SPACE +=
 COMMA := ,
 
 LIBRARIES+=$(wildcard $(FWDIR)/*.a)
-COLD_LIBRARIES:= $(filter-out $(EXCLUDE_COLD_LIBRARIES), $(LIBRARIES))
+COLD_LIBRARIES= $(filter-out $(EXCLUDE_COLD_LIBRARIES), $(LIBRARIES))
 wlprefix=-Wl,$(subst $(SPACE),$(COMMA),$1)
 LNK_FLAGS=--gc-sections --start-group $(strip $(LIBRARIES)) -lc -lm -lgcc -lstdc++ -lsupc++ --end-group
 


### PR DESCRIPTION
#### Summary:
Changes COLD_LIBRARIES from a simply expanded variable to a recursive one so that compilation with user-defined libraries still works.

#### Motivation:
Went to add a template generated from the latest code on develop to a project that uses a user-created library (the BLRS 15" robot), and the project failed to compile with the following error: 
```
bayle@pop-os:~/Documents/git/forkner$ make
Creating cold package with libpros,okapilib,libforkner [ERRORS]
/usr/bin/../lib/gcc/arm-none-eabi/7.3.1/../../../../arm-none-eabi/bin/ld: cannot find ./bin/libforkner.a: No such file or directory
collect2: error: ld returned 1 exit status
common.mk:201: recipe for target 'bin/cold.package.elf' failed
make: *** [bin/cold.package.elf] Error 1
```
##### References (optional):
I believe the bug was introduced in #121.

#### Test Plan:

All tests are done with the BLRS 15" project where the issue was originally discovered.
- [x] Compilation suceeds with template generated from master
- [x] Compilation fails with template generated from develop
- [x] Compilation succeeds with template generated from this branch