### PR TITLE
⬆ Upgrade vexOS to 1.0.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ compile_commands.json
 temp.log
 temp.errors
 .d/
+.clangd/

--- a/include/pros/imu.h
+++ b/include/pros/imu.h
@@ -56,6 +56,8 @@ typedef struct __attribute__((__packed__)) euler_s {
 	double yaw;
 } euler_s_t;
 
+#define IMU_MINIMUM_DATA_RATE 5
+
 /**
  * Calibrate IMU
  *

--- a/include/pros/imu.h
+++ b/include/pros/imu.h
@@ -79,7 +79,13 @@ int32_t imu_reset(uint8_t port);
  * Set the Inertial Sensor's refresh interval in milliseconds.
  *
  * The rate may be specified in increments of 5ms, and will be rounded down to
- * the nearest increment. The minimum allowable refresh rate is 5ms.
+ * the nearest increment. The minimum allowable refresh rate is 5ms. The default
+ * rate is 10ms.
+ *
+ * As values are copied into the shared memory buffer only at 10ms intervals,
+ * setting this value to less than 10ms does not mean that you can poll the
+ * sensor's values any faster. However, it will guarantee that the data is as
+ * recent as possible.
  *
  * This function uses the following values of errno when an error state is
  * reached:

--- a/include/pros/imu.h
+++ b/include/pros/imu.h
@@ -74,6 +74,27 @@ typedef struct __attribute__((__packed__)) euler_s {
  */
 int32_t imu_reset(uint8_t port);
 
+
+/**
+ * Set the Inertial Sensor's refresh interval in milliseconds.
+ *
+ * The rate may be specified in increments of 5ms, and will be rounded down to
+ * the nearest increment. The minimum allowable refresh rate is 5ms.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * ENXIO - The given value is not within the range of V5 ports (1-21).
+ * ENODEV - The port cannot be configured as an Inertial Sensor
+ * EAGAIN - The sensor is still calibrating
+ *
+ * \param port
+ *		  The V5 Inertial Sensor port number from 1-21
+ * \param rate The data refresh interval in milliseconds
+ * \return 1 if the operation was successful or PROS_ERR if the operation
+ * failed, setting errno.
+ */
+int32_t imu_set_data_rate(uint8_t port, uint32_t rate);
+
 /**
  * Get the total number of degrees the Inertial Sensor has spun about the z-axis
  *

--- a/include/pros/imu.hpp
+++ b/include/pros/imu.hpp
@@ -47,7 +47,13 @@ class Imu {
 	* Set the Inertial Sensor's refresh interval in milliseconds.
 	*
 	* The rate may be specified in increments of 5ms, and will be rounded down to
-	* the nearest increment. The minimum allowable refresh rate is 5ms.
+	* the nearest increment. The minimum allowable refresh rate is 5ms. The default
+	* rate is 10ms.
+	*
+	* As values are copied into the shared memory buffer only at 10ms intervals,
+	* setting this value to less than 10ms does not mean that you can poll the
+	* sensor's values any faster. However, it will guarantee that the data is as
+	* recent as possible.
 	*
 	* This function uses the following values of errno when an error state is
 	* reached:

--- a/include/pros/imu.hpp
+++ b/include/pros/imu.hpp
@@ -39,12 +39,27 @@ class Imu {
 	 * ENODEV - The port cannot be configured as an Inertial Sensor
 	 * EAGAIN - The sensor is already calibrating
 	 *
-	 * \param port
-	 *        The V5 Inertial Sensor port number from 1-21
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 */
 	virtual std::int32_t reset() const;
+	/**
+	* Set the Inertial Sensor's refresh interval in milliseconds.
+	*
+	* The rate may be specified in increments of 5ms, and will be rounded down to
+	* the nearest increment. The minimum allowable refresh rate is 5ms.
+	*
+	* This function uses the following values of errno when an error state is
+	* reached:
+	* ENXIO - The given value is not within the range of V5 ports (1-21).
+	* ENODEV - The port cannot be configured as an Inertial Sensor
+	* EAGAIN - The sensor is still calibrating
+	*
+	* \param rate The data refresh interval in milliseconds
+	* \return 1 if the operation was successful or PROS_ERR if the operation
+	* failed, setting errno.
+	*/
+	virtual std::int32_t set_data_rate(std::uint32_t rate) const;
 	/**
 	 * Get the total number of degrees the Inertial Sensor has spun about the z-axis
 	 *

--- a/src/devices/vdml_imu.c
+++ b/src/devices/vdml_imu.c
@@ -34,7 +34,11 @@ int32_t imu_set_data_rate(uint8_t port, uint32_t rate) {
 	ERROR_IMU_STILL_CALIBRATING(port, device, PROS_ERR);
 
 	// rate is not less than 5ms, and rounded down to nearest increment of 5
-	rate -= rate == 0 ? 5 : (rate - 5) % 5;
+	if (rate < IMU_MINIMUM_DATA_RATE) {
+		rate = IMU_MINIMUM_DATA_RATE;
+	} else {
+		rate -= rate % IMU_MINIMUM_DATA_RATE;
+	}
 
 	vexDeviceImuDataRateSet(device->device_info, rate);
 	return_port(port - 1, 1);

--- a/src/devices/vdml_imu.c
+++ b/src/devices/vdml_imu.c
@@ -29,6 +29,17 @@ int32_t imu_reset(uint8_t port) {
 	return_port(port - 1, 1);
 }
 
+int32_t imu_set_data_rate(uint8_t port, uint32_t rate) {
+	claim_port_i(port - 1, E_DEVICE_IMU);
+	ERROR_IMU_STILL_CALIBRATING(port, device, PROS_ERR);
+
+	// rate is not less than 5ms, and rounded down to nearest increment of 5
+	rate -= rate == 0 ? 5 : (rate - 5) % 5;
+
+	vexDeviceImuDataRateSet(device->device_info, rate);
+	return_port(port - 1, 1);
+}
+
 double imu_get_rotation(uint8_t port) {
 	claim_port_f(port - 1, E_DEVICE_IMU);
 	ERROR_IMU_STILL_CALIBRATING(port, device, PROS_ERR_F);

--- a/src/devices/vdml_imu.cpp
+++ b/src/devices/vdml_imu.cpp
@@ -10,11 +10,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include "pros/imu.h"
 #include "pros/imu.hpp"
 
 namespace pros {
 std::int32_t Imu::reset() const {
 	return pros::c::imu_reset(_port);
+}
+
+std::int32_t Imu::set_data_rate(std::uint32_t rate) const {
+	return pros::c::imu_set_data_rate(_port, rate);
 }
 
 double Imu::get_rotation() const {


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
Does what it says on the tin. Also adds the IMU data refresh rate setter function.

#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
This will allow us to support the new sensors when they come out. Also people were asking for the IMU part.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
N/A

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->
- [x] compiles
- [x] `imu_set_data_rate` works 
