### PR TITLE
Add alternate generic serial API and fix generic serial filesystem driver

### DIFF
--- a/include/api.h
+++ b/include/api.h
@@ -54,6 +54,7 @@
 #include "pros/motors.h"
 #include "pros/rtos.h"
 #include "pros/vision.h"
+#include "pros/serial.h"
 
 #ifdef __cplusplus
 #include "pros/adi.hpp"
@@ -62,6 +63,7 @@
 #include "pros/motors.hpp"
 #include "pros/rtos.hpp"
 #include "pros/vision.hpp"
+#include "pros/serial.hpp"
 #endif
 
 #endif  // _PROS_API_H_

--- a/include/api.h
+++ b/include/api.h
@@ -54,7 +54,6 @@
 #include "pros/motors.h"
 #include "pros/rtos.h"
 #include "pros/vision.h"
-#include "pros/serial.h"
 
 #ifdef __cplusplus
 #include "pros/adi.hpp"
@@ -63,7 +62,6 @@
 #include "pros/motors.hpp"
 #include "pros/rtos.hpp"
 #include "pros/vision.hpp"
-#include "pros/serial.hpp"
 #endif
 
 #endif  // _PROS_API_H_

--- a/include/pros/apix.h
+++ b/include/pros/apix.h
@@ -28,8 +28,10 @@
 #pragma GCC diagnostic ignored "-Wall"
 #include "display/lvgl.h"
 #pragma GCC diagnostic pop
+#include "pros/serial.h"
 
 #ifdef __cplusplus
+#include "pros/serial.hpp"
 namespace pros::c {
 extern "C" {
 #endif

--- a/include/pros/apix.h
+++ b/include/pros/apix.h
@@ -538,14 +538,14 @@ int32_t fdctl(int file, const uint32_t action, void* const extra_arg);
  * The extra argument is not used with this action, provide any value (e.g.
  * NULL) instead
  */
-#define DEVCTL_FIONWRITE 17
+#define DEVCTL_FIONWRITE 18
 
 /**
  * Action macro to set the Generic Serial Device's baudrate.
  *
  * The extra argument is the baudrate.
  */
-#define DEVCTL_SET_BAUDRATE 18
+#define DEVCTL_SET_BAUDRATE 17
 
 #ifdef __cplusplus
 }

--- a/include/pros/apix.h
+++ b/include/pros/apix.h
@@ -532,11 +532,20 @@ int32_t fdctl(int file, const uint32_t action, void* const extra_arg);
 #define DEVCTL_FIONREAD 16
 
 /**
+ * Action macro to check if there is space available in the Generic Serial
+ * Device's output buffer
+ *
+ * The extra argument is not used with this action, provide any value (e.g.
+ * NULL) instead
+ */
+#define DEVCTL_FIONWRITE 17
+
+/**
  * Action macro to set the Generic Serial Device's baudrate.
  *
  * The extra argument is the baudrate.
  */
-#define DEVCTL_SET_BAUDRATE 17
+#define DEVCTL_SET_BAUDRATE 18
 
 #ifdef __cplusplus
 }

--- a/include/pros/serial.h
+++ b/include/pros/serial.h
@@ -1,0 +1,247 @@
+/**
+ * \file pros/serial.h
+ *
+ * Contains prototypes for the V5 Generic Serial related functions.
+ *
+ * Visit https://pros.cs.purdue.edu/v5/tutorials/topical/serial.html to learn
+ * more.
+ *
+ * This file should not be modified by users, since it gets replaced whenever
+ * a kernel upgrade occurs.
+ *
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef _PROS_SERIAL_H_
+#define _PROS_SERIAL_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+namespace pros {
+namespace c {
+#endif
+
+/******************************************************************************/
+/**                      Serial communication functions                      **/
+/**                                                                          **/
+/**  These functions allow programmers to communicate using UART over RS485  **/
+/******************************************************************************/
+
+/**
+ * Enables generic serial on the given port.
+ *
+ * \note This function must be called before any of the generic serial
+ * functions will work.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EINVAL - The given value is not within the range of V5 ports (1-21).
+ * EACCES - Another resource is currently trying to access the port.
+ *
+ * \param port
+ *        The V5 port number from 1-21
+ *
+ * \return 1 if the operation was successful or PROS_ERR if the operation
+ * failed, setting errno.
+ */
+int32_t serial_enable(uint8_t port);
+
+/**
+ * Sets the baudrate for the serial port to operate at.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EINVAL - The given value is not within the range of V5 ports (1-21).
+ * EACCES - Another resource is currently trying to access the port.
+ *
+ * \param port
+ *        The V5 port number from 1-21
+ * \param baudrate
+ *        The baudrate to operate at
+ *
+ * \return 1 if the operation was successful or PROS_ERR if the operation
+ * failed, setting errno.
+ */
+int32_t serial_set_baudrate(uint8_t port, int32_t baudrate);
+
+/**
+ * Clears the internal input and output FIFO buffers.
+ *
+ * This can be useful to reset state and remove old, potentially unneeded data
+ * from the input FIFO buffer or to cancel sending any data in the output FIFO
+ * buffer.
+ *
+ * \note This function does not cause the data in the output buffer to be
+ * written, it simply clears the internal buffers. Unlike stdout, generic
+ * serial does not use buffered IO (the FIFO buffers are written as soon
+ * as possible).
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EINVAL - The given value is not within the range of V5 ports (1-21).
+ * EACCES - Another resource is currently trying to access the port.
+ *
+ * \param port
+ *        The V5 port number from 1-21
+ *
+ * \return 1 if the operation was successful or PROS_ERR if the operation
+ * failed, setting errno.
+ */
+int32_t serial_flush(uint8_t port);
+
+/**
+ * Returns the number of bytes available to be read in the the port's FIFO
+ * input buffer.
+ *
+ * \note This function does not actually read any bytes, is simply returns the
+ * number of bytes available to be read.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EINVAL - The given value is not within the range of V5 ports (1-21).
+ * EACCES - Another resource is currently trying to access the port.
+ *
+ * \param port
+ *        The V5 port number from 1-21
+ *
+ * \return The number of bytes avaliable to be read or PROS_ERR if the operation
+ * failed, setting errno.
+ */
+int32_t serial_read_avail(uint8_t port);
+
+/**
+ * Returns the number of bytes free in the port's FIFO output buffer.
+ *
+ * \note This function does not actually write any bytes, is simply returns the
+ * number of bytes free in the port's buffer.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EINVAL - The given value is not within the range of V5 ports (1-21).
+ * EACCES - Another resource is currently trying to access the port.
+ *
+ * \param port
+ *        The V5 port number from 1-21
+ *
+ * \return The number of bytes free or PROS_ERR if the operation failed,
+ * setting errno.
+ */
+int32_t serial_write_free(uint8_t port);
+
+/**
+ * Reads the next byte avaliable in the port's input buffer without removing it.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EINVAL - The given value is not within the range of V5 ports (1-21).
+ * EACCES - Another resource is currently trying to access the port.
+ *
+ * \param port
+ *        The V5 port number from 1-21
+ *
+ * \return The next byte avaliable to be read, -1 if none are available, or
+ * PROS_ERR if the operation failed, setting errno.
+ */
+int32_t serial_peek_byte(uint8_t port);
+
+/**
+ * Reads the next byte avaliable in the port's input buffer.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EINVAL - The given value is not within the range of V5 ports (1-21).
+ * EACCES - Another resource is currently trying to access the port.
+ *
+ * \param port
+ *        The V5 port number from 1-21
+ *
+ * \return The next byte avaliable to be read, -1 if none are available, or
+ * PROS_ERR if the operation failed, setting errno.
+ */
+int32_t serial_read_byte(uint8_t port);
+
+/**
+ * Reads up to the next length bytes from the port's input buffer and places
+ * them in the user supplied buffer.
+ *
+ * \note This function will only return bytes that are currently avaliable to be
+ * read and will not block waiting for any to arrive.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EINVAL - The given value is not within the range of V5 ports (1-21).
+ * EACCES - Another resource is currently trying to access the port.
+ *
+ * \param port
+ *        The V5 port number from 1-21
+ * \param buffer
+ *        The location to place the data read
+ * \param length
+ *        The maximum number of bytes to read
+ *
+ * \return The number of bytes read or PROS_ERR if the operation failed, setting
+ * errno.
+ */
+int32_t serial_read(uint8_t port, uint8_t* buffer, int32_t length);
+
+/**
+ * Write the given byte to the port's output buffer.
+ *
+ * \note Data in the port's output buffer is written to the serial port as soon
+ * as possible on a FIFO basis and can not be done manually by the user.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EINVAL - The given value is not within the range of V5 ports (1-21).
+ * EACCES - Another resource is currently trying to access the port.
+ * EIO - Serious internal write error.
+ *
+ * \param port
+ *        The V5 port number from 1-21
+ * \param buffer
+ *        The byte to write
+ *
+ * \return The number of bytes written or PROS_ERR if the operation failed,
+ * setting errno.
+ */
+int32_t serial_write_byte(uint8_t port, uint8_t buffer);
+
+/**
+ * Writes up to length bytes from the user supplied buffer to the port's output
+ * buffer.
+ *
+ * \note Data in the port's output buffer is written to the serial port as soon
+ * as possible on a FIFO basis and can not be done manually by the user.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EINVAL - The given value is not within the range of V5 ports (1-21).
+ * EACCES - Another resource is currently trying to access the port.
+ * EIO - Serious internal write error.
+ *
+ * \param port
+ *        The V5 port number from 1-21
+ * \param buffer
+ *        The data to write
+ * \param length
+ *        The maximum number of bytes to write
+ *
+ * \return The number of bytes written or PROS_ERR if the operation failed,
+ * setting errno.
+ */
+int32_t serial_write(uint8_t port, uint8_t* buffer, int32_t length);
+
+#ifdef __cplusplus
+}  // namespace c
+}  // namespace pros
+}
+#endif
+
+#endif  // _PROS_SERIAL_H_

--- a/include/pros/serial.h
+++ b/include/pros/serial.h
@@ -114,7 +114,7 @@ int32_t serial_flush(uint8_t port);
  * \return The number of bytes avaliable to be read or PROS_ERR if the operation
  * failed, setting errno.
  */
-int32_t serial_read_avail(uint8_t port);
+int32_t serial_get_read_avail(uint8_t port);
 
 /**
  * Returns the number of bytes free in the port's FIFO output buffer.
@@ -133,7 +133,7 @@ int32_t serial_read_avail(uint8_t port);
  * \return The number of bytes free or PROS_ERR if the operation failed,
  * setting errno.
  */
-int32_t serial_write_free(uint8_t port);
+int32_t serial_get_write_free(uint8_t port);
 
 /**
  * Reads the next byte avaliable in the port's input buffer without removing it.

--- a/include/pros/serial.hpp
+++ b/include/pros/serial.hpp
@@ -101,7 +101,7 @@ class Serial {
 	 * \return The number of bytes avaliable to be read or PROS_ERR if the operation
 	 * failed, setting errno.
 	 */
-	virtual std::int32_t read_avail() const;
+	virtual std::int32_t get_read_avail() const;
 
 	/**
 	 * Returns the number of bytes free in the port's FIFO output buffer.
@@ -117,7 +117,7 @@ class Serial {
 	 * \return The number of bytes free or PROS_ERR if the operation failed,
 	 * setting errno.
 	 */
-	virtual std::int32_t write_free() const;
+	virtual std::int32_t get_write_free() const;
 
 	/**
 	 * Reads the next byte avaliable in the port's input buffer without removing it.

--- a/include/pros/serial.hpp
+++ b/include/pros/serial.hpp
@@ -1,0 +1,221 @@
+/**
+ * \file pros/serial.hpp
+ *
+ * Contains prototypes for the V5 Generic Serial related functions.
+ *
+ * Visit https://pros.cs.purdue.edu/v5/tutorials/topical/serial.html to learn
+ * more.
+ *
+ * This file should not be modified by users, since it gets replaced whenever
+ * a kernel upgrade occurs.
+ *
+ * \copyright (c) 2017-2018, Purdue University ACM SIGBots.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef _PROS_SERIAL_HPP_
+#define _PROS_SERIAL_HPP_
+
+#include <cstdint>
+#include "pros/serial.h"
+
+namespace pros {
+class Serial {
+	public:
+	/**
+	 * Creates a Serial object for the given port and specifications.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * EINVAL - The given value is not within the range of V5 ports (1-21).
+	 * EACCES - Another resource is currently trying to access the port.
+	 *
+	 * \param port
+	 *        The V5 port number from 1-21
+	 * \param baudrate
+	 *        The baudrate to run the port at
+	 */
+	explicit Serial(std::uint8_t port, std::int32_t baudrate);
+
+	explicit Serial(std::uint8_t port);
+
+	/******************************************************************************/
+	/**                      Serial communication functions                      **/
+	/**                                                                          **/
+	/**  These functions allow programmers to communicate using UART over RS485  **/
+	/******************************************************************************/
+
+	/**
+	 * Sets the baudrate for the serial port to operate at.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * EINVAL - The given value is not within the range of V5 ports (1-21).
+	 * EACCES - Another resource is currently trying to access the port.
+	 *
+	 * \param baudrate
+	 *        The baudrate to operate at
+	 *
+	 * \return 1 if the operation was successful or PROS_ERR if the operation
+	 * failed, setting errno.
+	 */
+	virtual std::int32_t set_baudrate(std::int32_t baudrate) const;
+
+	/**
+	 * Clears the internal input and output FIFO buffers.
+	 *
+	 * This can be useful to reset state and remove old, potentially unneeded data
+	 * from the input FIFO buffer or to cancel sending any data in the output FIFO
+	 * buffer.
+	 *
+	 * \note This function does not cause the data in the output buffer to be
+	 * written, it simply clears the internal buffers. Unlike stdout, generic
+	 * serial does not use buffered IO (the FIFO buffers are written as soon
+	 * as possible).
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * EINVAL - The given value is not within the range of V5 ports (1-21).
+	 * EACCES - Another resource is currently trying to access the port.
+	 *
+	 * \return 1 if the operation was successful or PROS_ERR if the operation
+	 * failed, setting errno.
+	 */
+	virtual std::int32_t flush() const;
+
+	/**
+	 * Returns the number of bytes available to be read in the the port's FIFO
+	 * input buffer.
+	 *
+	 * \note This function does not actually read any bytes, is simply returns the
+	 * number of bytes available to be read.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * EINVAL - The given value is not within the range of V5 ports (1-21).
+	 * EACCES - Another resource is currently trying to access the port.
+	 *
+	 * \return The number of bytes avaliable to be read or PROS_ERR if the operation
+	 * failed, setting errno.
+	 */
+	virtual std::int32_t read_avail() const;
+
+	/**
+	 * Returns the number of bytes free in the port's FIFO output buffer.
+	 *
+	 * \note This function does not actually write any bytes, is simply returns the
+	 * number of bytes free in the port's buffer.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * EINVAL - The given value is not within the range of V5 ports (1-21).
+	 * EACCES - Another resource is currently trying to access the port.
+	 *
+	 * \return The number of bytes free or PROS_ERR if the operation failed,
+	 * setting errno.
+	 */
+	virtual std::int32_t write_free() const;
+
+	/**
+	 * Reads the next byte avaliable in the port's input buffer without removing it.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * EINVAL - The given value is not within the range of V5 ports (1-21).
+	 * EACCES - Another resource is currently trying to access the port.
+	 *
+	 * \return The next byte avaliable to be read, -1 if none are available, or
+	 * PROS_ERR if the operation failed, setting errno.
+	 */
+	virtual std::int32_t peek_byte() const;
+
+	/**
+	 * Reads the next byte avaliable in the port's input buffer.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * EINVAL - The given value is not within the range of V5 ports (1-21).
+	 * EACCES - Another resource is currently trying to access the port.
+	 *
+	 * \return The next byte avaliable to be read, -1 if none are available, or
+	 * PROS_ERR if the operation failed, setting errno.
+	 */
+	virtual std::int32_t read_byte() const;
+
+	/**
+	 * Reads up to the next length bytes from the port's input buffer and places
+	 * them in the user supplied buffer.
+	 *
+	 * \note This function will only return bytes that are currently avaliable to be
+	 * read and will not block waiting for any to arrive.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * EINVAL - The given value is not within the range of V5 ports (1-21).
+	 * EACCES - Another resource is currently trying to access the port.
+	 *
+	 * \param buffer
+	 *        The location to place the data read
+	 * \param length
+	 *        The maximum number of bytes to read
+	 *
+	 * \return The number of bytes read or PROS_ERR if the operation failed, setting
+	 * errno.
+	 */
+	virtual std::int32_t read(std::uint8_t* buffer, std::int32_t length) const;
+
+	/**
+	 * Write the given byte to the port's output buffer.
+	 *
+	 * \note Data in the port's output buffer is written to the serial port as soon
+	 * as possible on a FIFO basis and can not be done manually by the user.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * EINVAL - The given value is not within the range of V5 ports (1-21).
+	 * EACCES - Another resource is currently trying to access the port.
+	 * EIO - Serious internal write error.
+	 *
+	 * \param buffer
+	 *        The byte to write
+	 *
+	 * \return The number of bytes written or PROS_ERR if the operation failed,
+	 * setting errno.
+	 */
+	virtual std::int32_t write_byte(std::uint8_t buffer) const;
+
+	/**
+	 * Writes up to length bytes from the user supplied buffer to the port's output
+	 * buffer.
+	 *
+	 * \note Data in the port's output buffer is written to the serial port as soon
+	 * as possible on a FIFO basis and can not be done manually by the user.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * EINVAL - The given value is not within the range of V5 ports (1-21).
+	 * EACCES - Another resource is currently trying to access the port.
+	 * EIO - Serious internal write error.
+	 *
+	 * \param buffer
+	 *        The data to write
+	 * \param length
+	 *        The maximum number of bytes to write
+	 *
+	 * \return The number of bytes written or PROS_ERR if the operation failed,
+	 * setting errno.
+	 */
+	virtual std::int32_t write(std::uint8_t* buffer, std::int32_t length) const;
+
+	private:
+	const std::uint8_t _port;
+};
+
+namespace literals {
+const pros::Serial operator"" _ser(const unsigned long long int m);
+}  // namespace literals
+}  // namespace pros
+#endif  // _PROS_SERIAL_HPP_

--- a/src/devices/vdml_serial.c
+++ b/src/devices/vdml_serial.c
@@ -56,13 +56,13 @@ int32_t serial_flush(uint8_t port) {
 
 // Telemetry functions
 
-int32_t serial_read_avail(uint8_t port) {
+int32_t serial_get_read_avail(uint8_t port) {
 	claim_port(port - 1, E_DEVICE_GENERIC);
 	int32_t rtn = vexDeviceGenericSerialReceiveAvail(device->device_info);
 	return_port(port - 1, rtn);
 }
 
-int32_t serial_write_free(uint8_t port) {
+int32_t serial_get_write_free(uint8_t port) {
 	claim_port(port - 1, E_DEVICE_GENERIC);
 	int32_t rtn = vexDeviceGenericSerialWriteFree(device->device_info);
 	return_port(port - 1, rtn);

--- a/src/devices/vdml_serial.c
+++ b/src/devices/vdml_serial.c
@@ -1,0 +1,111 @@
+/**
+ * \file devices/vdml_serial.c
+ *
+ * Contains functions for interacting with V5 Generic Serial devices.
+ *
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <errno.h>
+#include <math.h>
+#include <stdio.h>
+
+#include "kapi.h"
+#include "pros/serial.h"
+#include "v5_api.h"
+#include "vdml/registry.h"
+#include "vdml/vdml.h"
+
+// Control function
+
+int32_t serial_enable(uint8_t port) {
+	/**
+	 * claim_port(port - 1, E_DEVICE_GENERIC) is not used because it requires
+	 * the port to already be of the requested type in VEXos, which will not yet
+	 * be the case for generic serial as vexDeviceGenericSerialEnable is what
+	 * switches the port into the correct mode
+	 */
+	if (!VALIDATE_PORT_NO(port - 1)) {
+		errno = EINVAL;
+		return PROS_ERR;
+	}
+	v5_smart_device_s_t* device = registry_get_device(port - 1);
+	if (!port_mutex_take(port - 1)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
+	vexDeviceGenericSerialEnable(device->device_info, 0);
+	return_port(port - 1, 1);
+}
+
+int32_t serial_set_baudrate(uint8_t port, int32_t baudrate) {
+	claim_port(port - 1, E_DEVICE_GENERIC);
+	vexDeviceGenericSerialBaudrate(device->device_info, baudrate);
+	return_port(port - 1, 1);
+}
+
+int32_t serial_flush(uint8_t port) {
+	claim_port(port - 1, E_DEVICE_GENERIC);
+	vexDeviceGenericSerialFlush(device->device_info);
+	return_port(port - 1, 1);
+}
+
+// Telemetry functions
+
+int32_t serial_read_avail(uint8_t port) {
+	claim_port(port - 1, E_DEVICE_GENERIC);
+	int32_t rtn = vexDeviceGenericSerialReceiveAvail(device->device_info);
+	return_port(port - 1, rtn);
+}
+
+int32_t serial_write_free(uint8_t port) {
+	claim_port(port - 1, E_DEVICE_GENERIC);
+	int32_t rtn = vexDeviceGenericSerialWriteFree(device->device_info);
+	return_port(port - 1, rtn);
+}
+
+// Read functions
+
+int32_t serial_peek_byte(uint8_t port) {
+	claim_port(port - 1, E_DEVICE_GENERIC);
+	int32_t rtn = vexDeviceGenericSerialPeekChar(device->device_info);
+	return_port(port - 1, rtn);
+}
+
+int32_t serial_read_byte(uint8_t port) {
+	claim_port(port - 1, E_DEVICE_GENERIC);
+	int32_t rtn = vexDeviceGenericSerialReadChar(device->device_info);
+	return_port(port - 1, rtn);
+}
+
+int32_t serial_read(uint8_t port, uint8_t* buffer, int32_t length) {
+	claim_port(port - 1, E_DEVICE_GENERIC);
+	int32_t rtn = vexDeviceGenericSerialReceive(device->device_info, buffer, length);
+	return_port(port - 1, rtn);
+}
+
+// Write functions
+
+int32_t serial_write_byte(uint8_t port, uint8_t buffer) {
+	claim_port(port - 1, E_DEVICE_GENERIC);
+	int32_t rtn = vexDeviceGenericSerialWriteChar(device->device_info, buffer);
+	if (rtn == -1) {
+		errno = EIO;
+		return_port(port - 1, PROS_ERR);
+	}
+	return_port(port - 1, rtn);
+}
+
+int32_t serial_write(uint8_t port, uint8_t* buffer, int32_t length) {
+	claim_port(port - 1, E_DEVICE_GENERIC);
+	int32_t rtn = vexDeviceGenericSerialTransmit(device->device_info, buffer, length);
+	if (rtn == -1) {
+		errno = EIO;
+		return_port(port - 1, PROS_ERR);
+	}
+	return_port(port - 1, rtn);
+}

--- a/src/devices/vdml_serial.cpp
+++ b/src/devices/vdml_serial.cpp
@@ -33,12 +33,12 @@ std::int32_t Serial::flush() const {
 	return serial_flush(_port);
 }
 
-std::int32_t Serial::read_avail() const {
-	return serial_read_avail(_port);
+std::int32_t Serial::get_read_avail() const {
+	return serial_get_read_avail(_port);
 }
 
-std::int32_t Serial::write_free() const {
-	return serial_write_free(_port);
+std::int32_t Serial::get_write_free() const {
+	return serial_get_write_free(_port);
 }
 
 std::int32_t Serial::peek_byte() const {

--- a/src/devices/vdml_serial.cpp
+++ b/src/devices/vdml_serial.cpp
@@ -1,0 +1,69 @@
+/**
+ * \file devices/vdml_serial.cpp
+ *
+ * Contains functions for interacting with V5 Generic Serial devices.
+ *
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "kapi.h"
+#include "pros/serial.hpp"
+
+namespace pros {
+using namespace pros::c;
+
+Serial::Serial(std::uint8_t port, std::int32_t baudrate) : _port(port) {
+	serial_enable(port);
+	set_baudrate(baudrate);
+}
+
+Serial::Serial(std::uint8_t port) : _port(port) {
+	serial_enable(port);
+}
+
+std::int32_t Serial::set_baudrate(std::int32_t baudrate) const {
+	return serial_set_baudrate(_port, baudrate);
+}
+
+std::int32_t Serial::flush() const {
+	return serial_flush(_port);
+}
+
+std::int32_t Serial::read_avail() const {
+	return serial_read_avail(_port);
+}
+
+std::int32_t Serial::write_free() const {
+	return serial_write_free(_port);
+}
+
+std::int32_t Serial::peek_byte() const {
+	return serial_peek_byte(_port);
+}
+
+std::int32_t Serial::read_byte() const {
+	return serial_read_byte(_port);
+}
+
+std::int32_t Serial::read(std::uint8_t* buffer, std::int32_t length) const {
+	return serial_read(_port, buffer, length);
+}
+
+std::int32_t Serial::write_byte(std::uint8_t buffer) const {
+	return serial_write_byte(_port, buffer);
+}
+
+std::int32_t Serial::write(std::uint8_t* buffer, std::int32_t length) const {
+	return serial_write(_port, buffer, length);
+}
+
+namespace literals {
+const pros::Serial operator"" _ser(const unsigned long long int m) {
+	return pros::Serial(m);
+}
+}  // namespace literals
+}  // namespace pros

--- a/src/system/dev/dev_driver.c
+++ b/src/system/dev/dev_driver.c
@@ -51,7 +51,7 @@ int dev_read_r(struct _reent* r, void* const arg, uint8_t* buffer, const size_t 
 		if (file_arg->flags & O_NONBLOCK || recv >= 1) {
 			break;
 		}
-		task_delay(1);
+		task_delay(2);
 	}
 	if (recv == 0) {
 		errno = EAGAIN;
@@ -73,7 +73,7 @@ int dev_write_r(struct _reent* r, void* const arg, const uint8_t* buf, const siz
 		if (file_arg->flags & O_NONBLOCK || wrtn >= len) {
 			break;
 		}
-		task_delay(1);
+		task_delay(2);
 	}
 	if (wrtn == 0) {
 		errno = EAGAIN;

--- a/src/system/dev/dev_driver.c
+++ b/src/system/dev/dev_driver.c
@@ -108,9 +108,9 @@ int dev_ctl(void* const arg, const uint32_t cmd, void* const extra_arg) {
 	uint32_t port = file_arg->port;
 	switch (cmd) {
 		case DEVCTL_FIONREAD:
-			return serial_read_avail(port);
+			return serial_get_read_avail(port);
 		case DEVCTL_FIONWRITE:
-			return serial_write_free(port);
+			return serial_get_write_free(port);
 		case DEVCTL_SET_BAUDRATE:
 			return serial_set_baudrate(port, (int32_t)extra_arg);
 		default:

--- a/src/tests/generic_serial.cpp
+++ b/src/tests/generic_serial.cpp
@@ -1,0 +1,192 @@
+/**
+ * \file tests/generic_serial.cpp
+ *
+ * Test code for the generic serial driver
+ *
+ * NOTE: There should be a cable plugged into ports 1 and 2, connecting
+ * them together
+ *
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
+ * All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "main.h"
+#include <stdarg.h>
+
+pros::Serial *serial_w = nullptr, *serial_r = nullptr;
+
+constexpr bool VERBOSE_OUTPUT = false;
+
+constexpr uint32_t BUF_SIZE = 65536;
+uint8_t out_buf[BUF_SIZE], in_buf[BUF_SIZE];
+
+void verbose_printf(const char *format, ...) {
+	if (VERBOSE_OUTPUT) {
+		va_list va;
+		va_start(va, format);
+		vprintf(format, va);
+		va_end(va);
+	}
+}
+
+bool test_send_recv_byte(const uint32_t interval, const uint32_t bytes) {
+	printf("%07d Starting send/recv byte test with an interval of %dms for %d bytes...\n", pros::millis(), interval, bytes);
+
+	uint8_t count = 0, expected = 0;
+	uint32_t last_send_time = 0, cur_time, recv_count = 0;
+	bool pass = true;
+
+	do {
+		cur_time = pros::millis();
+
+		if (cur_time - last_send_time >= interval) {
+			int32_t w = serial_w->write_byte(count);
+			if (w == PROS_ERR) {
+				pass = false;
+				printf("%07d Write failed with error %d\n", cur_time, errno);
+				break;
+			}
+			else if (w) {
+				count++;
+				last_send_time = cur_time;
+			}
+		}
+
+		int32_t read = serial_r->read_byte();
+		if (read == PROS_ERR) {
+			pass = false;
+			printf("%07d Read failed with error %d\n", cur_time, errno);
+			break;
+		}
+		else if (read >= 0) {
+			if (read != expected) {
+				printf("%07d ERR Read: 0x%02x, Expt: 0x%02x\n", cur_time, read, expected);
+				pass = false;
+			}
+			else {
+				verbose_printf("%07d 0x%02x\n", cur_time, read);
+			}
+			expected++;
+			recv_count++;
+		}
+
+		pros::delay(interval);
+	} while (recv_count < bytes);
+
+	if (pass)
+		printf("%07d PASS\n", pros::millis());
+	else
+		printf("%07d FAIL\n", pros::millis());
+
+	return pass;
+}
+
+bool test_send_recv_block() {
+	printf("%07d Starting send/recv block test...\n", pros::millis());
+
+	uint32_t written = 0, read = 0;
+	bool pass = true;
+
+	for (uint32_t i = 0; i < BUF_SIZE; i++) {
+		out_buf[i] = i;
+	}
+
+	while (written < BUF_SIZE || read < BUF_SIZE) {
+		uint32_t cur_time = pros::millis();
+
+		int32_t r = serial_r->read(in_buf + read, BUF_SIZE - read);
+		if (r == PROS_ERR) {
+			pass = false;
+			printf("%07d Read failed with error %d\n", cur_time, errno);
+			break;
+		}
+		else if (r) {
+			verbose_printf("%07d R %d [", cur_time, r);
+			for (int32_t i = 0; i < r; i++) {
+				verbose_printf("%02x", in_buf[read + i]);
+				if (in_buf[read + i] != out_buf[read + i]) {
+					pass = false;
+					verbose_printf(" (%02x)", out_buf[read + i]);
+				}
+				if (i < r - 1)
+					verbose_printf(", ");
+			}
+			verbose_printf("]\n");
+
+			read += r;
+		}
+
+		int32_t w = serial_w->write(out_buf + written, BUF_SIZE - written);
+		if (w == PROS_ERR) {
+			pass = false;
+			printf("%07d Write failed with error %d\n", cur_time, errno);
+			break;
+		}
+		else if (w) {
+			verbose_printf("%07d, W %d\n", cur_time, w);
+			written += w;
+		}
+
+		pros::delay(1);
+	}
+
+	if (pass)
+		printf("%07d PASS\n", pros::millis());
+	else
+		printf("%07d FAIL\n", pros::millis());
+
+	return pass;
+}
+
+void set_baudrate(const int32_t baudrate) {
+	printf("%07d Setting baudrate to %d\n", pros::millis(), baudrate);
+	serial_w->set_baudrate(baudrate);
+	serial_r->set_baudrate(baudrate);
+}
+
+void flush() {
+	serial_w->flush();
+	pros::delay(100);
+	serial_r->flush();
+}
+
+void init_ports(uint8_t write_port, uint8_t recv_port) {
+	printf("%07d Using port %d to write and %d to recv\n", pros::millis(), write_port, recv_port);
+
+	if (serial_w != nullptr) delete serial_w;
+	serial_w = new pros::Serial(write_port);
+	if (serial_r != nullptr) delete serial_r;
+	serial_r = new pros::Serial(recv_port);
+}
+
+bool run_tests() {
+	flush();
+	set_baudrate(115200);
+	if (!test_send_recv_byte(5, 1000)) return false;
+
+	flush();
+	set_baudrate(230400);
+	if (!test_send_recv_byte(2, 2500)) return false;
+
+	for (int i = 0; i < 5; i++) {
+		flush();
+		if (!test_send_recv_block()) return false;
+	}
+
+	return true;
+}
+
+void opcontrol() {
+	printf("---Generic Serial Test---\nPlease ensure a cable is plugged into port 1 and port 2, connecting them together\n\n%07d Starting serial tests...\n", pros::millis());
+
+	init_ports(1, 2);
+	if (!run_tests()) return;
+
+	init_ports(2, 1);
+	if (!run_tests()) return;
+
+	printf("%07d All tests passed!\n", pros::millis());
+}

--- a/src/tests/generic_serial.cpp
+++ b/src/tests/generic_serial.cpp
@@ -15,6 +15,7 @@
  */
 #include "main.h"
 #include <stdarg.h>
+#include "pros/apix.h"
 
 pros::Serial *serial_w = nullptr, *serial_r = nullptr;
 

--- a/src/tests/generic_serial_file.cpp
+++ b/src/tests/generic_serial_file.cpp
@@ -1,0 +1,208 @@
+/**
+ * \file tests/generic_serial_file.cpp
+ *
+ * Test code for the generic serial filesystem driver
+ *
+ * NOTE: There should be a cable plugged into ports 1 and 2, connecting
+ * them together
+ *
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
+ * All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+#include "main.h"
+#include <stdarg.h>
+#include "pros/apix.h"
+
+FILE *serial_w = nullptr, *serial_r = nullptr;
+char serial_w_name[8], serial_r_name[8];
+int serial_w_port, serial_r_port;
+
+constexpr bool VERBOSE_OUTPUT = false;
+
+constexpr uint32_t BUF_SIZE = 65536;
+uint8_t out_buf[BUF_SIZE], in_buf[BUF_SIZE];
+
+void verbose_printf(const char *format, ...) {
+	if (VERBOSE_OUTPUT) {
+		va_list va;
+		va_start(va, format);
+		vprintf(format, va);
+		va_end(va);
+	}
+}
+
+bool test_send_recv_byte(const uint32_t interval, const uint32_t bytes) {
+	printf("%07d Starting send/recv byte test with an interval of %dms for %d bytes...\n", pros::millis(), interval, bytes);
+
+	uint8_t count = 0, expected = 0;
+	uint32_t last_send_time = 0, cur_time, recv_count = 0;
+	bool pass = true;
+
+	do {
+		cur_time = pros::millis();
+
+		if (cur_time - last_send_time >= interval) {
+			int32_t w = fputc(count, serial_w);
+			fflush(serial_w);
+			if (w == EOF) {
+				if (ferror(serial_w)) {
+					pass = false;
+					printf("%07d Write failed with error %d\n", cur_time, errno);
+					break;
+				}
+			}
+			else if (w == count) {
+				count++;
+				last_send_time = cur_time;
+			}
+		}
+
+		int32_t read = fgetc(serial_r);
+		if (read == EOF) {
+			if (ferror(serial_r)) {
+				pass = false;
+				printf("%07d Read failed with error %d\n", cur_time, ferror(serial_r));
+				break;
+			}
+		}
+		else {
+			if (read != expected) {
+				printf("%07d ERR Read: 0x%02x, Expt: 0x%02x\n", cur_time, read, expected);
+				pass = false;
+			}
+			else {
+				verbose_printf("%07d 0x%02x\n", cur_time, read);
+			}
+			expected++;
+			recv_count++;
+		}
+
+		pros::delay(interval);
+	} while (recv_count < bytes);
+
+	if (pass)
+		printf("%07d PASS\n", pros::millis());
+	else
+		printf("%07d FAIL\n", pros::millis());
+
+	return pass;
+}
+
+bool test_send_recv_block() {
+	printf("%07d Starting send/recv block test...\n", pros::millis());
+
+	uint32_t written = 0, read = 0;
+	bool pass = true;
+
+	for (uint32_t i = 0; i < BUF_SIZE; i++) {
+		out_buf[i] = i;
+	}
+
+	while (written < BUF_SIZE || read < BUF_SIZE) {
+		uint32_t cur_time = pros::millis();
+		int32_t free = pros::c::fdctl(fileno(serial_w), DEVCTL_FIONWRITE, NULL);
+		int32_t w = fwrite(out_buf + written, 1, BUF_SIZE - written > free ? free : BUF_SIZE - written, serial_w);
+		fflush(serial_w);
+		if (w == EOF) {
+			pass = false;
+			printf("%07d Write failed with error %d\n", cur_time, errno);
+			break;
+		}
+		else if (w) {
+			verbose_printf("%07d, W %d\n", cur_time, w);
+			written += w;
+		}
+
+		int32_t avail = pros::c::fdctl(fileno(serial_r), DEVCTL_FIONREAD, NULL);
+		int32_t r = fread(in_buf + read, 1, BUF_SIZE - read > avail ? avail : BUF_SIZE - read, serial_r);
+		if (r == EOF) {
+			if (ferror(serial_r)) {
+				pass = false;
+				printf("%07d Read failed with error %d\n", cur_time, errno);
+				break;
+			}
+		}
+		else if (r) {
+			verbose_printf("%07d R %d [", cur_time, r);
+			for (int32_t i = 0; i < r; i++) {
+				verbose_printf("%02x", in_buf[read + i]);
+				if (in_buf[read + i] != out_buf[read + i]) {
+					pass = false;
+					verbose_printf(" (%02x)", out_buf[read + i]);
+				}
+				if (i < r - 1)
+					verbose_printf(", ");
+			}
+			verbose_printf("]\n");
+
+			read += r;
+		}
+
+		pros::delay(1);
+	}
+
+	if (pass)
+		printf("%07d PASS\n", pros::millis());
+	else
+		printf("%07d FAIL\n", pros::millis());
+
+	return pass;
+}
+
+void set_baudrate(const int32_t baudrate) {
+	printf("%07d Setting baudrate to %d\n", pros::millis(), baudrate);
+	pros::c::fdctl(fileno(serial_w), DEVCTL_SET_BAUDRATE, (void *)baudrate);
+	pros::c::fdctl(fileno(serial_r), DEVCTL_SET_BAUDRATE, (void *)baudrate);
+}
+
+void flush() {
+	pros::c::serial_flush(serial_w_port);
+	pros::delay(100);
+	pros::c::serial_flush(serial_r_port);
+}
+
+void init_ports(uint8_t write_port, uint8_t recv_port) {
+	printf("%07d Using port %d to write and %d to recv\n", pros::millis(), write_port, recv_port);
+
+	serial_w_port = write_port;
+	if (serial_w != nullptr) fclose(serial_w);
+	sprintf(serial_w_name, "/dev/%d", write_port);
+	serial_w = fopen(serial_w_name, "wb");
+	serial_r_port = recv_port;
+	if (serial_r != nullptr) fclose(serial_r);
+	sprintf(serial_r_name, "/dev/%d", recv_port);
+	serial_r = fopen(serial_r_name, "rb");
+}
+
+bool run_tests() {
+	flush();
+	set_baudrate(115200);
+	if (!test_send_recv_byte(5, 1000)) return false;
+
+	flush();
+	set_baudrate(230400);
+	if (!test_send_recv_byte(2, 2500)) return false;
+
+	for (int i = 0; i < 5; i++) {
+		flush();
+		if (!test_send_recv_block()) return false;
+	}
+
+	return true;
+}
+
+void opcontrol() {
+	printf("---Generic Serial Test---\nPlease ensure a cable is plugged into port 1 and port 2, connecting them together\n\n%07d Starting serial tests...\n", pros::millis());
+
+	init_ports(1, 2);
+	if (!run_tests()) return;
+
+	init_ports(2, 1);
+	if (!run_tests()) return;
+
+	printf("%07d All tests passed!\n", pros::millis());
+}

--- a/src/tests/generic_serial_file.cpp
+++ b/src/tests/generic_serial_file.cpp
@@ -49,11 +49,9 @@ bool test_send_recv_byte(const uint32_t interval, const uint32_t bytes) {
 			int32_t w = fputc(count, serial_w);
 			fflush(serial_w);
 			if (w == EOF) {
-				if (ferror(serial_w)) {
-					pass = false;
-					printf("%07d Write failed with error %d\n", cur_time, errno);
-					break;
-				}
+				pass = false;
+				printf("%07d Write failed with error %d\n", cur_time, errno);
+				break;
 			}
 			else if (w == count) {
 				count++;
@@ -63,11 +61,9 @@ bool test_send_recv_byte(const uint32_t interval, const uint32_t bytes) {
 
 		int32_t read = fgetc(serial_r);
 		if (read == EOF) {
-			if (ferror(serial_r)) {
-				pass = false;
-				printf("%07d Read failed with error %d\n", cur_time, ferror(serial_r));
-				break;
-			}
+			pass = false;
+			printf("%07d Read failed with error %d\n", cur_time, errno);
+			break;
 		}
 		else {
 			if (read != expected) {
@@ -120,11 +116,9 @@ bool test_send_recv_block() {
 		int32_t avail = pros::c::fdctl(fileno(serial_r), DEVCTL_FIONREAD, NULL);
 		int32_t r = fread(in_buf + read, 1, BUF_SIZE - read > avail ? avail : BUF_SIZE - read, serial_r);
 		if (r == EOF) {
-			if (ferror(serial_r)) {
-				pass = false;
-				printf("%07d Read failed with error %d\n", cur_time, errno);
-				break;
-			}
+			pass = false;
+			printf("%07d Read failed with error %d\n", cur_time, errno);
+			break;
 		}
 		else if (r) {
 			verbose_printf("%07d R %d [", cur_time, r);


### PR DESCRIPTION
#### Summary:
- Add alternate generic serial API
- Fix filesystem generic serial driver

#### Motivation:
The alternate generic serial API was added for users who want a lower level serial API. The generic serial filesystem driver was broken so it was fixed and implemented using the new API so the VEXos functions are only called in one place.

#### Test Plan:
- [x] Compile kernel
- [x] Ensure `src/tests/generic_serial.cpp` passes
- [x] Ensure `src/tests/generic_serial_file.cpp` passes
