### PR TITLE
Add missing include directives for <stdbool.h>

### DIFF
--- a/include/pros/adi.h
+++ b/include/pros/adi.h
@@ -18,6 +18,7 @@
 #ifndef _PROS_ADI_H_
 #define _PROS_ADI_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 #ifndef PROS_ERR
 #define PROS_ERR (INT32_MAX)

--- a/include/pros/llemu.h
+++ b/include/pros/llemu.h
@@ -24,6 +24,7 @@
 #define _PROS_LLEMU_H_
 
 #include <errno.h>
+#include <stdbool.h>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"

--- a/include/pros/rtos.h
+++ b/include/pros/rtos.h
@@ -21,6 +21,7 @@
 #ifndef _PROS_RTOS_H_
 #define _PROS_RTOS_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
#### Summary:
Some header files for the C API were missing include directives for `<stdbool.h>`. This is only evident when they are included directly, rather than via `<api.h>` or `<apix.h>`. In this case, it results in a compiler error, as the then-undefined `bool` type is used in the header; the user is forced to include `<stdbool.h>` themselves before including the particular header.

#### Motivation:
General good practice of including everything that the header depends on.

#### Test Plan:
Just make sure it compiles, trivial and non-functional change so I don't expect any issues.

- [ ] test item
