### PR TITLE
Add default `.gitignore` to template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ EXCLUDE_SRC_FROM_LIB+=$(foreach file, $(SRCDIR)/opcontrol $(SRCDIR)/initialize $
 TEMPLATE_FILES=$(ROOT)/common.mk $(FWDIR)/v5.ld $(FWDIR)/v5-common.ld $(FWDIR)/v5-hot.ld
 TEMPLATE_FILES+= $(INCDIR)/api.h $(INCDIR)/main.h $(INCDIR)/pros/*.* $(INCDIR)/display
 TEMPLATE_FILES+= $(SRCDIR)/opcontrol.cpp $(SRCDIR)/initialize.cpp $(SRCDIR)/autonomous.cpp
+TEMPLATE_FILES+= $(ROOT)/template-gitignore
 
 PATCHED_SDK=$(FWDIR)/libv5rts/sdk/vexv5/libv5rts.patched.a
 
@@ -57,7 +58,7 @@ $(PATCHED_SDK): $(FWDIR)/libv5rts/sdk/vexv5/libv5rts.a
 
 
 CREATE_TEMPLATE_ARGS=--system "./**/*"
-CREATE_TEMPLATE_ARGS+=--user "src/opcontrol.{c,cpp,cc}" --user "src/initialize.{cpp,c,cc}" --user "src/autonomous.{cpp,c,cc}" --user "include/main.{hpp,h,hh}" --user "Makefile"
+CREATE_TEMPLATE_ARGS+=--user "src/opcontrol.{c,cpp,cc}" --user "src/initialize.{cpp,c,cc}" --user "src/autonomous.{cpp,c,cc}" --user "include/main.{hpp,h,hh}" --user "Makefile" --user ".gitignore"
 CREATE_TEMPLATE_ARGS+=--target v5
 CREATE_TEMPLATE_ARGS+=--output bin/monolith.bin --cold_output bin/cold.package.bin --hot_output bin/hot.package.bin --cold_addr 58720256 --hot_addr 125829120
 
@@ -68,6 +69,7 @@ template: clean-template library
 	$(VV)mkdir -p $(TEMPLATE_DIR)/firmware
 	$Dcp $(LIBAR) $(TEMPLATE_DIR)/firmware
 	$Dcp $(ROOT)/template-Makefile $(TEMPLATE_DIR)/Makefile
+	$Dmv $(TEMPLATE_DIR)/template-gitignore $(TEMPLATE_DIR)/.gitignore
 	@echo "Creating template"
 	$Dprosv5 c create-template $(TEMPLATE_DIR) kernel $(shell cat $(ROOT)/version) $(CREATE_TEMPLATE_ARGS)
 

--- a/template-gitignore
+++ b/template-gitignore
@@ -1,0 +1,15 @@
+# Compiled Object files
+*.o
+*.obj
+
+# Executables
+*.bin
+*.elf
+
+# PROS
+bin/
+.vscode/
+compile_commands.json
+temp.log
+temp.errors
+*.ini


### PR DESCRIPTION
#### Summary:
Add a default `.gitignore` file to the project template.

#### Motivation:
Some beginner programmers don't know how to use git, and fail to add a `.gitignore` file to their project before creating a repository. Creating a repository is relatively simple, so it is likely that someone who does not know about `.gitignore` will still be able to create and commit to a repository.
PROS and cquery generate a lot of junk files, which get tracked by git if not explicitly ignored. This leads to programmers having ~500 files in their staging area each time they commit.

#### Known Problem:
For some reason, the file does not like being marked as a user file.
I have `--user ".gitignore"` in the `CREATE_TEMPLATE_ARGS` flag, and in the generated `project.pros` the file is there:
![image](https://user-images.githubusercontent.com/16546293/63568685-f61e7400-c52a-11e9-967e-b27981f2d7f4.png)
However, when I apply the template to a project, the `.gitignore` file gets overwritten, but `Makefile` for example does not get touched (as user files shouldn't).
Is it possible the weird naming of `.gitignore` is messing with the file detection?
