### PR TITLE
🚨 Make things work with GCC 8.3

### DIFF
--- a/src/system/cpp_support.cpp
+++ b/src/system/cpp_support.cpp
@@ -25,7 +25,7 @@ extern "C" void task_fn_wrapper(task_fn_t fn, void* args) {
 #endif
 		fn(args);
 #ifdef __cpp_exceptions
-	} catch (std::runtime_error re) {
+	} catch (std::runtime_error& re) {
 		vexDisplayString(7, "caught runtime error: %s", re.what());
 	} catch (...) {
 		vexDisplayString(7, "caught an unknown error");

--- a/src/system/mlock.c
+++ b/src/system/mlock.c
@@ -1,0 +1,24 @@
+/**
+ * \file system/mlock.c
+ *
+ * memory lock newlib stubs
+ *
+ * Contains implementations of memory-locking functions for newlib.
+ *
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
+ * All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "rtos/task.h"
+
+ void __malloc_lock(void) {
+ 	rtos_suspend_all();
+ }
+
+ void __malloc_unlock(void) {
+ 	rtos_resume_all();
+ }

--- a/src/system/newlib_stubs.c
+++ b/src/system/newlib_stubs.c
@@ -28,14 +28,6 @@ void _exit(int status) {
 	}
 }
 
-void __malloc_lock(void) {
-	rtos_suspend_all();
-}
-
-void __malloc_unlock(void) {
-	rtos_resume_all();
-}
-
 void __env_lock(void) {
 	rtos_suspend_all();
 }

--- a/src/system/newlib_stubs.c
+++ b/src/system/newlib_stubs.c
@@ -43,3 +43,9 @@ void __env_lock(void) {
 void __env_unlock(void) {
 	rtos_resume_all();
 }
+
+// HACK: this helps confused libc++ functions call the right instruction. for
+// info see https://github.com/purduesigbots/pros/issues/153#issuecomment-519335375
+void __sync_synchronize(void) {
+	__sync_synchronize();
+}


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
arm-none-eabi-8-2019-q3-update was released, which finally bumped arm-none-eabi-gcc to 8.3 officially, so we started running into the missing `__sync_synchronize` symbol as well. This PR fixes that, as well as a new multiple definitions issue (`__malloc_lock`/`unlock`).

The solution to the `__sync_synchronize` issue is described in https://github.com/purduesigbots/pros/issues/153#issuecomment-519335375.

`__malloc_lock` and `__malloc_unlock` were moved from src/system/newlib_stubs.c to their own file src/system/mlock.c, which [apparently is how newlib determines overrides](http://sourceware-org.1504.n7.nabble.com/malloc-lock-tp179955p179956.html).

#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
Since the latest official version of the toolchain now includes 8.3, we can't really just tell people that they should use the official one instead of the preview build arch package managers had access to. We should also be endeavoring to build the kernel against the latest version of the toolchain anyway.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
fixes #153, ref #146, ref #134, forum posts: https://www.vexforum.com/t/pros-programming-help/64328 https://www.vexforum.com/t/problem-with-building-files-in-pros-on-a-mac/64326, at least one email

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->
- [x] compiles with no errors or warnings against arm-none-eabi-8-2019-q3-update
- [x] compiles with no errors or warnings against an older version of the toolchain
