### PR TITLE
pros::Task::notify_take static and pros::Task::operator= stl compliant

### DIFF
--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -152,7 +152,7 @@ class Task {
 	 *        A task handle from task_create() for which to create a pros::Task
 	 *        object.
 	 */
-	void operator=(const task_t in);
+	Task& operator=(task_t in);
 
 	/**
 	 * Removes the Task from the RTOS real time kernel's management. This task
@@ -267,7 +267,7 @@ class Task {
 	 * \return The value of the task's notification value before it is decremented
 	 * or cleared
 	 */
-	std::uint32_t notify_take(bool clear_on_exit, std::uint32_t timeout);
+	static std::uint32_t notify_take(bool clear_on_exit, std::uint32_t timeout);
 
 	/**
 	 * Clears the notification for a task.

--- a/src/rtos/rtos.cpp
+++ b/src/rtos/rtos.cpp
@@ -32,8 +32,9 @@ using namespace pros::c;
       : Task(function, parameters, TASK_PRIORITY_DEFAULT, TASK_STACK_DEPTH_DEFAULT, name) {}
 
   Task::Task(task_t task) : task(task) { }
-  void Task::operator = (const task_t in) {
-    task = in;
+  Task& Task::operator=(const task_t in) {
+	  task = in;
+	  return *this;
   }
 
   Task Task::current() {


### PR DESCRIPTION
#### Summary:
Makes pros::Task::notify_take static and pros::Task::operator= stl compliant.

#### Motivation:
pros::Task::notify_take used to require a task handle to be used but that task handle was never used in the function. With it being static it can now be called without a handle without breaking current user code.

pros::Task::operator= used to return void and this makes it return pros::Task&, a good explanation for why this is better can be found here: [explanation](https://stackoverflow.com/questions/42335200/assignment-operator-overloading-returning-void-versus-returning-reference-param)