### PR TITLE
🔧 Enable hot/cold by default

### DIFF
--- a/template-Makefile
+++ b/template-Makefile
@@ -17,7 +17,7 @@ EXTRA_CFLAGS=
 EXTRA_CXXFLAGS=
 
 # Set to 1 to enable hot/cold linking
-USE_PACKAGE:=0
+USE_PACKAGE:=1
 
 # Add libraries you do not wish to include in the cold image here
 # EXCLUDE_COLD_LIBRARIES:= $(FWDIR)/your_library.a


### PR DESCRIPTION
#### Summary:
This PR enables hot/cold by default.

#### Motivation:
Wireless uploading is optimized on other platforms by default. PROS should match this behavior.

#### Test Plan:

- [x] Make a new project and verify hot/cold is enabled by default.
