### PR TITLE
🤫 Suppress ignored qualifiers when including lvgl

### DIFF
--- a/include/pros/llemu.h
+++ b/include/pros/llemu.h
@@ -27,6 +27,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wignored-qualifiers"
 #include "display/lvgl.h"
 #pragma GCC diagnostic pop
 


### PR DESCRIPTION
#### Summary:
This PR pushes `ignored "-Wignored-qualifiers"` when including the LVGL headers.

#### Motivation:
The LVGL headers cause a lot of noise via compiler warnings. This PR silences those warnings.

#### Test Plan:
- [x] Compile and verify no warnings are generated by LVGL headers
