### PR TITLE
🐛 Fix multiple ADI bugs and inconsistencies

### DIFF
--- a/VSCode.md
+++ b/VSCode.md
@@ -4,3 +4,5 @@ Use the following include paths for intellisense completion:
 "${env:PROS_TOOLCHAIN}/lib/gcc/arm-none-eabi/6.3.1/include",
 "${workspaceRoot}",
 "${workspaceRoot}/include"
+
+Add "_INTELLISENSE" to your defines to fix certain intellisense errors that will actually compile without issue

--- a/include/pros/adi.h
+++ b/include/pros/adi.h
@@ -37,8 +37,13 @@ typedef enum adi_port_config_e {
 	E_ADI_DIGITAL_IN = 2,
 	E_ADI_DIGITAL_OUT = 3,
 
+#ifdef _INTELLISENSE
+#define _DEPRECATE_DIGITAL_IN = E_ADI_DIGITAL_IN
+#define _DEPRECATE_ANALOG_IN = E_ADI_ANALOG_IN
+#else
 #define _DEPRECATE_DIGITAL_IN __attribute__((deprecated("use E_ADI_DIGITAL_IN instead"))) = E_ADI_DIGITAL_IN
 #define _DEPRECATE_ANALOG_IN __attribute__((deprecated("use E_ADI_ANALOG_IN instead"))) = E_ADI_ANALOG_IN
+#endif
 
 	E_ADI_SMART_BUTTON _DEPRECATE_DIGITAL_IN,
 	E_ADI_SMART_POT _DEPRECATE_ANALOG_IN,

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -39,7 +39,7 @@ class ADIPort {
 	 */
 	ADIPort(std::uint8_t port, adi_port_config_e_t type = E_ADI_TYPE_UNDEFINED);
 
-	virtual ~ADIPort(void);
+	virtual ~ADIPort(void) = default;
 
 	/**
 	 * Gets the configuration for the given ADI port.

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -39,6 +39,8 @@ class ADIPort {
 	 */
 	ADIPort(std::uint8_t port, adi_port_config_e_t type = E_ADI_TYPE_UNDEFINED);
 
+	virtual ~ADIPort(void);
+
 	/**
 	 * Gets the configuration for the given ADI port.
 	 *

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -39,8 +39,6 @@ class ADIPort {
 	 */
 	ADIPort(std::uint8_t port, adi_port_config_e_t type = E_ADI_TYPE_UNDEFINED);
 
-	virtual ~ADIPort(void);
-
 	/**
 	 * Gets the configuration for the given ADI port.
 	 *
@@ -473,8 +471,6 @@ class ADIGyro : private ADIPort {
 	 *        supplied by the ADI
 	 */
 	ADIGyro(std::uint8_t port, double multiplier = 1);
-
-	~ADIGyro(void) override;
 
 	/**
 	 * Gets the current gyro angle in tenths of a degree. Unless a multiplier is

--- a/include/vdml/registry.h
+++ b/include/vdml/registry.h
@@ -24,7 +24,6 @@ extern "C" {
 typedef struct {
 	v5_device_e_t device_type;
 	V5_DeviceT device_info;
-	// HACK: Make pad a union of all possible types that can be stored
 	uint8_t pad[128];  // 16 bytes in adi_data_s_t times 8 ADI Ports = 128
 } v5_smart_device_s_t;
 

--- a/include/vdml/registry.h
+++ b/include/vdml/registry.h
@@ -24,6 +24,7 @@ extern "C" {
 typedef struct {
 	v5_device_e_t device_type;
 	V5_DeviceT device_info;
+	// HACK: Make pad a union of all possible types that can be stored
 	uint8_t pad[128];  // 16 bytes in adi_data_s_t times 8 ADI Ports = 128
 } v5_smart_device_s_t;
 

--- a/include/vdml/vdml.h
+++ b/include/vdml/vdml.h
@@ -33,7 +33,8 @@
  * If a mutex cannot be taken, errno is set to EACCES (access denied) and
  * returns.
  * 
- * FIXME: If this is used in a function that returns a double, PROS_ERR_F should be returned
+ * This and other similar macros should only be used in functions that return
+ * int32_t as PROS_ERR could be returned.
  *
  * \param port
  *        The V5 port number from 0-20

--- a/include/vdml/vdml.h
+++ b/include/vdml/vdml.h
@@ -32,6 +32,8 @@
  * If a port isn't yet registered, it registered as a motor automatically.
  * If a mutex cannot be taken, errno is set to EACCES (access denied) and
  * returns.
+ * 
+ * FIXME: If this is used in a function that returns a double, PROS_ERR_F should be returned
  *
  * \param port
  *        The V5 port number from 0-20

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -24,6 +24,8 @@ ADIPort::ADIPort(void) {
 	// for use by derived classes like ADIEncoder
 }
 
+ADIPort::~ADIPort(void) {}
+
 std::int32_t ADIPort::set_config(adi_port_config_e_t type) const {
 	return adi_port_set_config(_port, type);
 }

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -24,8 +24,6 @@ ADIPort::ADIPort(void) {
 	// for use by derived classes like ADIEncoder
 }
 
-ADIPort::~ADIPort(void) {}
-
 std::int32_t ADIPort::set_config(adi_port_config_e_t type) const {
 	return adi_port_set_config(_port, type);
 }

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -24,10 +24,6 @@ ADIPort::ADIPort(void) {
 	// for use by derived classes like ADIEncoder
 }
 
-ADIPort::~ADIPort(void) {
-	adi_port_set_config(_port, E_ADI_TYPE_UNDEFINED);
-}
-
 std::int32_t ADIPort::set_config(adi_port_config_e_t type) const {
 	return adi_port_set_config(_port, type);
 }
@@ -105,10 +101,6 @@ ADIUltrasonic::ADIUltrasonic(std::uint8_t port_ping, std::uint8_t port_echo) {
 
 ADIGyro::ADIGyro(std::uint8_t port, double multiplier) {
 	_port = adi_gyro_init(port, multiplier);
-}
-
-ADIGyro::~ADIGyro(void) {
-	// Don't change the port configuration so we don't have to recalibrate
 }
 
 double ADIGyro::get_value(void) const {

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -40,13 +40,9 @@ std::int32_t ADIPort::get_value(void) const {
 	return adi_port_get_value(_port);
 }
 
-ADIAnalogIn::ADIAnalogIn(std::uint8_t port) : ADIPort(port) {
-	set_config(E_ADI_ANALOG_IN);
-}
+ADIAnalogIn::ADIAnalogIn(std::uint8_t port) : ADIPort(port, E_ADI_ANALOG_IN) {}
 
-ADIAnalogOut::ADIAnalogOut(std::uint8_t port) : ADIPort(port) {
-	set_config(E_ADI_ANALOG_OUT);
-}
+ADIAnalogOut::ADIAnalogOut(std::uint8_t port) : ADIPort(port, E_ADI_ANALOG_OUT) {}
 
 std::int32_t ADIAnalogIn::calibrate(void) const {
 	return adi_analog_calibrate(_port);
@@ -60,21 +56,17 @@ std::int32_t ADIAnalogIn::get_value_calibrated_HR(void) const {
 	return adi_analog_read_calibrated_HR(_port);
 }
 
-ADIDigitalOut::ADIDigitalOut(std::uint8_t port, bool init_state) : ADIPort(port) {
-	set_config(E_ADI_DIGITAL_OUT);
+ADIDigitalOut::ADIDigitalOut(std::uint8_t port, bool init_state) : ADIPort(port, E_ADI_DIGITAL_OUT) {
 	set_value(init_state);
 }
 
-ADIDigitalIn::ADIDigitalIn(std::uint8_t port) : ADIPort(port) {
-	set_config(E_ADI_DIGITAL_IN);
-}
+ADIDigitalIn::ADIDigitalIn(std::uint8_t port) : ADIPort(port, E_ADI_DIGITAL_IN) {}
 
 std::int32_t ADIDigitalIn::get_new_press(void) const {
 	return adi_digital_get_new_press(_port);
 }
 
-ADIMotor::ADIMotor(std::uint8_t port) : ADIPort(port) {
-	set_config(E_ADI_LEGACY_PWM);
+ADIMotor::ADIMotor(std::uint8_t port) : ADIPort(port, E_ADI_LEGACY_PWM) {
 	stop();
 }
 

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -87,8 +87,7 @@ std::int32_t ADIEncoder::get_value(void) const {
 }
 
 ADIUltrasonic::ADIUltrasonic(std::uint8_t port_ping, std::uint8_t port_echo) {
-	_port = adi_ultrasonic_init(port_ping, port_echo) + 1;
-	// Add 1 to ensure that the ADIPort::get_value can be used
+	_port = adi_ultrasonic_init(port_ping, port_echo);
 }
 
 ADIGyro::ADIGyro(std::uint8_t port, double multiplier) {


### PR DESCRIPTION
#### Summary:
The ADI C API has been modified to be more self consistent. `adi_encoder_t`, `adi_ultrasonic_t` and `adi_gyro_t` now represent the user supplied port (1 through 8 instead of 0 through 7) so that functions like `adi_encoder_get` can accept either the return value from the device initialization or a user supplied port number. `errno` is now properly set during ADI port validation failures and other small bugs were fixed. The ADI C++ destructor was changed to not clear the port configuration to make it similar to other PROS API's where multiple instances can be created and destroyed without side effects.

#### Motivation:
Some functionality did not match what a user would expect and in some cases did not match the PROS documentation.

##### References:
closes #115 
closes #148 
closes #149 

#### Test Plan:
- [x] Run some ADI tests
