### PR TITLE
🚸 Implement exception logging to terminal

### DIFF
--- a/src/system/cpp_support.cpp
+++ b/src/system/cpp_support.cpp
@@ -28,15 +28,17 @@ extern "C" void task_fn_wrapper(task_fn_t fn, void* args) {
 #ifdef __cpp_exceptions
 	} catch (const std::runtime_error& re) {
 		std::cerr << "Runtime error: " << re.what() << std::endl;
-		vexDisplayString(7, "an runtime error occured:");
-		vexDisplayString(8, "%s", re.what());
+		vexDisplayString(5, "an runtime error occured:");
+		vexDisplayString(6, "%s", re.what());
+		vexDisplayString(7, "open terminal to see full error message");
 	} catch (const std::exception& ex) {
 		std::cerr << "Exception occurred: " << ex.what() << std::endl;
-		vexDisplayString(7, "an exception occured:");
-		vexDisplayString(8, "%s", ex.what());
+		vexDisplayString(5, "an exception occured:");
+		vexDisplayString(6, "%s", ex.what());
+		vexDisplayString(7, "open terminal to see full error message");
 	} catch (...) {
 		std::cerr << "Unknown error occurred. Possible memory corruption" << std::endl;
-		vexDisplayString(7, "an unknown error occurred");
+		vexDisplayString(5, "an unknown error occurred");
 	}
 #endif
 }

--- a/src/system/cpp_support.cpp
+++ b/src/system/cpp_support.cpp
@@ -27,17 +27,17 @@ extern "C" void task_fn_wrapper(task_fn_t fn, void* args) {
 #ifdef __cpp_exceptions
 	} catch (const std::runtime_error& re) {
 		fprintf(stderr, "Runtime error: %s", re.what(), "\n");
-		vexDisplayString(5, "an runtime error occured:");
+		vexDisplayString(5, "An runtime error occured:");
 		vexDisplayString(6, "%s", re.what());
-		vexDisplayString(7, "open terminal to see full error message");
+		vexDisplayString(7, "Note: open terminal for error message");
 	} catch (const std::exception& ex) {
 		fprintf(stderr, "Exception occurred: %s", ex.what(), "\n");
-		vexDisplayString(5, "an exception occured:");
+		vexDisplayString(5, "An exception occured:");
 		vexDisplayString(6, "%s", ex.what());
-		vexDisplayString(7, "open terminal to see full error message");
+		vexDisplayString(7, "Note: open terminal to see full error message");
 	} catch (...) {
-		fprintf(stderr, "Unknown error occurred. Possible memory corruption");
-		vexDisplayString(5, "an unknown error occurred");
+		fprintf(stderr, "Unknown error occurred. Possible memory corruption\n");
+		vexDisplayString(5, "An unknown error occurred");
 	}
 #endif
 }

--- a/src/system/cpp_support.cpp
+++ b/src/system/cpp_support.cpp
@@ -27,16 +27,16 @@ extern "C" void task_fn_wrapper(task_fn_t fn, void* args) {
 #ifdef __cpp_exceptions
 	} catch (const std::runtime_error& re) {
 		fprintf(stderr, "Runtime error: %s \n", re.what());
-		vexDisplayString(5, "An runtime error occured:");
+		vexDisplayString(5, "A runtime error occurred:");
 		vexDisplayString(6, "%s", re.what());
 		vexDisplayString(7, "Note: open terminal for error message");
 	} catch (const std::exception& ex) {
 		fprintf(stderr, "Exception occurred: %s \n", ex.what());
-		vexDisplayString(5, "An exception occured:");
+		vexDisplayString(5, "An exception occurred:");
 		vexDisplayString(6, "%s", ex.what());
-		vexDisplayString(7, "Note: open terminal to see full error message");
+		vexDisplayString(7, "Note: open terminal for error message");
 	} catch (...) {
-		fprintf(stderr, "Unknown error occurred. Possible memory corruption \n");
+		fprintf(stderr, "Unknown error occurred. \n");
 		vexDisplayString(5, "An unknown error occurred");
 	}
 #endif

--- a/src/system/cpp_support.cpp
+++ b/src/system/cpp_support.cpp
@@ -13,7 +13,6 @@
 
 #include <cstddef>
 #include <cstdlib>
-#include <iostream>
 #include <stdexcept>
 
 #include "rtos/FreeRTOS.h"
@@ -27,17 +26,17 @@ extern "C" void task_fn_wrapper(task_fn_t fn, void* args) {
 		fn(args);
 #ifdef __cpp_exceptions
 	} catch (const std::runtime_error& re) {
-		std::cerr << "Runtime error: " << re.what() << std::endl;
+		fprintf(stderr, "Runtime error: %s", re.what(), "\n");
 		vexDisplayString(5, "an runtime error occured:");
 		vexDisplayString(6, "%s", re.what());
 		vexDisplayString(7, "open terminal to see full error message");
 	} catch (const std::exception& ex) {
-		std::cerr << "Exception occurred: " << ex.what() << std::endl;
+		fprintf(stderr, "Exception occurred: %s", ex.what(), "\n");
 		vexDisplayString(5, "an exception occured:");
 		vexDisplayString(6, "%s", ex.what());
 		vexDisplayString(7, "open terminal to see full error message");
 	} catch (...) {
-		std::cerr << "Unknown error occurred. Possible memory corruption" << std::endl;
+		fprintf(stderr, "Unknown error occurred. Possible memory corruption");
 		vexDisplayString(5, "an unknown error occurred");
 	}
 #endif

--- a/src/system/cpp_support.cpp
+++ b/src/system/cpp_support.cpp
@@ -13,6 +13,7 @@
 
 #include <cstddef>
 #include <cstdlib>
+#include <iostream>
 #include <stdexcept>
 
 #include "rtos/FreeRTOS.h"
@@ -25,10 +26,17 @@ extern "C" void task_fn_wrapper(task_fn_t fn, void* args) {
 #endif
 		fn(args);
 #ifdef __cpp_exceptions
-	} catch (std::runtime_error& re) {
-		vexDisplayString(7, "caught runtime error: %s", re.what());
+	} catch (const std::runtime_error& re) {
+		std::cerr << "Runtime error: " << re.what() << std::endl;
+		vexDisplayString(7, "an runtime error occured:");
+		vexDisplayString(8, "%s", re.what());
+	} catch (const std::exception& ex) {
+		std::cerr << "Exception occurred: " << ex.what() << std::endl;
+		vexDisplayString(7, "an exception occured:");
+		vexDisplayString(8, "%s", ex.what());
 	} catch (...) {
-		vexDisplayString(7, "caught an unknown error");
+		std::cerr << "Unknown error occurred. Possible memory corruption" << std::endl;
+		vexDisplayString(7, "an unknown error occurred");
 	}
 #endif
 }

--- a/src/system/cpp_support.cpp
+++ b/src/system/cpp_support.cpp
@@ -26,17 +26,17 @@ extern "C" void task_fn_wrapper(task_fn_t fn, void* args) {
 		fn(args);
 #ifdef __cpp_exceptions
 	} catch (const std::runtime_error& re) {
-		fprintf(stderr, "Runtime error: %s", re.what(), "\n");
+		fprintf(stderr, "Runtime error: %s \n", re.what());
 		vexDisplayString(5, "An runtime error occured:");
 		vexDisplayString(6, "%s", re.what());
 		vexDisplayString(7, "Note: open terminal for error message");
 	} catch (const std::exception& ex) {
-		fprintf(stderr, "Exception occurred: %s", ex.what(), "\n");
+		fprintf(stderr, "Exception occurred: %s \n", ex.what());
 		vexDisplayString(5, "An exception occured:");
 		vexDisplayString(6, "%s", ex.what());
 		vexDisplayString(7, "Note: open terminal to see full error message");
 	} catch (...) {
-		fprintf(stderr, "Unknown error occurred. Possible memory corruption\n");
+		fprintf(stderr, "Unknown error occurred. Possible memory corruption \n");
 		vexDisplayString(5, "An unknown error occurred");
 	}
 #endif


### PR DESCRIPTION
#### Summary:
When exceptions are thrown, PROS catches them and prints them to the screen.
However, long messages are often cut short and unreadable.
With this PR, exceptions caught by PROS will be printed to the terminal as well as to the V5 Screen.

I have also separated the screen printing commands to try and fit the most of the error message as possible.

#### Known Issues:
After testing this PR, it does not seem to be printing to the terminal.
This might be due to the order of initialization or something, idk.