### PR TITLE
✨Increasing the Max String Size on the Controller Display

### DIFF
--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -17,7 +17,7 @@
 #include "v5_api.h"
 #include "vdml/vdml.h"
 
-#define CONTROLLER_MAX_COLS 15
+#define CONTROLLER_MAX_COLS 19
 
 // From enum in misc.h
 #define NUM_BUTTONS 12

--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -259,7 +259,7 @@ int32_t controller_print(controller_id_e_t id, uint8_t line, uint8_t col, const 
 }
 
 int32_t controller_clear_line(controller_id_e_t id, uint8_t line) {
-	static const char* clear = "               ";
+	static const char* clear = "                   ";
 	return controller_print(id, line, 0, clear);
 }
 

--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -12,6 +12,8 @@
  */
 
 #include <stdio.h>
+#include <string.h>
+#include <assert.h>
 
 #include "kapi.h"
 #include "v5_api.h"
@@ -260,6 +262,7 @@ int32_t controller_print(controller_id_e_t id, uint8_t line, uint8_t col, const 
 
 int32_t controller_clear_line(controller_id_e_t id, uint8_t line) {
 	static const char* clear = "                   ";
+	kassert(strlen(clear) == CONTROLLER_MAX_COLS);
 	return controller_print(id, line, 0, clear);
 }
 

--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -13,7 +13,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 
 #include "kapi.h"
 #include "v5_api.h"


### PR DESCRIPTION
#### Summary:
<!-- --> VCS and RMS have had their controller max string sizes at 19 for a while, and PROS also having this wouldn't be too hard of a change. This was done by changing `CONTROLLER_MAX_COLS` under `src/devices/controller.c` to 19.

#### Motivation:
<!-- .-->There was an issue opened by @djava requesting that we do this, but the discussion surround this died pretty suddenly so I decided to open a PR regarding this to restart the conversation

##### References (optional):
fixes https://github.com/purduesigbots/pros/issues/217

#### Test Plan:
<!-- Build and Upload to a robot with a 19 character display, check controller to see if it shows up.-->

- [x] Build and Upload to a robot with a 19 character display, see if it shows up.  
