### PR TITLE
🐛 Fix clearing controller LCD

### DIFF
--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -259,33 +259,8 @@ int32_t controller_print(controller_id_e_t id, uint8_t line, uint8_t col, const 
 }
 
 int32_t controller_clear_line(controller_id_e_t id, uint8_t line) {
-	uint8_t port;
-	switch (id) {
-		case E_CONTROLLER_MASTER:
-			port = V5_PORT_CONTROLLER_1;
-			break;
-		case E_CONTROLLER_PARTNER:
-			port = V5_PORT_CONTROLLER_2;
-			break;
-		default:
-			errno = EINVAL;
-			return PROS_ERR;
-	}
-	if (!internal_port_mutex_take(port)) {
-		errno = EACCES;
-		return PROS_ERR;
-	}
-	line++;
-
-	const char* const blank = "                 ";
-	uint32_t rtn_val = vexControllerTextSet(port, line, 0, blank);
-	internal_port_mutex_give(port);
-
-	if (!rtn_val) {
-		errno = EAGAIN;
-		return PROS_ERR;
-	}
-	return 1;
+	const char* clear = "               ";
+	return controller_print(id, line, 0, clear);
 }
 
 int32_t controller_clear(controller_id_e_t id) {

--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -259,7 +259,7 @@ int32_t controller_print(controller_id_e_t id, uint8_t line, uint8_t col, const 
 }
 
 int32_t controller_clear_line(controller_id_e_t id, uint8_t line) {
-	const char* clear = "               ";
+	static const char* clear = "               ";
 	return controller_print(id, line, 0, clear);
 }
 

--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -290,7 +290,7 @@ int32_t controller_clear_line(controller_id_e_t id, uint8_t line) {
 
 int32_t controller_clear(controller_id_e_t id) {
 	if (vexSystemVersion() > 0x01000000) {
-		return controller_print(id, 0, 0, "");
+		return controller_print(id, -1, 0, "");
 	} else {
 		for (int i = 0; i < 3; i++) {
 			int32_t rtn = controller_clear_line(id, i);


### PR DESCRIPTION
#### Summary:
Fixes clearing both the full screen and a single line.

#### Test Plan:
- [x] VEX Atomic clear works
- [x] non atomic clear works
- [x] clearing a line works

With this working:

`master.print(0, 0, "abcdefghijklmnopq");`
`pros::delay(50);`
`master.print(1, 0, "abcdefghijklmno");`
`pros::delay(50);`
`master.print(2,0,strerror(errno));`
`pros::delay(50);`
`master.clear();`
`pros::delay(3000);`
`master.print(0, 0, "abcdefghijklmnopq");`
`pros::delay(50);`
`master.clear_line(0);`
