### PR TITLE
🐛 Add default LLEMU init code back to main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,15 @@
 #include "main.h"
 
+void on_center_button() {
+	static bool pressed = false;
+	pressed = !pressed;
+	if (pressed) {
+		pros::lcd::set_text(2, "I was pressed!");
+	} else {
+		pros::lcd::clear_line(2);
+	}
+}
+
 /**
  * Runs initialization code. This occurs as soon as the program is started.
  *
@@ -7,6 +17,10 @@
  * to keep execution time for this mode under a few seconds.
  */
 void initialize() {
+	pros::lcd::initialize();
+	pros::lcd::set_text(1, "Hello PROS User!");
+
+	pros::lcd::register_btn1_cb(on_center_button);
 }
 
 /**
@@ -14,8 +28,7 @@ void initialize() {
  * the VEX Competition Switch, following either autonomous or opcontrol. When
  * the robot is enabled, this task will exit.
  */
-void disabled() {
-}
+void disabled() {}
 
 /**
  * Runs after initialize(), and before autonomous when connected to the Field
@@ -26,8 +39,7 @@ void disabled() {
  * This task will exit when the robot is enabled and autonomous or opcontrol
  * starts.
  */
-void competition_initialize() {
-}
+void competition_initialize() {}
 
 /**
  * Runs the user autonomous code. This function will be started in its own task
@@ -40,8 +52,7 @@ void competition_initialize() {
  * will be stopped. Re-enabling the robot will restart the task, not re-start it
  * from where it left off.
  */
-void autonomous() {
-}
+void autonomous() {}
 
 /**
  * Runs the operator control code. This function will be started in its own task

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,11 @@
 #include "main.h"
 
+/**
+ * A callback function for LLEMU's center button.
+ *
+ * When this callback is fired, it will toggle line 2 of the LCD text between
+ * "I was pressed!" and nothing.
+ */
 void on_center_button() {
 	static bool pressed = false;
 	pressed = !pressed;


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
Fixes a regression introduced in #152 whereby the default LLEMU initialization code was removed.

#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
Code in `opcontrol()` that displays information to LLEMU was not removed, so users will (reasonably) expect the code to Just Work™ out of the box.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
closes #164 

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->
- [x] Code compiles
- [x] Default project displays LLEMU as expected
