### PR TITLE
🚸 Add alternate constructor for pros::Task

### DIFF
--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -56,6 +56,28 @@ class Task {
 	 */
 	Task(task_fn_t function, void* parameters = NULL, std::uint32_t prio = TASK_PRIORITY_DEFAULT,
 	     std::uint16_t stack_depth = TASK_STACK_DEPTH_DEFAULT, const char* name = "");
+
+	/**
+	 * Creates a new task and add it to the list of tasks that are ready to run.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENOMEM - The stack cannot be used as the TCB was not created.
+	 *
+	 * \param function
+	 *        Pointer to the task entry function
+	 * \param parameters
+	 *        Pointer to memory that will be used as a parameter for the task
+	 *        being created. This memory should not typically come from stack,
+	 *        but rather from dynamically (i.e., malloc'd) or statically
+	 *        allocated memory.
+	 * \param name
+	 *        A descriptive name for the task.  This is mainly used to facilitate
+	 *        debugging. The name may be up to 32 characters long.
+	 *
+	 */
+	Task(task_fn_t function, void* parameters = NULL, const char* name = "");
+
 	/**
 	 * Create a C++ task object from a task handle
 	 *

--- a/src/rtos/rtos.cpp
+++ b/src/rtos/rtos.cpp
@@ -26,6 +26,12 @@ using namespace pros::c;
             const char* name) {
     task = task_create(function, parameters, prio, stack_depth, name);
   }
+
+  Task::Task(task_fn_t function, void* parameters,
+            const char* name) {
+    task = task_create(function, parameters, TASK_PRIORITY_DEFAULT, TASK_STACK_DEPTH_DEFAULT, name);
+  }
+
   Task::Task(task_t task) : task(task) { }
   void Task::operator = (const task_t in) {
     task = in;

--- a/src/rtos/rtos.cpp
+++ b/src/rtos/rtos.cpp
@@ -28,9 +28,8 @@ using namespace pros::c;
   }
 
   Task::Task(task_fn_t function, void* parameters,
-            const char* name) {
-    task = task_create(function, parameters, TASK_PRIORITY_DEFAULT, TASK_STACK_DEPTH_DEFAULT, name);
-  }
+            const char* name)
+      : Task(function, parameters, TASK_PRIORITY_DEFAULT, TASK_STACK_DEPTH_DEFAULT, name) {}
 
   Task::Task(task_t task) : task(task) { }
   void Task::operator = (const task_t in) {


### PR DESCRIPTION
#### Summary:
Adds an alternate constructor to pros::Task that omits task priority and stack depth, while keeping the task function, parameter, and name.

#### Motivation:
Modifying priority and stack depth is not always used, however users such as myself like to always have task names set. This alternate constructor will assume defaults without needing them specified.

#### Test Plan:
There is no reason why this should not work, as it just passing to task_create, but any tests that apply to standard tasks could be easily adapted to ensure this works.