### PR TITLE
Added an std::string overload of Controller::set_text()

### DIFF
--- a/include/pros/misc.hpp
+++ b/include/pros/misc.hpp
@@ -196,7 +196,7 @@ class Controller {
 	 * failed, setting errno.
 	 */
 	std::int32_t set_text(std::uint8_t line, std::uint8_t col, const char* str);
-	std::int32_t set_text(std::uint8_t line, std::uint8_t col, std::string str);
+	std::int32_t set_text(std::uint8_t line, std::uint8_t col, const std::string& str);
 
 	/**
 	 * Clears an individual line of the controller screen.

--- a/include/pros/misc.hpp
+++ b/include/pros/misc.hpp
@@ -196,6 +196,7 @@ class Controller {
 	 * failed, setting errno.
 	 */
 	std::int32_t set_text(std::uint8_t line, std::uint8_t col, const char* str);
+	std::int32_t set_text(std::uint8_t line, std::uint8_t col, std::string str);
 
 	/**
 	 * Clears an individual line of the controller screen.

--- a/src/devices/controller.cpp
+++ b/src/devices/controller.cpp
@@ -13,6 +13,7 @@
  */
 
 #include "kapi.h"
+#include <string>
 
 namespace pros {
 using namespace pros::c;
@@ -45,6 +46,10 @@ std::int32_t Controller::get_digital_new_press(pros::controller_digital_e_t butt
 
 std::int32_t Controller::set_text(std::uint8_t line, std::uint8_t col, const char* str) {
 	return controller_set_text(_id, line, col, str);
+}
+
+std::int32_t Controller::set_text(std::uint8_t line, std::uint8_t col, std::string str) {
+	return controller_set_text(_id, line, col, str.c_str());
 }
 
 std::int32_t Controller::clear_line(std::uint8_t line) {

--- a/src/devices/controller.cpp
+++ b/src/devices/controller.cpp
@@ -47,7 +47,7 @@ std::int32_t Controller::set_text(std::uint8_t line, std::uint8_t col, const cha
 	return controller_set_text(_id, line, col, str);
 }
 
-std::int32_t Controller::set_text(std::uint8_t line, std::uint8_t col, std::string str) {
+std::int32_t Controller::set_text(std::uint8_t line, std::uint8_t col, const std::string& str) {
 	return controller_set_text(_id, line, col, str.c_str());
 }
 

--- a/src/devices/controller.cpp
+++ b/src/devices/controller.cpp
@@ -13,7 +13,6 @@
  */
 
 #include "kapi.h"
-#include <string>
 
 namespace pros {
 using namespace pros::c;


### PR DESCRIPTION
#### Summary:
Basically what the title says.... it's pretty simple.  I also included std::string into the file because I wasn't really sure if it was included elsewhere but I figured I might as well be safe.

#### Motivation:
It was annoying me that I had to add .c_str() every time I called set_text();
Also hotel said it was ok :)

#### Test Plan:
uh you can call it and see if it works I guess.  I don't foresee there being any major issues with this change.

- [ ] test item
