### PR TITLE
:bug: Fix problem of return PROS_ERR_F error code

### DIFF
--- a/src/devices/vdml.c
+++ b/src/devices/vdml.c
@@ -30,17 +30,7 @@ extern void registry_init();
 extern void port_mutex_init();
 
 int32_t claim_port_try(uint8_t port, v5_device_e_t type) {
-	if (!VALIDATE_PORT_NO(port)) {
-		errno = ENXIO;
-		return PROS_ERR;
-	}
-	if (registry_validate_binding(port, type) != 0) {
-		return PROS_ERR;
-	}
-	if (!port_mutex_take(port)) {
-		errno = EACCES;
-		return PROS_ERR;
-	}
+	claim_port(port, type, 0);
 	return 1;
 }
 

--- a/src/devices/vdml_adi.c
+++ b/src/devices/vdml_adi.c
@@ -93,35 +93,35 @@ typedef union adi_data {
 
 adi_port_config_e_t adi_port_get_config(uint8_t port) {
 	transform_adi_port(port);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	adi_port_config_e_t rtn = (adi_port_config_e_t)vexDeviceAdiPortConfigGet(device->device_info, port);
 	return_port(INTERNAL_ADI_PORT, rtn);
 }
 
 int32_t adi_port_get_value(uint8_t port) {
 	transform_adi_port(port);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	int32_t rtn = vexDeviceAdiValueGet(device->device_info, port);
 	return_port(INTERNAL_ADI_PORT, rtn);
 }
 
 int32_t adi_port_set_config(uint8_t port, adi_port_config_e_t type) {
 	transform_adi_port(port);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	vexDeviceAdiPortConfigSet(device->device_info, port, (V5_AdiPortConfiguration)type);
 	return_port(INTERNAL_ADI_PORT, 1);
 }
 
 int32_t adi_port_set_value(uint8_t port, int32_t value) {
 	transform_adi_port(port);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	vexDeviceAdiValueSet(device->device_info, port, value);
 	return_port(INTERNAL_ADI_PORT, 1);
 }
 
 int32_t adi_analog_calibrate(uint8_t port) {
 	transform_adi_port(port);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_type(device, port, E_ADI_ANALOG_IN);
 	uint32_t total = 0;
 	for (uint32_t i = 0; i < 512; i++) {
@@ -135,7 +135,7 @@ int32_t adi_analog_calibrate(uint8_t port) {
 
 int32_t adi_analog_read(uint8_t port) {
 	transform_adi_port(port);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_type(device, port, E_ADI_ANALOG_IN);
 	int32_t rtn = vexDeviceAdiValueGet(device->device_info, port);
 	return_port(INTERNAL_ADI_PORT, rtn);
@@ -143,7 +143,7 @@ int32_t adi_analog_read(uint8_t port) {
 
 int32_t adi_analog_read_calibrated(uint8_t port) {
 	transform_adi_port(port);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_type(device, port, E_ADI_ANALOG_IN);
 	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[port];
 	int32_t rtn = (vexDeviceAdiValueGet(device->device_info, port) - (adi_data->analog_data.calib >> 4));
@@ -152,7 +152,7 @@ int32_t adi_analog_read_calibrated(uint8_t port) {
 
 int32_t adi_analog_read_calibrated_HR(uint8_t port) {
 	transform_adi_port(port);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_type(device, port, E_ADI_ANALOG_IN);
 	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[port];
 	int32_t rtn = ((vexDeviceAdiValueGet(device->device_info, port) << 4) - adi_data->analog_data.calib);
@@ -161,7 +161,7 @@ int32_t adi_analog_read_calibrated_HR(uint8_t port) {
 
 int32_t adi_digital_read(uint8_t port) {
 	transform_adi_port(port);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_type(device, port, E_ADI_DIGITAL_IN);
 	int32_t rtn = vexDeviceAdiValueGet(device->device_info, port);
 	return_port(INTERNAL_ADI_PORT, rtn);
@@ -169,7 +169,7 @@ int32_t adi_digital_read(uint8_t port) {
 
 int32_t adi_digital_get_new_press(uint8_t port) {
 	transform_adi_port(port);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_type(device, port, E_ADI_DIGITAL_IN);
 
 	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[port];
@@ -189,7 +189,7 @@ int32_t adi_digital_get_new_press(uint8_t port) {
 
 int32_t adi_digital_write(uint8_t port, const bool value) {
 	transform_adi_port(port);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_type(device, port, E_ADI_DIGITAL_OUT);
 	vexDeviceAdiValueSet(device->device_info, port, (int32_t)value);
 	return_port(INTERNAL_ADI_PORT, 1);
@@ -218,7 +218,7 @@ int32_t adi_pin_mode(uint8_t port, uint8_t mode) {
 
 int32_t adi_motor_set(uint8_t port, int8_t speed) {
 	transform_adi_port(port);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_motor(device, port);
 	if (speed > ADI_MOTOR_MAX_SPEED)
 		speed = ADI_MOTOR_MAX_SPEED;
@@ -230,7 +230,7 @@ int32_t adi_motor_set(uint8_t port, int8_t speed) {
 
 int32_t adi_motor_get(uint8_t port) {
 	transform_adi_port(port);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_motor(device, port);
 	int32_t rtn = vexDeviceAdiValueGet(device->device_info, port) - ADI_MOTOR_MAX_SPEED;
 	return_port(INTERNAL_ADI_PORT, rtn);
@@ -243,7 +243,7 @@ int32_t adi_motor_stop(uint8_t port) {
 adi_encoder_t adi_encoder_init(uint8_t port_top, uint8_t port_bottom, const bool reverse) {
 	transform_adi_port(port_top);
 	transform_adi_port(port_bottom);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_twowire(port_top, port_bottom);
 
 	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[port];
@@ -254,7 +254,7 @@ adi_encoder_t adi_encoder_init(uint8_t port_top, uint8_t port_bottom, const bool
 
 int32_t adi_encoder_get(adi_encoder_t enc) {
 	transform_adi_port(enc);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_type(device, enc, E_ADI_LEGACY_ENCODER);
 	
 	int32_t rtn;
@@ -266,7 +266,7 @@ int32_t adi_encoder_get(adi_encoder_t enc) {
 
 int32_t adi_encoder_reset(adi_encoder_t enc) {
 	transform_adi_port(enc);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_type(device, enc, E_ADI_LEGACY_ENCODER);
 	
 	vexDeviceAdiValueSet(device->device_info, enc, 0);
@@ -275,7 +275,7 @@ int32_t adi_encoder_reset(adi_encoder_t enc) {
 
 int32_t adi_encoder_shutdown(adi_encoder_t enc) {
 	transform_adi_port(enc);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_type(device, enc, E_ADI_LEGACY_ENCODER);
 
 	vexDeviceAdiPortConfigSet(device->device_info, enc, E_ADI_TYPE_UNDEFINED);
@@ -291,14 +291,14 @@ adi_ultrasonic_t adi_ultrasonic_init(uint8_t port_ping, uint8_t port_echo) {
 		return PROS_ERR;
 	}
 
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	vexDeviceAdiPortConfigSet(device->device_info, port, E_ADI_LEGACY_ULTRASONIC);
 	return_port(INTERNAL_ADI_PORT, port + 1);
 }
 
 int32_t adi_ultrasonic_get(adi_ultrasonic_t ult) {
 	transform_adi_port(ult);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_type(device, ult, E_ADI_LEGACY_ULTRASONIC);
 	
 	int32_t rtn = vexDeviceAdiValueGet(device->device_info, ult);
@@ -307,7 +307,7 @@ int32_t adi_ultrasonic_get(adi_ultrasonic_t ult) {
 
 int32_t adi_ultrasonic_shutdown(adi_ultrasonic_t ult) {
 	transform_adi_port(ult);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_type(device, ult, E_ADI_LEGACY_ULTRASONIC);
 
 	vexDeviceAdiPortConfigSet(device->device_info, ult, E_ADI_TYPE_UNDEFINED);
@@ -316,7 +316,7 @@ int32_t adi_ultrasonic_shutdown(adi_ultrasonic_t ult) {
 
 adi_gyro_t adi_gyro_init(uint8_t port, double multiplier) {
 	transform_adi_port(port);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 
 	if (multiplier == 0) multiplier = 1;
 	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[port];
@@ -340,10 +340,10 @@ adi_gyro_t adi_gyro_init(uint8_t port, double multiplier) {
 	return_port(INTERNAL_ADI_PORT, port + 1);
 }
 
-// Internal wrapper for adi_gyro_get to get around transform_adi_port, claim_port, validate_type and return_port possibly returning PROS_ERR, not PROS_ERR_F
+// Internal wrapper for adi_gyro_get to get around transform_adi_port, claim_port_i, validate_type and return_port possibly returning PROS_ERR, not PROS_ERR_F
 int32_t _adi_gyro_get(adi_gyro_t gyro, double* out) {
 	transform_adi_port(gyro);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_type(device, gyro, E_ADI_LEGACY_GYRO);
 
 	double rtn = (double)vexDeviceAdiValueGet(device->device_info, gyro);
@@ -362,7 +362,7 @@ double adi_gyro_get(adi_gyro_t gyro) {
 
 int32_t adi_gyro_reset(adi_gyro_t gyro) {
 	transform_adi_port(gyro);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_type(device, gyro, E_ADI_LEGACY_GYRO);
 
 	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[gyro];
@@ -372,7 +372,7 @@ int32_t adi_gyro_reset(adi_gyro_t gyro) {
 
 int32_t adi_gyro_shutdown(adi_gyro_t gyro) {
 	transform_adi_port(gyro);
-	claim_port(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
 	validate_type(device, gyro, E_ADI_LEGACY_GYRO);
 
 	vexDeviceAdiPortConfigSet(device->device_info, gyro, E_ADI_TYPE_UNDEFINED);

--- a/src/devices/vdml_motors.c
+++ b/src/devices/vdml_motors.c
@@ -62,43 +62,43 @@ int32_t motor_move(uint8_t port, int32_t voltage) {
 }
 
 int32_t motor_move_absolute(uint8_t port, const double position, const int32_t velocity) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	vexDeviceMotorAbsoluteTargetSet(device->device_info, position, velocity);
 	return_port(port - 1, 1);
 }
 
 int32_t motor_move_relative(uint8_t port, const double position, const int32_t velocity) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	vexDeviceMotorRelativeTargetSet(device->device_info, position, velocity);
 	return_port(port - 1, 1);
 }
 
 int32_t motor_move_velocity(uint8_t port, const int32_t velocity) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	vexDeviceMotorVelocitySet(device->device_info, velocity);
 	return_port(port - 1, 1);
 }
 
 int32_t motor_move_voltage(uint8_t port, const int32_t voltage) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	vexDeviceMotorVoltageSet(device->device_info, voltage);
 	return_port(port - 1, 1);
 }
 
 int32_t motor_modify_profiled_velocity(uint8_t port, const int32_t velocity) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	vexDeviceMotorVelocityUpdate(device->device_info, velocity);
 	return_port(port - 1, 1);
 }
 
 double motor_get_target_position(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_f(port - 1, E_DEVICE_MOTOR);
 	double rtn = vexDeviceMotorTargetGet(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 int32_t motor_get_target_velocity(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	int32_t rtn = vexDeviceMotorVelocityGet(device->device_info);
 	return_port(port - 1, rtn);
 }
@@ -106,37 +106,37 @@ int32_t motor_get_target_velocity(uint8_t port) {
 // Telemetry functions
 
 double motor_get_actual_velocity(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_f(port - 1, E_DEVICE_MOTOR);
 	double rtn = vexDeviceMotorActualVelocityGet(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 int32_t motor_get_current_draw(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	int32_t rtn = vexDeviceMotorCurrentGet(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 int32_t motor_get_direction(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	int32_t rtn = vexDeviceMotorDirectionGet(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 double motor_get_efficiency(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_f(port - 1, E_DEVICE_MOTOR);
 	double rtn = vexDeviceMotorEfficiencyGet(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 int32_t motor_is_over_current(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	int rtn = vexDeviceMotorCurrentLimitFlagGet(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 int32_t motor_is_over_temp(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	int rtn = vexDeviceMotorOverTempFlagGet(device->device_info);
 	return_port(port - 1, rtn);
 }
@@ -144,7 +144,7 @@ int32_t motor_is_over_temp(uint8_t port) {
 int32_t motor_is_stopped(uint8_t port) {
 	errno = ENOSYS;
 	return PROS_ERR;
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	int rtn = vexDeviceMotorZeroVelocityFlagGet(device->device_info);
 	return_port(port - 1, rtn);
 }
@@ -152,55 +152,55 @@ int32_t motor_is_stopped(uint8_t port) {
 int32_t motor_get_zero_position_flag(uint8_t port) {
 	errno = ENOSYS;
 	return PROS_ERR;
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	int rtn = vexDeviceMotorZeroPositionFlagGet(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 uint32_t motor_get_faults(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	uint32_t rtn = vexDeviceMotorFaultsGet(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 uint32_t motor_get_flags(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	uint32_t rtn = vexDeviceMotorFlagsGet(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 int32_t motor_get_raw_position(uint8_t port, uint32_t* const timestamp) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	int32_t rtn = vexDeviceMotorPositionRawGet(device->device_info, timestamp);
 	return_port(port - 1, rtn);
 }
 
 double motor_get_position(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_f(port - 1, E_DEVICE_MOTOR);
 	double rtn = vexDeviceMotorPositionGet(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 double motor_get_power(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_f(port - 1, E_DEVICE_MOTOR);
 	double rtn = vexDeviceMotorPowerGet(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 double motor_get_temperature(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_f(port - 1, E_DEVICE_MOTOR);
 	double rtn = vexDeviceMotorTemperatureGet(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 double motor_get_torque(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_f(port - 1, E_DEVICE_MOTOR);
 	double rtn = vexDeviceMotorTorqueGet(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 int32_t motor_get_voltage(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	int32_t rtn = vexDeviceMotorVoltageGet(device->device_info);
 	return_port(port - 1, rtn);
 }
@@ -208,37 +208,37 @@ int32_t motor_get_voltage(uint8_t port) {
 // Config functions
 
 int32_t motor_set_zero_position(uint8_t port, const double position) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	vexDeviceMotorPositionSet(device->device_info, position);
 	return_port(port - 1, 1);
 }
 
 int32_t motor_tare_position(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	vexDeviceMotorPositionReset(device->device_info);
 	return_port(port - 1, 1);
 }
 
 int32_t motor_set_brake_mode(uint8_t port, const motor_brake_mode_e_t mode) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	vexDeviceMotorBrakeModeSet(device->device_info, (V5MotorBrakeMode)mode);
 	return_port(port - 1, 1);
 }
 
 int32_t motor_set_current_limit(uint8_t port, const int32_t limit) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	vexDeviceMotorCurrentLimitSet(device->device_info, limit);
 	return_port(port - 1, 1);
 }
 
 int32_t motor_set_encoder_units(uint8_t port, const motor_encoder_units_e_t units) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	vexDeviceMotorEncoderUnitsSet(device->device_info, (V5MotorEncoderUnits)units);
 	return_port(port - 1, 1);
 }
 
 int32_t motor_set_gearing(uint8_t port, const motor_gearset_e_t gearset) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	vexDeviceMotorGearingSet(device->device_info, (V5MotorGearset)gearset);
 	return_port(port - 1, 1);
 }
@@ -267,7 +267,7 @@ motor_pid_s_t motor_convert_pid(double kf, double kp, double ki, double kd) {
 }
 
 int32_t motor_set_pos_pid(uint8_t port, const motor_pid_s_t pid) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	V5_DeviceMotorPid out;
 	out.kf = pid.kf;
 	out.kp = pid.kp;
@@ -279,7 +279,7 @@ int32_t motor_set_pos_pid(uint8_t port, const motor_pid_s_t pid) {
 }
 
 int32_t motor_set_pos_pid_full(uint8_t port, const motor_pid_full_s_t pid) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	V5_DeviceMotorPid out;
 	out.kf = pid.kf;
 	out.kp = pid.kp;
@@ -295,7 +295,7 @@ int32_t motor_set_pos_pid_full(uint8_t port, const motor_pid_full_s_t pid) {
 }
 
 int32_t motor_set_vel_pid(uint8_t port, const motor_pid_s_t pid) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	V5_DeviceMotorPid out;
 	out.kf = pid.kf;
 	out.kp = pid.kp;
@@ -307,7 +307,7 @@ int32_t motor_set_vel_pid(uint8_t port, const motor_pid_s_t pid) {
 }
 
 int32_t motor_set_vel_pid_full(uint8_t port, const motor_pid_full_s_t pid) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	V5_DeviceMotorPid out;
 	out.kf = pid.kf;
 	out.kp = pid.kp;
@@ -323,45 +323,45 @@ int32_t motor_set_vel_pid_full(uint8_t port, const motor_pid_full_s_t pid) {
 }
 
 int32_t motor_set_reversed(uint8_t port, const bool reverse) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	vexDeviceMotorReverseFlagSet(device->device_info, reverse);
 	return_port(port - 1, 1);
 }
 
 int32_t motor_set_voltage_limit(uint8_t port, const int32_t limit) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	vexDeviceMotorVoltageLimitSet(device->device_info, limit);
 	return_port(port - 1, 1);
 }
 
 motor_brake_mode_e_t motor_get_brake_mode(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	V5MotorBrakeMode rtn = vexDeviceMotorBrakeModeGet(device->device_info);
 	return_port(port - 1, (motor_brake_mode_e_t)rtn);
 }
 
 int32_t motor_get_current_limit(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	int32_t rtn = vexDeviceMotorCurrentLimitGet(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 motor_encoder_units_e_t motor_get_encoder_units(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	V5MotorEncoderUnits rtn = vexDeviceMotorEncoderUnitsGet(device->device_info);
 	return_port(port - 1, (motor_encoder_units_e_t)rtn);
 }
 
 motor_gearset_e_t motor_get_gearing(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_MOTOR);
+	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	V5MotorGearset rtn = vexDeviceMotorGearingGet(device->device_info);
 	return_port(port - 1, (motor_gearset_e_t)rtn);
 }
 
 motor_pid_full_s_t motor_get_pos_pid(uint8_t port) {
 	motor_pid_full_s_t rtn;
-	int32_t err = claim_port_try(port - 1, E_DEVICE_MOTOR);
-	if (err == PROS_ERR) {
+	int32_t success = claim_port_try(port - 1, E_DEVICE_MOTOR);
+	if (success == false) {
 		// Set all fields to lowest
 		rtn.kf = 0;
 		rtn.kp = 0;
@@ -388,8 +388,8 @@ motor_pid_full_s_t motor_get_pos_pid(uint8_t port) {
 
 motor_pid_full_s_t motor_get_vel_pid(uint8_t port) {
 	motor_pid_full_s_t rtn;
-	int32_t err = claim_port_try(port - 1, E_DEVICE_MOTOR);
-	if (err == PROS_ERR) {
+	int32_t success = claim_port_try(port - 1, E_DEVICE_MOTOR);
+	if (success == false) {
 		// Set all fields to lowest
 		rtn.kf = 0;
 		rtn.kp = 0;

--- a/src/devices/vdml_serial.c
+++ b/src/devices/vdml_serial.c
@@ -24,7 +24,7 @@
 
 int32_t serial_enable(uint8_t port) {
 	/**
-	 * claim_port(port - 1, E_DEVICE_GENERIC) is not used because it requires
+	 * claim_port_i(port - 1, E_DEVICE_GENERIC) is not used because it requires
 	 * the port to already be of the requested type in VEXos, which will not yet
 	 * be the case for generic serial as vexDeviceGenericSerialEnable is what
 	 * switches the port into the correct mode
@@ -43,13 +43,13 @@ int32_t serial_enable(uint8_t port) {
 }
 
 int32_t serial_set_baudrate(uint8_t port, int32_t baudrate) {
-	claim_port(port - 1, E_DEVICE_GENERIC);
+	claim_port_i(port - 1, E_DEVICE_GENERIC);
 	vexDeviceGenericSerialBaudrate(device->device_info, baudrate);
 	return_port(port - 1, 1);
 }
 
 int32_t serial_flush(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_GENERIC);
+	claim_port_i(port - 1, E_DEVICE_GENERIC);
 	vexDeviceGenericSerialFlush(device->device_info);
 	return_port(port - 1, 1);
 }
@@ -57,13 +57,13 @@ int32_t serial_flush(uint8_t port) {
 // Telemetry functions
 
 int32_t serial_get_read_avail(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_GENERIC);
+	claim_port_i(port - 1, E_DEVICE_GENERIC);
 	int32_t rtn = vexDeviceGenericSerialReceiveAvail(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 int32_t serial_get_write_free(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_GENERIC);
+	claim_port_i(port - 1, E_DEVICE_GENERIC);
 	int32_t rtn = vexDeviceGenericSerialWriteFree(device->device_info);
 	return_port(port - 1, rtn);
 }
@@ -71,19 +71,19 @@ int32_t serial_get_write_free(uint8_t port) {
 // Read functions
 
 int32_t serial_peek_byte(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_GENERIC);
+	claim_port_i(port - 1, E_DEVICE_GENERIC);
 	int32_t rtn = vexDeviceGenericSerialPeekChar(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 int32_t serial_read_byte(uint8_t port) {
-	claim_port(port - 1, E_DEVICE_GENERIC);
+	claim_port_i(port - 1, E_DEVICE_GENERIC);
 	int32_t rtn = vexDeviceGenericSerialReadChar(device->device_info);
 	return_port(port - 1, rtn);
 }
 
 int32_t serial_read(uint8_t port, uint8_t* buffer, int32_t length) {
-	claim_port(port - 1, E_DEVICE_GENERIC);
+	claim_port_i(port - 1, E_DEVICE_GENERIC);
 	int32_t rtn = vexDeviceGenericSerialReceive(device->device_info, buffer, length);
 	return_port(port - 1, rtn);
 }
@@ -91,7 +91,7 @@ int32_t serial_read(uint8_t port, uint8_t* buffer, int32_t length) {
 // Write functions
 
 int32_t serial_write_byte(uint8_t port, uint8_t buffer) {
-	claim_port(port - 1, E_DEVICE_GENERIC);
+	claim_port_i(port - 1, E_DEVICE_GENERIC);
 	int32_t rtn = vexDeviceGenericSerialWriteChar(device->device_info, buffer);
 	if (rtn == -1) {
 		errno = EIO;
@@ -101,7 +101,7 @@ int32_t serial_write_byte(uint8_t port, uint8_t buffer) {
 }
 
 int32_t serial_write(uint8_t port, uint8_t* buffer, int32_t length) {
-	claim_port(port - 1, E_DEVICE_GENERIC);
+	claim_port_i(port - 1, E_DEVICE_GENERIC);
 	int32_t rtn = vexDeviceGenericSerialTransmit(device->device_info, buffer, length);
 	if (rtn == -1) {
 		errno = EIO;

--- a/src/devices/vdml_vision.c
+++ b/src/devices/vdml_vision.c
@@ -51,7 +51,7 @@ int32_t vision_get_object_count(uint8_t port) {
 vision_object_s_t vision_get_by_size(uint8_t port, const uint32_t size_id) {
 	vision_object_s_t rtn;
 	v5_smart_device_s_t* device;
-	if (claim_port_try(port - 1, E_DEVICE_VISION) == PROS_ERR) {
+	if (claim_port_try(port - 1, E_DEVICE_VISION) == false) {
 		rtn.signature = VISION_OBJECT_ERR_SIG;
 		return rtn;
 	}
@@ -80,7 +80,7 @@ vision_object_s_t _vision_get_by_sig(uint8_t port, const uint32_t size_id, const
 	uint8_t count = 0;
 	int32_t object_count = 0;
 
-	if (claim_port_try(port - 1, E_DEVICE_VISION) == PROS_ERR) {
+	if (claim_port_try(port - 1, E_DEVICE_VISION) == false) {
 		goto err_return_no_mutex;
 	}
 
@@ -223,7 +223,7 @@ vision_signature_s_t vision_get_signature(uint8_t port, const uint8_t signature_
 		return sig;
 	}
 	int32_t rtn = claim_port_try(port - 1, E_DEVICE_VISION);
-	if (rtn == PROS_ERR) {
+	if (rtn == false) {
 		return sig;
 	}
 	v5_smart_device_s_t* device = registry_get_device(port - 1);


### PR DESCRIPTION
#### Summary:
Someone is very lazy. Use `claim_port` in all functions.

Modify `claim_port(port, device_type)` to `claim_port(port, device_type, error_code)`
Add claim_port_i(port, device_type) for int32_t function
Add claim_port_f(port, device_type) for double and float function
Modify `claim_port_try`, return 1 if success, else 0(It was return PROS_ERR)

#### Motivation:
Love, Harry, Love.

##### References (optional):
#159 

#### Test Plan:
- [ ] I can't compile the files
- [ ] I don't know what to do.
