### PR TITLE
🐛 Fix the problem of millis()

### DIFF
--- a/src/rtos/tasks.c
+++ b/src/rtos/tasks.c
@@ -2058,7 +2058,7 @@ uint32_t xTicks;
 	}
 	portTICK_TYPE_EXIT_CRITICAL();
 
-	return xTicks * configTICK_RATE_HZ / 1000;
+	return xTicks * (configTICK_RATE_HZ / 1000);
 }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
#### Summary:
The millis() number reset to zero every 1h 11m 34s and 967ms.

According to the source code:
https://github.com/purduesigbots/pros/blob/1e07ae915b38689ae53a9f03cacc8fbbed09dbff/src/rtos/tasks.c#L2050-L2062
Ok, so we are using `uint32_t` and the maximum value is `2^32 = 4294967296`
At the same time. 1h 11m and 35s equal to `71*60*1000+35*1000 = 4295000`

Please pay attention to line 2061, `return xTicks * configTICK_RATE_HZ / 1000;`

That equals to `4295000 * 1000 / 1000` -> `4295000000 / 1000` and 4295000000 > 4294967296
The millis() overflow. 

#### Motivation:
Running a program for over an hour.

##### References (optional):
My time

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [x] run the test code
```cpp
void opcontrol() {
	while (1) {
        pros::lcd::print(6, "Time: %d", pros::millis());
        pros::lcd::print(7, "H:%d M:%d S:%d", pros::millis()/1000/60/60,
                                              pros::millis()/1000/60%60,
                                              pros::millis()/1000%60);
        pros::delay(20);
    }
}
```
