### PR TITLE
Fix incorrect port type

### DIFF
--- a/include/pros/motors.h
+++ b/include/pros/motors.h
@@ -325,7 +325,7 @@ int32_t motor_is_over_temp(uint8_t port);
  * \return 1 if the motor is not moving, 0 if the motor is moving, or PROS_ERR
  * if the operation failed, setting errno
  */
-int32_t motor_is_stopped(uint32_t port);
+int32_t motor_is_stopped(uint8_t port);
 
 /**
  * Checks if the motor is at its zero position.
@@ -341,7 +341,7 @@ int32_t motor_is_stopped(uint32_t port);
  * moved from its absolute zero, or PROS_ERR if the operation failed,
  * setting errno
  */
-int32_t motor_get_zero_position_flag(uint32_t port);
+int32_t motor_get_zero_position_flag(uint8_t port);
 
 #ifdef __cplusplus
 }  // namespace c

--- a/src/devices/vdml_motors.c
+++ b/src/devices/vdml_motors.c
@@ -141,7 +141,7 @@ int32_t motor_is_over_temp(uint8_t port) {
 	return_port(port - 1, rtn);
 }
 
-int32_t motor_is_stopped(uint32_t port) {
+int32_t motor_is_stopped(uint8_t port) {
 	errno = ENOSYS;
 	return PROS_ERR;
 	claim_port(port - 1, E_DEVICE_MOTOR);
@@ -149,7 +149,7 @@ int32_t motor_is_stopped(uint32_t port) {
 	return_port(port - 1, rtn);
 }
 
-int32_t motor_get_zero_position_flag(uint32_t port) {
+int32_t motor_get_zero_position_flag(uint8_t port) {
 	errno = ENOSYS;
 	return PROS_ERR;
 	claim_port(port - 1, E_DEVICE_MOTOR);


### PR DESCRIPTION
#### Summary:
Fix incorrect port type in some motor functions

#### Motivation:
They were different from everywhere else with seemingly no reason.

#### Test Plan:

- [x] Still compiles
