### PR TITLE
🐛 Properly flush character to user frontend

### DIFF
--- a/src/system/dev/ser_daemon.c
+++ b/src/system/dev/ser_daemon.c
@@ -114,9 +114,8 @@ static void ser_daemon_task(void* ign) {
 		uint8_t b = vex_read_char();
 		if (b == 'p') {  // TODO: make the command prefix not typeable
 			command_stack[command_stack_idx++] = b;
-			b = vex_read_char();
+			b = command_stack[command_stack_idx++] = vex_read_char();
 			if (b == 'R') {
-				command_stack[command_stack_idx++] = b;
 				b = command_stack[command_stack_idx++] = vex_read_char();
 				switch (b) {
 					case 'a':


### PR DESCRIPTION
#### Summary:
Properly flush character in serial command buffer if 'p' is accepted and the following character is not.

#### Motivation:
If you echo back every character that is typed in shell, you will observe that any character following "p" never shows up.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
- [x] Type `help\n`, all the characters appear
