### PR TITLE
✨ Add SD card detection command

### DIFF
--- a/include/pros/misc.h
+++ b/include/pros/misc.h
@@ -424,6 +424,13 @@ double battery_get_temperature(void);
  */
 double battery_get_capacity(void);
 
+/**
+ * Checks if the SD card is installed.
+ *
+ * \return 1 if the SD card is installed, 0 otherwise
+ */
+int32_t usd_is_installed(void);
+
 #ifdef __cplusplus
 }
 }

--- a/include/pros/misc.hpp
+++ b/include/pros/misc.hpp
@@ -316,6 +316,15 @@ std::uint8_t is_autonomous(void);
 std::uint8_t is_connected(void);
 std::uint8_t is_disabled(void);
 }  // namespace competition
+
+namespace usd {
+/**
+ * Checks if the SD card is installed.
+ *
+ * \return 1 if the SD card is installed, 0 otherwise
+ */
+std::int32_t is_installed(void);
+}  // namespace usd
 }  // namespace pros
 
 #endif  // _PROS_MISC_HPP_

--- a/src/devices/vdml_usd.c
+++ b/src/devices/vdml_usd.c
@@ -1,0 +1,19 @@
+/**
+ * \file devices/usd.c
+ *
+ * Contains functions for interacting with the SD card.
+ *
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
+ * All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "kapi.h"
+#include "v5_api.h"
+
+int32_t usd_is_installed(void) {
+	return vexFileDriveStatus(0);
+}

--- a/src/devices/vdml_usd.cpp
+++ b/src/devices/vdml_usd.cpp
@@ -1,0 +1,25 @@
+/**
+ * \file devices/usd.cpp
+ *
+ * Contains functions for interacting with the SD card.
+ *
+ * Copyright (c) 2017-2019, Purdue University ACM SIGBots.
+ * All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "kapi.h"
+
+namespace pros {
+namespace usd {
+using namespace pros::c;
+
+double is_installed(void) {
+	return usd_is_installed();
+}
+
+}  // namespace usd
+}  // namespace pros

--- a/src/devices/vdml_usd.cpp
+++ b/src/devices/vdml_usd.cpp
@@ -17,7 +17,7 @@ namespace pros {
 namespace usd {
 using namespace pros::c;
 
-double is_installed(void) {
+std::int32_t is_installed(void) {
 	return usd_is_installed();
 }
 


### PR DESCRIPTION
#### Summary:
Well, I am still thinking about is it a suitable name for namespace and method.

**Namespace**: usd? SDcard? sdcard? or without namespace? (like: `pros::is_usd_installed()`)
**Method**: is_installed? is_inserted? is_mounted? is_connected? is_valid? etc...

#### Motivation:
Add it

##### References (optional):
#174 @nathan-moore 

#### Test Plan:
```cpp
void opcontrol() {
    while (true) {
        pros::lcd::print(2, "Installed? %d", pros::usd::is_installed());
        pros::lcd::print(3, "Installed? %d", pros::c::usd_is_installed());
        pros::delay(20);
    }
}
```

- [x] run the test code
