### PR TITLE
🐛 Fix race and an abandoned mutex

### DIFF
--- a/src/display/lv_misc/lv_task.c
+++ b/src/display/lv_misc/lv_task.c
@@ -66,7 +66,7 @@ LV_ATTRIBUTE_TASK_HANDLER void lv_task_handler(void)
 
     if(lv_task_run == false)
     {
-		LV_LOG_TRACE("lv_task_handler bailed early, task run false");
+        LV_LOG_TRACE("lv_task_handler bailed early, task run false");
         return;
     }
 

--- a/src/display/lv_misc/lv_task.c
+++ b/src/display/lv_misc/lv_task.c
@@ -76,7 +76,7 @@ LV_ATTRIBUTE_TASK_HANDLER void lv_task_handler(void)
 
     bool expected = false;
     bool toSet = true;
-    bool alreadyTaken = __atomic_compare_exchange(&task_handler_mutex, &expected, &toSet,/* weak*/ false, __ATOMIC_ACQ_REL, __ATOMIC_ACQ_REL);
+    bool alreadyTaken = __atomic_compare_exchange(&task_handler_mutex, &expected, &toSet,/* weak*/ false, __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE);
 
     if (alreadyTaken) return;
 

--- a/src/display/lv_misc/lv_task.c
+++ b/src/display/lv_misc/lv_task.c
@@ -33,7 +33,7 @@ static bool lv_task_exec(lv_task_t * lv_task_p);
 /**********************
  *  STATIC VARIABLES
  **********************/
-static  bool lv_task_run = false;
+static bool lv_task_run = false;
 static uint8_t idle_last = 0;
 static bool task_deleted;
 static bool task_created;

--- a/src/display/lv_misc/lv_task.c
+++ b/src/display/lv_misc/lv_task.c
@@ -63,7 +63,7 @@ void lv_task_init(void)
 LV_ATTRIBUTE_TASK_HANDLER void lv_task_handler(void)
 {
     LV_LOG_TRACE("lv_task_handler started");
-    bool task_run = __atomic_load_n(&lv_task_run, __ATOMIC_RELEASE);
+    bool task_run = __atomic_load_n(&lv_task_run, __ATOMIC_ACQUIRE);
 
     if(task_run == false)
     {


### PR DESCRIPTION
#### Summary:
Within lv_task, we were using a non atomic swap as a mutex. This changes these to be volatile/atomic where necessary. I also noticed a path where said "mutex" could be abandoned, so that's fixed as well.

#### Motivation:
Non deterministic races aren't fun.

##### References (optional):
Pointed out in https://github.com/purduesigbots/pros/issues/90#issuecomment-545628430

#### Test Plan:
- [x] lvgl still works.
