### PR TITLE
Removed non-sensical imu calibrating check in imu_get_status

### DIFF
--- a/src/devices/vdml_imu.c
+++ b/src/devices/vdml_imu.c
@@ -153,7 +153,6 @@ imu_status_e_t imu_get_status(uint8_t port) {
 		return rtn;
 	}
 	device = registry_get_device(port - 1);
-	ERROR_IMU_STILL_CALIBRATING(port, device, E_IMU_STATUS_ERROR);
 	rtn = vexDeviceImuStatusGet(device->device_info);
 	return_port(port - 1, rtn);
 }


### PR DESCRIPTION
Removed a ERROR_IMU_STILL_CALIBRATING in vdml_imu.c, which doesn't make sense to check if the imu was still calibrating and not return this status. 
