### PR TITLE
✨Add support for extra Make scripts

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -162,6 +162,8 @@ ifeq ($(USE_PACKAGE),1)
 DEFAULT_BIN=$(HOT_BIN)
 endif
 
+-include $(wildcard $(FWDIR)/*.mk)
+
 .PHONY: all clean quick
 
 quick: $(DEFAULT_BIN)
@@ -198,10 +200,10 @@ endif
 
 # if project is a library source, compile the archive and link output.elf against the archive rather than source objects
 ifeq ($(IS_LIBRARY),1)
-ELF_DEPS=$(filter-out $(call GETALLOBJ,$(EXCLUDE_SRC_FROM_LIB)), $(call GETALLOBJ,$(EXCLUDE_SRCDIRS)))
+ELF_DEPS+=$(filter-out $(call GETALLOBJ,$(EXCLUDE_SRC_FROM_LIB)), $(call GETALLOBJ,$(EXCLUDE_SRCDIRS)))
 LIBRARIES+=$(LIBAR)
 else
-ELF_DEPS=$(call GETALLOBJ,$(EXCLUDE_SRCDIRS))
+ELF_DEPS+=$(call GETALLOBJ,$(EXCLUDE_SRCDIRS))
 endif
 
 $(MONOLITH_BIN): $(MONOLITH_ELF) $(BINDIR)


### PR DESCRIPTION
#### Summary:
Automatically include any firmware/*.mk scripts in Make system to allow
templates to modify build process (e.g. add extra flags or
dependencies).

#### Motivation:
A library wishes to dynamically generate a C file at Make time based on some text file and include in project's binary. There is currently no support for this. With this modification, library author creates a firmware/mylibrary.mk file which adds the corresponding variable modifications and rules to ensure the C file is generated and compiled as part of the user's project.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [X] Scripts are included
