### PR TITLE
🚸 Allow tasks to be constructed from any void() callable

### DIFF
--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
+#include <memory>
 #include <type_traits>
 
 namespace pros {
@@ -104,9 +105,8 @@ class Task {
 	Task(F&& function, std::uint32_t prio = TASK_PRIORITY_DEFAULT,
 	     std::uint16_t stack_depth = TASK_STACK_DEPTH_DEFAULT, const char* name = "")
 	     : Task([] (void* parameters) {
-		auto ptr = static_cast<std::function<void()>*>(parameters);
+		std::unique_ptr<std::function<void()>> ptr{static_cast<std::function<void()>*>(parameters)};
 		(*ptr)();
-		delete ptr;
 	     }, new std::function<void()>(std::forward<F>(function)), prio, stack_depth, name) {
 		static_assert(std::is_invocable_r_v<void, F>);
 	}

--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -108,7 +108,7 @@ class Task {
 		(*ptr)();
 		delete ptr;
 	     }, new std::function<void()>(std::forward<F>(function)), prio, stack_depth, name) {
-		static_assert(std::is_invocable_v<F>);
+		static_assert(std::is_invocable_r_v<void, F>);
 	     }
 	}
 

--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -128,8 +128,8 @@ class Task {
 	 *
 	 */
 	template <class F>
-	Task(F&& function, const char* name) : Task(std::forward<F>(function),
-	     TASK_PRIORITY_DEFAULT, TASK_STACK_DEPTH_DEFAULT, name) {}
+	Task(F&& function, const char* name)
+	    : Task(std::forward<F>(function), TASK_PRIORITY_DEFAULT, TASK_STACK_DEPTH_DEFAULT, name) {}
 
 	/**
 	 * Create a C++ task object from a task handle

--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -25,6 +25,7 @@
 #undef delay
 #include <cstdint>
 #include <cstdlib>
+#include <functional>
 
 namespace pros {
 class Task {
@@ -77,6 +78,53 @@ class Task {
 	 *
 	 */
 	Task(task_fn_t function, void* parameters = NULL, const char* name = "");
+
+	/**
+	 * Creates a new task and add it to the list of tasks that are ready to run.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENOMEM - The stack cannot be used as the TCB was not created.
+	 *
+	 * \param function
+	 *        Callable object to use as entry function
+	 * \param prio
+	 *        The priority at which the task should run.
+	 *        TASK_PRIO_DEFAULT plus/minus 1 or 2 is typically used.
+	 * \param stack_depth
+	 *        The number of words (i.e. 4 * stack_depth) available on the task's
+	 *        stack. TASK_STACK_DEPTH_DEFAULT is typically sufficienct.
+	 * \param name
+	 *        A descriptive name for the task.  This is mainly used to facilitate
+	 *        debugging. The name may be up to 32 characters long.
+	 *
+	 */
+	template <class F>
+	Task(F&& function, std::uint32_t prio = TASK_PRIORITY_DEFAULT,
+	     std::uint16_t stack_depth = TASK_STACK_DEPTH_DEFAULT, const char* name = "")
+	     : Task(&[] (void* parameters) {
+		auto ptr = std::static_cast<std::function<void()>*>(parameters);
+		(*ptr)();
+		delete ptr;
+	     }, new std::function<void()>(std::forward<F>(function))) {}
+
+	/**
+	 * Creates a new task and add it to the list of tasks that are ready to run.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENOMEM - The stack cannot be used as the TCB was not created.
+	 *
+	 * \param function
+	 *        Callable object to use as entry function
+	 * \param name
+	 *        A descriptive name for the task.  This is mainly used to facilitate
+	 *        debugging. The name may be up to 32 characters long.
+	 *
+	 */
+	template <class F>
+	Task(F&& function, const char* name = "") : Task(std::forward<F>(function),
+	     TASK_PRIORITY_DEFAULT, TASK_STACK_DEPTH_DEFAULT, name) {}
 
 	/**
 	 * Create a C++ task object from a task handle

--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -109,7 +109,6 @@ class Task {
 		delete ptr;
 	     }, new std::function<void()>(std::forward<F>(function)), prio, stack_depth, name) {
 		static_assert(std::is_invocable_r_v<void, F>);
-	     }
 	}
 
 	/**
@@ -127,7 +126,7 @@ class Task {
 	 *
 	 */
 	template <class F>
-	Task(F&& function, const char* name = "") : Task(std::forward<F>(function),
+	Task(F&& function, const char* name) : Task(std::forward<F>(function),
 	     TASK_PRIORITY_DEFAULT, TASK_STACK_DEPTH_DEFAULT, name) {}
 
 	/**

--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -102,12 +102,14 @@ class Task {
 	 *
 	 */
 	template <class F>
-	Task(F&& function, std::uint32_t prio = TASK_PRIORITY_DEFAULT,
-	     std::uint16_t stack_depth = TASK_STACK_DEPTH_DEFAULT, const char* name = "")
-	     : Task([] (void* parameters) {
-		std::unique_ptr<std::function<void()>> ptr{static_cast<std::function<void()>*>(parameters)};
-		(*ptr)();
-	     }, new std::function<void()>(std::forward<F>(function)), prio, stack_depth, name) {
+	Task(F&& function, std::uint32_t prio = TASK_PRIORITY_DEFAULT, std::uint16_t stack_depth = TASK_STACK_DEPTH_DEFAULT,
+	     const char* name = "")
+	    : Task(
+	          [](void* parameters) {
+		          std::unique_ptr<std::function<void()>> ptr{static_cast<std::function<void()>*>(parameters)};
+		          (*ptr)();
+	          },
+	          new std::function<void()>(std::forward<F>(function)), prio, stack_depth, name) {
 		static_assert(std::is_invocable_r_v<void, F>);
 	}
 


### PR DESCRIPTION
#### Summary:
Add two constructors to `Task`, analogous to the existing ones, to enable construction from any `void()` callable (including lambdas with captures).

#### Motivation:
This should improve ease of use and intuitive interface for creating Tasks. It is also a C++-idiomatic approach.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
Simple tests can be constructed using C++ lambdas with captures. Example code:

```
std::unique_ptr<int> data{new int(7)};
pros::Task task{[=] {
  pros::delay(1000);
  std::cout << *data << std::endl;
}};
```

- [ ] test item
