### PR TITLE
Put in temporary file system stubs

### DIFF
--- a/src/system/dev/file_system_stubs.c
+++ b/src/system/dev/file_system_stubs.c
@@ -14,53 +14,45 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <sys/stat.h>
 #include <errno.h>
+#include <sys/stat.h>
 
-int chdir(const char* path)
-{
-  errno = ENOSYS;
-  return -1;
+int chdir(const char* path) {
+	errno = ENOSYS;
+	return -1;
 }
 
-int mkdir(const char* pathname, mode_t mode)
-{
-  errno = ENOSYS;
-  return -1;
+int mkdir(const char* pathname, mode_t mode) {
+	errno = ENOSYS;
+	return -1;
 }
 
-int chmod(const char* pathname, mode_t mode)
-{
-  errno = ENOSYS;
-  return -1;
+int chmod(const char* pathname, mode_t mode) {
+	errno = ENOSYS;
+	return -1;
 }
 
-long pathconf(const char* path, int name)
-{
-  errno = ENOSYS;
-  return -1;
+long pathconf(const char* path, int name) {
+	errno = ENOSYS;
+	return -1;
 }
 
-char* getcwd(char* buf, size_t size)
-{
-  errno = ENOSYS;
-  return NULL;
+char* getcwd(char* buf, size_t size) {
+	errno = ENOSYS;
+	return NULL;
 }
 
-int _unlink(const char* name)
-{
-  errno = ENOSYS;
-  return -1;
+int _unlink(const char* name) {
+	errno = ENOSYS;
+	return -1;
 }
 
-int _link(const char* old, const char* new)
-{
-  errno = ENOSYS;
-  return -1;
+int _link(const char* old, const char* new) {
+	errno = ENOSYS;
+	return -1;
 }
 
-int _stat(const char* file, struct stat* st)
-{
-  errno = ENOSYS;
-  return -1;
+int _stat(const char* file, struct stat* st) {
+	errno = ENOSYS;
+	return -1;
 }

--- a/src/system/dev/file_system_stubs.c
+++ b/src/system/dev/file_system_stubs.c
@@ -35,7 +35,7 @@ int chmod(const char* pathname, mode_t mode)
   return -1;
 }
 
-long pathconf(char* path, int name)
+long pathconf(const char* path, int name)
 {
   errno = ENOSYS;
   return -1;
@@ -47,20 +47,20 @@ char* getcwd(char* buf, size_t size)
   return NULL;
 }
 
-int _unlink(char* name)
+int _unlink(const char* name)
 {
-  errno = ENOENT;
+  errno = ENOSYS;
   return -1;
 }
 
-int _link(char* old, char* new)
+int _link(const char* old, const char* new)
 {
-  errno = EMLINK;
+  errno = ENOSYS;
   return -1;
 }
 
-int _stat(char* file, struct stat* st)
+int _stat(const char* file, struct stat* st)
 {
-  st->st_mode = S_IFCHR;
-  return 0;
+  errno = ENOSYS;
+  return -1;
 }

--- a/src/system/dev/file_system_stubs.c
+++ b/src/system/dev/file_system_stubs.c
@@ -1,0 +1,66 @@
+/**
+ * \file system/dev/dev_driver.c
+ *
+ * Generic Serial Device driver
+ *
+ * Contains temporary stubs for the file system to allow compilation under gcc 9.2
+ * This is temporary and should be removed as part of #184
+ *
+ * Copyright (c) 2017-2020, Purdue University ACM SIGBots.
+ * All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <sys/stat.h>
+#include <errno.h>
+
+int chdir(const char* path)
+{
+  errno = ENOSYS;
+  return -1;
+}
+
+int mkdir(const char* pathname, mode_t mode)
+{
+  errno = ENOSYS;
+  return -1;
+}
+
+int chmod(const char* pathname, mode_t mode)
+{
+  errno = ENOSYS;
+  return -1;
+}
+
+long pathconf(char* path, int name)
+{
+  errno = ENOSYS;
+  return -1;
+}
+
+char* getcwd(char* buf, size_t size)
+{
+  errno = ENOSYS;
+  return NULL;
+}
+
+int _unlink(char* name)
+{
+  errno = ENOENT;
+  return -1;
+}
+
+int _link(char* old, char* new)
+{
+  errno = EMLINK;
+  return -1;
+}
+
+int _stat(char* file, struct stat* st)
+{
+  st->st_mode = S_IFCHR;
+  return 0;
+}


### PR DESCRIPTION
#### Summary:
Put in some temporary file system stubs to allow people to compile. This will hold us over until #184 is merged, and should reverted as part of that pr.

#### Motivation:
This allows people using the newest c++ stdlib to use hot cold. Previously they would either need to define the stubs themselves, downgrade gcc, or not use hot/cold.

##### References (optional):
Contribues to #176 

#### Test Plan:
- [x] See if this fixes the hot/cold compilation issues when compiling with gcc 9.2.
