### PR TITLE
🔇 Stop warnings for GCC 7.1 ABI change

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -5,7 +5,7 @@ MFLAGS=-mcpu=cortex-a9 -mfpu=neon-fp16 -mfloat-abi=softfp -Os -g
 CPPFLAGS=-D_POSIX_THREADS -D_UNIX98_THREAD_MUTEX_ATTRIBUTES
 GCCFLAGS=-ffunction-sections -fdata-sections -fdiagnostics-color -funwind-tables
 
-WARNFLAGS+=
+WARNFLAGS+=-Wno-psabi
 
 SPACE :=
 SPACE +=


### PR DESCRIPTION
#### Summary:
This PR adds `-Wno-psabi` to `WARNFLAGS`.

#### Motivation:
Many users encounter a warning similar to this, especially when using OkapiLib:
```
 parameter passing for argument of type 'std::initializer_list<okapi::Point>' changed in GCC 7.1
```

It causes a lot of unnecessary confusion, so we should ignore it by default.

##### References (optional):
None.

#### Test Plan:
There is no test plan.