### PR TITLE
✨ Provide error if updates are sent too quickly to the controller or if it is not connected

### DIFF
--- a/include/pros/misc.h
+++ b/include/pros/misc.h
@@ -337,7 +337,8 @@ int32_t controller_clear_line(controller_id_e_t id, uint8_t line);
  * Clears all of the lines on the controller screen.
  *
  * \note Controller text setting is currently in beta, so continuous, fast
- * updates will not work well.
+ * updates will not work well. On vexOS version 1.0.0 this function will block
+ * for 110ms.
  *
  * This function uses the following values of errno when an error state is
  * reached:

--- a/include/pros/misc.h
+++ b/include/pros/misc.h
@@ -337,8 +337,7 @@ int32_t controller_clear_line(controller_id_e_t id, uint8_t line);
  * Clears all of the lines on the controller screen.
  *
  * \note Controller text setting is currently in beta, so continuous, fast
- * updates will not work well. To be able to clear all 3 lines, the function
- * blocks for a total of 110ms.
+ * updates will not work well.
  *
  * This function uses the following values of errno when an error state is
  * reached:

--- a/include/pros/misc.h
+++ b/include/pros/misc.h
@@ -337,7 +337,8 @@ int32_t controller_clear_line(controller_id_e_t id, uint8_t line);
  * Clears all of the lines on the controller screen.
  *
  * \note Controller text setting is currently in beta, so continuous, fast
- * updates will not work well.
+ * updates will not work well. To be able to clear all 3 lines, the function
+ * blocks for a total of 110ms.
  *
  * This function uses the following values of errno when an error state is
  * reached:

--- a/include/pros/misc.hpp
+++ b/include/pros/misc.hpp
@@ -241,7 +241,8 @@ class Controller {
 	 * Clears all of the lines on the controller screen.
 	 *
 	 * \note Controller text setting is currently in beta, so continuous, fast
-	 * updates will not work well.
+	 * updates will not work well. On vexOS version 1.0.0 this function will
+	 * block for 110ms.
 	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:

--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -274,7 +274,13 @@ int32_t controller_clear_line(controller_id_e_t id, uint8_t line) {
 }
 
 int32_t controller_clear(controller_id_e_t id) {
-	for (int i = 0; i < 3; i++) controller_clear_line(id, i);
+	for (int i = 0; i < 3; i++) {
+		int32_t rtn = controller_clear_line(id, i);
+		if (rtn == PROS_ERR)
+			return PROS_ERR;
+		if (i != 2)
+			delay(55);
+	}
 	return 1;
 }
 

--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -289,7 +289,16 @@ int32_t controller_clear_line(controller_id_e_t id, uint8_t line) {
 }
 
 int32_t controller_clear(controller_id_e_t id) {
-	return controller_print(id, 0, 0, "");
+	if (vexSystemVersion() > 0x01000000) {
+		return controller_print(id, 0, 0, "");
+	} else {
+		for (int i = 0; i < 3; i++) {
+			int32_t rtn = controller_clear_line(id, i);
+			if (rtn == PROS_ERR) return PROS_ERR;
+			if (i != 2) delay(55);
+		}
+		return 1;
+	}
 }
 
 int32_t controller_rumble(controller_id_e_t id, const char* rumble_pattern) {

--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -206,9 +206,14 @@ int32_t controller_set_text(controller_id_e_t id, uint8_t line, uint8_t col, con
 
 	char* buf = strndup(str, CONTROLLER_MAX_COLS + 1);
 
-	vexControllerTextSet(id, line, col, buf);
+	uint32_t rtn_val = vexControllerTextSet(id, line, col, buf);
 	free(buf);
 	internal_port_mutex_give(port);
+
+	if (!rtn_val) {
+		errno = EAGAIN;
+		return PROS_ERR;
+	}
 	return 1;
 }
 
@@ -240,11 +245,16 @@ int32_t controller_print(controller_id_e_t id, uint8_t line, uint8_t col, const 
 	char* buf = (char*)malloc(CONTROLLER_MAX_COLS + 1);
 	vsnprintf(buf, CONTROLLER_MAX_COLS + 1, fmt, args);
 
-	vexControllerTextSet(id, line, col, buf);
+	uint32_t rtn_val = vexControllerTextSet(id, line, col, buf);
 	free(buf);
 	va_end(args);
 
 	internal_port_mutex_give(port);
+
+	if (!rtn_val) {
+		errno = EAGAIN;
+		return PROS_ERR;
+	}
 	return 1;
 }
 
@@ -268,8 +278,13 @@ int32_t controller_clear_line(controller_id_e_t id, uint8_t line) {
 	line++;
 
 	const char* const blank = "                 ";
-	vexControllerTextSet(port, line, 0, blank);
+	uint32_t rtn_val = vexControllerTextSet(port, line, 0, blank);
 	internal_port_mutex_give(port);
+
+	if (!rtn_val) {
+		errno = EAGAIN;
+		return PROS_ERR;
+	}
 	return 1;
 }
 

--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -289,14 +289,7 @@ int32_t controller_clear_line(controller_id_e_t id, uint8_t line) {
 }
 
 int32_t controller_clear(controller_id_e_t id) {
-	for (int i = 0; i < 3; i++) {
-		int32_t rtn = controller_clear_line(id, i);
-		if (rtn == PROS_ERR)
-			return PROS_ERR;
-		if (i != 2)
-			delay(55);
-	}
-	return 1;
+	return controller_print(id, 0, 0, "");
 }
 
 int32_t controller_rumble(controller_id_e_t id, const char* rumble_pattern) {


### PR DESCRIPTION
#### Summary:
Through some testing I determined that `vexControllerTextSet` returns 0 if it fails to send data to the controller (such as when the user sends updates quicker then every 50ms or if the controller is unplugged). Using this, `controller_set_text`, `controller_print` and `controller_clear_line` have been updated to return `PROS_ERR` on failure setting `errno` to `EAGAIN`.

I also updated `controller_clear` to block for the required 110ms for it to work. I would probably recommend either deprecating this function or implementing a more complex controller system that queues updates and pushes to each line in a cyclic pattern every 50ms, but that's another matter.

#### Motivation:
Would probably be nice to give the user feedback on whether their calls succeed instead of silently failing.

#### Test Plan:
If someone could test this kernel that would be great. I won't have access to a V5 for the next little while.

- [ ] Ensure that the functions return `PROS_ERR` and set `errno` if the updates are sent quicker then 50ms
- [ ] Ensure that the functions do not return `PROS_ERR` and do not set `errno` if the updates are sent slower then 50ms
- [ ] Test `controller_clear`