### PR TITLE
Added mutex_delete functionality

### DIFF
--- a/include/pros/rtos.h
+++ b/include/pros/rtos.h
@@ -403,6 +403,14 @@ bool mutex_take(mutex_t mutex, uint32_t timeout);
  */
 bool mutex_give(mutex_t mutex);
 
+/**
+ * Deletes a mutex
+ *
+ * \param mutex
+ *        Mutex to unlock.
+ */
+void mutex_delete(mutex_t mutex);
+
 #ifdef __cplusplus
 }  // namespace c
 }  // namespace pros

--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -356,6 +356,11 @@ class Mutex {
 	 */
 	bool give(void);
 
+	/**
+	 * Should be called only on the last instance to free the memory the mutex takes up.
+	 */
+	void free(void);
+
 	private:
 	mutex_t mutex;
 };

--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -356,13 +356,8 @@ class Mutex {
 	 */
 	bool give(void);
 
-	/**
-	 * Should be called only on the last instance to free the memory the mutex takes up.
-	 */
-	void free(void);
-
 	private:
-	mutex_t mutex;
+	std::shared_ptr<std::remove_pointer_t<mutex_t>> mutex;
 };
 
 /**

--- a/src/rtos/rtos.cpp
+++ b/src/rtos/rtos.cpp
@@ -96,7 +96,7 @@ using namespace pros::c;
     return task_get_count();
   }
 
-  Mutex::Mutex(void) : mutex(std::shared_ptr<std::remove_pointer_t<mutex_t>>{mutex_create(), mutex_delete}) { }
+  Mutex::Mutex(void) : mutex(mutex_create(), mutex_delete) { }
 
   bool Mutex::take(std::uint32_t timeout) {
     return mutex_take(mutex.get(), timeout);

--- a/src/rtos/rtos.cpp
+++ b/src/rtos/rtos.cpp
@@ -105,4 +105,8 @@ using namespace pros::c;
   bool Mutex::give(void) {
     return mutex_give(mutex);
   }
+
+  void Mutex::free(void) {
+	  mutex_delete(mutex);
+  }
 }

--- a/src/rtos/rtos.cpp
+++ b/src/rtos/rtos.cpp
@@ -96,10 +96,6 @@ using namespace pros::c;
     return task_get_count();
   }
 
-  class MutexDeleter{
-
-  };
-
   Mutex::Mutex(void) : mutex(std::shared_ptr<std::remove_pointer_t<mutex_t>>{mutex_create(), mutex_delete}) { }
 
   bool Mutex::take(std::uint32_t timeout) {

--- a/src/rtos/rtos.cpp
+++ b/src/rtos/rtos.cpp
@@ -96,17 +96,17 @@ using namespace pros::c;
     return task_get_count();
   }
 
-  Mutex::Mutex(void) : mutex(mutex_create()) { }
+  class MutexDeleter{
+
+  };
+
+  Mutex::Mutex(void) : mutex(std::shared_ptr<std::remove_pointer_t<mutex_t>>{mutex_create(), mutex_delete}) { }
 
   bool Mutex::take(std::uint32_t timeout) {
-    return mutex_take(mutex, timeout);
+    return mutex_take(mutex.get(), timeout);
   }
 
   bool Mutex::give(void) {
-    return mutex_give(mutex);
-  }
-
-  void Mutex::free(void) {
-	  mutex_delete(mutex);
+    return mutex_give(mutex.get());
   }
 }

--- a/src/rtos/semphr.c
+++ b/src/rtos/semphr.c
@@ -203,7 +203,7 @@ uint8_t mutex_take(mutex_t mutex, uint32_t timeout) {
 }
 
 void mutex_delete(mutex_t mutex){
-  queue_delete((queue_t)(mutex));
+  sem_delete((sem_t)(mutex));
 }
 
 /**

--- a/src/rtos/semphr.c
+++ b/src/rtos/semphr.c
@@ -202,6 +202,10 @@ uint8_t mutex_take(mutex_t mutex, uint32_t timeout) {
 	return xQueueSemaphoreTake( ( mutex ), ( timeout ) );
 }
 
+void mutex_delete(mutex_t mutex){
+  queue_delete((queue_t)(mutex));
+}
+
 /**
  * semphr. h
  * <pre>sem_t sem_binary_create( void )</pre>


### PR DESCRIPTION
#### Summary:
Added a function to allow for deleting a mutex within a c++ context as well as a specific c function in order to fix the possible memory leak.

Currently this code will cause the v5 to freeze to an unrecoverable state after <15 seconds:
`while(true){pros::Mutex{});}`

Some possible issues:
-The function to free memory is called pros::Mutex::free, delete would have been preferable to match the c api but is a reserved word.
-This function cannot be implemented within a destructor because for a mutex to fulfill it's purpose multiple objects with the same memory pointer must exist. This can be done utilizing reference counting but that is a larger change outside the scope of this.

Future improvements
-Adding reference counting to make destruction automatic
-Making free also set the pointer to nullptr, however this will not effect other instances unless pros::Mutex is changed to hold a mutex_t**
-Adding scoped locking functionality akin to #229

#### Motivation:
pros::Mutex did not have a way for the user to free its memory and the c api did not have a clear way to do the same.

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

Run the following code:
`while(true){pros::Mutex{}.free();}`
The v5 should not crash due to memory leakage, test for ~1 min.

I have tested the concept by running the following code with header changes for public access to pros::Mutex::mutex, however I cannot build the pros kernel myself.
`while(true){pros::c::sem_delete(pros::Mutex{}.mutex);}`
This code was tested up to 3 min.
