### PR TITLE
Add Support for the ADI Expander

### DIFF
--- a/include/pros/adi.h
+++ b/include/pros/adi.h
@@ -136,7 +136,7 @@ namespace c {
  *
  * \return The ADI configuration for the given port
  */
-adi_port_config_e_t adi_port_get_config(uint8_t port);
+adi_port_config_e_t adi_port_get_config(uint8_t smart_port, uint8_t adi_port);
 
 /**
  * Gets the value for the given ADI port.
@@ -151,7 +151,7 @@ adi_port_config_e_t adi_port_get_config(uint8_t port);
  *
  * \return The value stored for the given port
  */
-int32_t adi_port_get_value(uint8_t port);
+int32_t adi_port_get_value(uint8_t smart_port, uint8_t adi_port);
 
 /**
  * Configures an ADI port to act as a given sensor type.
@@ -168,7 +168,7 @@ int32_t adi_port_get_value(uint8_t port);
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.
  */
-int32_t adi_port_set_config(uint8_t port, adi_port_config_e_t type);
+int32_t adi_port_set_config(uint8_t smart_port, uint8_t adi_port, adi_port_config_e_t type);
 
 /**
  * Sets the value for the given ADI port.
@@ -189,7 +189,7 @@ int32_t adi_port_set_config(uint8_t port, adi_port_config_e_t type);
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.
  */
-int32_t adi_port_set_value(uint8_t port, int32_t value);
+int32_t adi_port_set_value(uint8_t smart_port, uint8_t adi_port, int32_t value);
 
 /******************************************************************************/
 /**                      PROS 2 Compatibility Functions                      **/
@@ -252,7 +252,7 @@ int32_t adi_port_set_value(uint8_t port, int32_t value);
  *
  * \return The average sensor value computed by this function
  */
-int32_t adi_analog_calibrate(uint8_t port);
+int32_t adi_analog_calibrate(uint8_t smart_port, uint8_t adi_port);
 
 /**
  * Gets the 12-bit value of the specified port.
@@ -272,7 +272,7 @@ int32_t adi_analog_calibrate(uint8_t port);
  * \return The analog sensor value, where a value of 0 reflects an input voltage
  * of nearly 0 V and a value of 4095 reflects an input voltage of nearly 5 V
  */
-int32_t adi_analog_read(uint8_t port);
+int32_t adi_analog_read(uint8_t smart_port, uint8_t adi_port);
 
 /**
  * Gets the 12 bit calibrated value of an analog input port.
@@ -294,7 +294,7 @@ int32_t adi_analog_read(uint8_t port);
  * \return The difference of the sensor value from its calibrated default from
  * -4095 to 4095
  */
-int32_t adi_analog_read_calibrated(uint8_t port);
+int32_t adi_analog_read_calibrated(uint8_t smart_port, uint8_t adi_port);
 
 /**
  * Gets the 16 bit calibrated value of an analog input port.
@@ -321,7 +321,7 @@ int32_t adi_analog_read_calibrated(uint8_t port);
  * \return The difference of the sensor value from its calibrated default from
  * -16384 to 16384
  */
-int32_t adi_analog_read_calibrated_HR(uint8_t port);
+int32_t adi_analog_read_calibrated_HR(uint8_t smart_port, uint8_t adi_port);
 
 /**
  * Gets the digital value (1 or 0) of a port configured as a digital input.
@@ -341,7 +341,7 @@ int32_t adi_analog_read_calibrated_HR(uint8_t port);
  *
  * \return True if the pin is HIGH, or false if it is LOW
  */
-int32_t adi_digital_read(uint8_t port);
+int32_t adi_digital_read(uint8_t smart_port, uint8_t adi_port);
 
 /**
  * Gets a rising-edge case for a digital button press.
@@ -365,7 +365,7 @@ int32_t adi_digital_read(uint8_t port);
  * \return 1 if the button is pressed and had not been pressed
  * the last time this function was called, 0 otherwise.
  */
-int32_t adi_digital_get_new_press(uint8_t port);
+int32_t adi_digital_get_new_press(uint8_t smart_port, uint8_t adi_port);
 
 /**
  * Sets the digital value (1 or 0) of a port configured as a digital output.
@@ -386,7 +386,7 @@ int32_t adi_digital_get_new_press(uint8_t port);
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.
  */
-int32_t adi_digital_write(uint8_t port, const bool value);
+int32_t adi_digital_write(uint8_t smart_port, uint8_t adi_port, const bool value);
 
 /**
  * Configures the port as an input or output with a variety of settings.
@@ -403,7 +403,7 @@ int32_t adi_digital_write(uint8_t port, const bool value);
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.
  */
-int32_t adi_pin_mode(uint8_t port, uint8_t mode);
+int32_t adi_pin_mode(uint8_t smart_port, uint8_t adi_port, uint8_t mode);
 
 /**
  * Sets the speed of the motor on the given port.
@@ -422,7 +422,7 @@ int32_t adi_pin_mode(uint8_t port, uint8_t mode);
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.
  */
-int32_t adi_motor_set(uint8_t port, int8_t speed);
+int32_t adi_motor_set(uint8_t smart_port, uint8_t adi_port, int8_t speed);
 
 /**
  * Gets the last set speed of the motor on the given port.
@@ -437,7 +437,7 @@ int32_t adi_motor_set(uint8_t port, int8_t speed);
  *
  * \return The last set speed of the motor on the given port
  */
-int32_t adi_motor_get(uint8_t port);
+int32_t adi_motor_get(uint8_t smart_port, uint8_t adi_port);
 
 /**
  * Stops the motor on the given port.
@@ -453,7 +453,7 @@ int32_t adi_motor_get(uint8_t port);
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.
  */
-int32_t adi_motor_stop(uint8_t port);
+int32_t adi_motor_stop(uint8_t smart_port, uint8_t adi_port);
 
 /**
  * Reference type for an initialized encoder.
@@ -461,7 +461,10 @@ int32_t adi_motor_stop(uint8_t port);
  * This merely contains the port number for the encoder, unlike its use as an
  * object to store encoder data in PROS 2.
  */
-typedef int32_t adi_encoder_t;
+typedef struct {
+	int32_t smart_port;
+	int32_t adi_port;
+} adi_encoder_t;
 
 /**
  * Gets the number of ticks recorded by the encoder.
@@ -502,7 +505,7 @@ int32_t adi_encoder_get(adi_encoder_t enc);
  * \return An adi_encoder_t object to be stored and used for later calls to
  * encoder functions
  */
-adi_encoder_t adi_encoder_init(uint8_t port_top, uint8_t port_bottom, const bool reverse);
+adi_encoder_t adi_encoder_init(uint8_t smart_port, uint8_t adi_port_top, uint8_t adi_port_bottom, const bool reverse);
 
 /**
  * Sets the encoder value to zero.
@@ -546,7 +549,10 @@ int32_t adi_encoder_shutdown(adi_encoder_t enc);
  * This merely contains the port number for the ultrasonic, unlike its use as an
  * object to store ultrasonic data in PROS 2.
  */
-typedef int32_t adi_ultrasonic_t;
+typedef struct {
+	int32_t smart_port;
+	int32_t adi_port;
+} adi_ultrasonic_t;
 
 /**
  * Gets the current ultrasonic sensor value in centimeters.
@@ -586,7 +592,7 @@ int32_t adi_ultrasonic_get(adi_ultrasonic_t ult);
  * \return An adi_ultrasonic_t object to be stored and used for later calls to
  * ultrasonic functions
  */
-adi_ultrasonic_t adi_ultrasonic_init(uint8_t port_ping, uint8_t port_echo);
+adi_ultrasonic_t adi_ultrasonic_init(uint8_t smart_port, uint8_t adi_port_ping, uint8_t adi_port_echo);
 
 /**
  * Disables the ultrasonic sensor and voids the configuration on its ports.
@@ -610,7 +616,10 @@ int32_t adi_ultrasonic_shutdown(adi_ultrasonic_t ult);
  * This merely contains the port number for the gyroscope, unlike its use as an
  * object to store gyro data in PROS 2.
  */
-typedef int32_t adi_gyro_t;
+typedef struct {
+	int32_t smart_port;
+	int32_t adi_port;
+} adi_gyro_t;
 
 /**
  * Gets the current gyro angle in tenths of a degree. Unless a multiplier is
@@ -654,7 +663,7 @@ double adi_gyro_get(adi_gyro_t gyro);
  * \return An adi_gyro_t object containing the given port, or PROS_ERR if the
  * initialization failed.
  */
-adi_gyro_t adi_gyro_init(uint8_t port, double multiplier);
+adi_gyro_t adi_gyro_init(uint8_t smart_port, uint8_t adi_port, double multiplier);
 
 /**
  * Resets the gyroscope value to zero.

--- a/include/pros/adi.h
+++ b/include/pros/adi.h
@@ -253,9 +253,9 @@ int32_t adi_port_set_value(uint8_t smart_port, uint8_t adi_port, int32_t value);
  * ENXIO - The given value is not within the range of ADI Ports
  *
  * \param smart_port
-	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
-	 * \param adi_port
-	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port
+ *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return The average sensor value computed by this function
  */
@@ -273,9 +273,9 @@ int32_t adi_analog_calibrate(uint8_t smart_port, uint8_t adi_port);
  * EADDRINUSE - The port is not configured as an analog input
  *
  * \param smart_port
-	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
-	 * \param adi_port
-	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port
+ *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return The analog sensor value, where a value of 0 reflects an input voltage
  * of nearly 0 V and a value of 4095 reflects an input voltage of nearly 5 V
@@ -296,9 +296,9 @@ int32_t adi_analog_read(uint8_t smart_port, uint8_t adi_port);
  * EADDRINUSE - The port is not configured as an analog input
  *
  * \param smart_port
-	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
-	 * \param adi_port
-	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port
+ *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return The difference of the sensor value from its calibrated default from
  * -4095 to 4095
@@ -324,9 +324,9 @@ int32_t adi_analog_read_calibrated(uint8_t smart_port, uint8_t adi_port);
  * EADDRINUSE - The port is not configured as an analog input
  *
  * \param smart_port
-	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
-	 * \param adi_port
-	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port
+ *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return The difference of the sensor value from its calibrated default from
  * -16384 to 16384
@@ -347,9 +347,9 @@ int32_t adi_analog_read_calibrated_HR(uint8_t smart_port, uint8_t adi_port);
  * EADDRINUSE - The port is not configured as a digital input
  *
  * \param smart_port
-	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
-	 * \param adi_port
-	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port
+ *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return True if the pin is HIGH, or false if it is LOW
  */
@@ -372,9 +372,9 @@ int32_t adi_digital_read(uint8_t smart_port, uint8_t adi_port);
  * EADDRINUSE - The port is not configured as a digital input
  *
  * \param smart_port
-	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
-	 * \param adi_port
-	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port
+ *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return 1 if the button is pressed and had not been pressed
  * the last time this function was called, 0 otherwise.
@@ -392,9 +392,9 @@ int32_t adi_digital_get_new_press(uint8_t smart_port, uint8_t adi_port);
  * EADDRINUSE - The port is not configured as a digital output
  *
  * \param smart_port
-	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
-	 * \param adi_port
-	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port
+ *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  * \param value
  *        An expression evaluating to "true" or "false" to set the output to
  *        HIGH or LOW respectively, or the constants HIGH or LOW themselves
@@ -410,11 +410,11 @@ int32_t adi_digital_write(uint8_t smart_port, uint8_t adi_port, const bool value
  * This function uses the following values of errno when an error state is
  * reached:
  * ENXIO - The given value is not within the range of ADI Ports
- * 
+ *
  *\param smart_port
-	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
-	 * \param adi_port
-	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port
+ *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  * \param mode
  *        One of INPUT, INPUT_ANALOG, INPUT_FLOATING, OUTPUT, or OUTPUT_OD
  *
@@ -430,11 +430,11 @@ int32_t adi_pin_mode(uint8_t smart_port, uint8_t adi_port, uint8_t mode);
  * reached:
  * ENXIO - The given value is not within the range of ADI Ports
  * EADDRINUSE - The port is not configured as an motor
- * 
+ *
  *\param smart_port
-	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
-	 * \param adi_port
-	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port
+ *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  * \param speed
  *        The new signed speed; -127 is full reverse and 127 is full forward,
  *        with 0 being off
@@ -453,9 +453,9 @@ int32_t adi_motor_set(uint8_t smart_port, uint8_t adi_port, int8_t speed);
  * EADDRINUSE - The port is not configured as an motor
  *
  * \param smart_port
-	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
-	 * \param adi_port
-	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port
+ *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return The last set speed of the motor on the given port
  */
@@ -470,9 +470,9 @@ int32_t adi_motor_get(uint8_t smart_port, uint8_t adi_port);
  * EADDRINUSE - The port is not configured as an motor
  *
  * \param smart_port
-	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
-	 * \param adi_port
-	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port
+ *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.
@@ -519,7 +519,7 @@ int32_t adi_encoder_get(adi_encoder_t enc);
  * EADDRINUSE - The port is not configured as an encoder
  *
  * \param smart_port
-*        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
  * \param adi_port_top
  *        The "top" wire from the encoder sensor with the removable cover side
  *        UP
@@ -608,7 +608,7 @@ int32_t adi_ultrasonic_get(adi_ultrasonic_t ult);
  * reached:
  * ENXIO - The given value is not within the range of ADI Ports
  * EADDRINUSE - The port is not configured as an ultrasonic
- * 
+ *
  * \param smart_port
  *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
  * \param adi_port_ping

--- a/include/pros/adi.h
+++ b/include/pros/adi.h
@@ -130,9 +130,10 @@ namespace c {
  * reached:
  * ENXIO - The given value is not within the range of ADI Ports.
  *
- * \param port
- *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') for which to return
- *        the configuration
+ * \param smart_port
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port
+ *	        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return The ADI configuration for the given port
  */
@@ -145,9 +146,10 @@ adi_port_config_e_t adi_port_get_config(uint8_t smart_port, uint8_t adi_port);
  * reached:
  * ENXIO - The given value is not within the range of ADI Ports.
  *
- * \param port
- *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') for which the value
- *        will be returned
+ * \param smart_port
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port
+ *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return The value stored for the given port
  */
@@ -160,7 +162,9 @@ int32_t adi_port_get_value(uint8_t smart_port, uint8_t adi_port);
  * reached:
  * ENXIO - The given value is not within the range of ADI Ports.
  *
- * \param port
+ * \param smart_port
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port
  *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  * \param type
  *        The configuration type for the port
@@ -180,9 +184,10 @@ int32_t adi_port_set_config(uint8_t smart_port, uint8_t adi_port, adi_port_confi
  * reached:
  * ENXIO  - The given value is not within the range of ADI Ports.
  *
- * \param port
- *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') for which the value
- *        will be set
+ * \param smart_port
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port
+ *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  * \param value
  *        The value to set the ADI port to
  *
@@ -247,8 +252,10 @@ int32_t adi_port_set_value(uint8_t smart_port, uint8_t adi_port, int32_t value);
  * reached:
  * ENXIO - The given value is not within the range of ADI Ports
  *
- * \param port
- *        The ADI port to calibrate (from 1-8, 'a'-'h', 'A'-'H')
+ * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
+	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return The average sensor value computed by this function
  */
@@ -265,9 +272,10 @@ int32_t adi_analog_calibrate(uint8_t smart_port, uint8_t adi_port);
  * ENXIO - The given value is not within the range of ADI Ports
  * EADDRINUSE - The port is not configured as an analog input
  *
- * \param port
- *        The ADI port (from 1-8, 'a'-'h', 'A'-'H') for which the value will be
- *        returned
+ * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
+	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return The analog sensor value, where a value of 0 reflects an input voltage
  * of nearly 0 V and a value of 4095 reflects an input voltage of nearly 5 V
@@ -287,9 +295,10 @@ int32_t adi_analog_read(uint8_t smart_port, uint8_t adi_port);
  * ENXIO - The given value is not within the range of ADI Ports
  * EADDRINUSE - The port is not configured as an analog input
  *
- * \param port
- *        The ADI port (from 1-8, 'a'-'h', 'A'-'H') for which the value will be
- *        returned
+ * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
+	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return The difference of the sensor value from its calibrated default from
  * -4095 to 4095
@@ -314,9 +323,10 @@ int32_t adi_analog_read_calibrated(uint8_t smart_port, uint8_t adi_port);
  * ENXIO - The given value is not within the range of ADI Ports
  * EADDRINUSE - The port is not configured as an analog input
  *
- * \param port
- *        The ADI port (from 1-8, 'a'-'h', 'A'-'H') for which the value will be
- *        returned
+ * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
+	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return The difference of the sensor value from its calibrated default from
  * -16384 to 16384
@@ -336,8 +346,10 @@ int32_t adi_analog_read_calibrated_HR(uint8_t smart_port, uint8_t adi_port);
  * ENXIO - The given value is not within the range of ADI Ports
  * EADDRINUSE - The port is not configured as a digital input
  *
- * \param port
- *        The ADI port to read (from 1-8, 'a'-'h', 'A'-'H')
+ * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
+	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return True if the pin is HIGH, or false if it is LOW
  */
@@ -359,8 +371,10 @@ int32_t adi_digital_read(uint8_t smart_port, uint8_t adi_port);
  * ENXIO - The given value is not within the range of ADI Ports
  * EADDRINUSE - The port is not configured as a digital input
  *
- * \param port
- *        The ADI port to read (from 1-8, 'a'-'h', 'A'-'H')
+ * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
+	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return 1 if the button is pressed and had not been pressed
  * the last time this function was called, 0 otherwise.
@@ -377,8 +391,10 @@ int32_t adi_digital_get_new_press(uint8_t smart_port, uint8_t adi_port);
  * ENXIO - The given value is not within the range of ADI Ports
  * EADDRINUSE - The port is not configured as a digital output
  *
- * \param port
- *        The ADI port to read (from 1-8, 'a'-'h', 'A'-'H')
+ * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
+	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  * \param value
  *        An expression evaluating to "true" or "false" to set the output to
  *        HIGH or LOW respectively, or the constants HIGH or LOW themselves
@@ -394,9 +410,11 @@ int32_t adi_digital_write(uint8_t smart_port, uint8_t adi_port, const bool value
  * This function uses the following values of errno when an error state is
  * reached:
  * ENXIO - The given value is not within the range of ADI Ports
- *
- * \param port
- *        The ADI port to read (from 1-8, 'a'-'h', 'A'-'H')
+ * 
+ *\param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
+	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  * \param mode
  *        One of INPUT, INPUT_ANALOG, INPUT_FLOATING, OUTPUT, or OUTPUT_OD
  *
@@ -412,9 +430,11 @@ int32_t adi_pin_mode(uint8_t smart_port, uint8_t adi_port, uint8_t mode);
  * reached:
  * ENXIO - The given value is not within the range of ADI Ports
  * EADDRINUSE - The port is not configured as an motor
- *
- * \param port
- *        The ADI port to set (from 1-8, 'a'-'h', 'A'-'H')
+ * 
+ *\param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
+	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  * \param speed
  *        The new signed speed; -127 is full reverse and 127 is full forward,
  *        with 0 being off
@@ -432,8 +452,10 @@ int32_t adi_motor_set(uint8_t smart_port, uint8_t adi_port, int8_t speed);
  * ENXIO - The given value is not within the range of ADI Ports
  * EADDRINUSE - The port is not configured as an motor
  *
- * \param port
- *        The ADI port to get (from 1-8, 'a'-'h', 'A'-'H')
+ * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
+	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return The last set speed of the motor on the given port
  */
@@ -447,8 +469,10 @@ int32_t adi_motor_get(uint8_t smart_port, uint8_t adi_port);
  * ENXIO - The given value is not within the range of ADI Ports
  * EADDRINUSE - The port is not configured as an motor
  *
- * \param port
- *        The ADI port to set (from 1-8, 'a'-'h', 'A'-'H')
+ * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
+	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
  *
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.
@@ -458,8 +482,9 @@ int32_t adi_motor_stop(uint8_t smart_port, uint8_t adi_port);
 /**
  * Reference type for an initialized encoder.
  *
- * This merely contains the port number for the encoder, unlike its use as an
- * object to store encoder data in PROS 2.
+ * This merely contains the port number for the encoder and the
+ * smart port number for the 3-wire expander (INTERNAL_ADI_PORT for ADI ports on the brain),
+ * unlike its use as an object to store encoder data in PROS 2.
  */
 typedef struct {
 	int32_t smart_port;
@@ -492,12 +517,13 @@ int32_t adi_encoder_get(adi_encoder_t enc);
  * reached:
  * ENXIO - The given value is not within the range of ADI Ports
  * EADDRINUSE - The port is not configured as an encoder
-
  *
- * \param port_top
+ * \param smart_port
+*        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port_top
  *        The "top" wire from the encoder sensor with the removable cover side
  *        UP
- * \param port_bottom
+ * \param adi_port_bottom
  *        The "bottom" wire from the encoder sensor
  * \param reverse
  *        If "true", the sensor will count in the opposite direction
@@ -546,8 +572,9 @@ int32_t adi_encoder_shutdown(adi_encoder_t enc);
 /**
  * Reference type for an initialized ultrasonic.
  *
- * This merely contains the port number for the ultrasonic, unlike its use as an
- * object to store ultrasonic data in PROS 2.
+ * This merely contains the ADI port number for the ultrasonic and the
+ * smart port number for the 3-wire expander (INTERNAL_ADI_PORT for ADI ports
+ * on the brain), unlike its use as an object to store ultrasonic data in PROS 2.
  */
 typedef struct {
 	int32_t smart_port;
@@ -581,11 +608,13 @@ int32_t adi_ultrasonic_get(adi_ultrasonic_t ult);
  * reached:
  * ENXIO - The given value is not within the range of ADI Ports
  * EADDRINUSE - The port is not configured as an ultrasonic
- *
- * \param port_ping
+ * 
+ * \param smart_port
+ *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port_ping
  *        The port connected to the orange OUTPUT cable. This should be in port
  *        1, 3, 5, or 7 ('A', 'C', 'E', 'G').
- * \param port_echo
+ * \param adi_port_echo
  *        The port connected to the yellow INPUT cable. This should be in the
  *        next highest port following port_ping.
  *
@@ -613,8 +642,9 @@ int32_t adi_ultrasonic_shutdown(adi_ultrasonic_t ult);
 /**
  * Reference type for an initialized gyroscope.
  *
- * This merely contains the port number for the gyroscope, unlike its use as an
- * object to store gyro data in PROS 2.
+ * This merely contains the port number and the smart port number for
+ * the 3-wire expander (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * for the gyroscope, unlike its use as an object to store gyro data in PROS 2.
  */
 typedef struct {
 	int32_t smart_port;
@@ -654,7 +684,9 @@ double adi_gyro_get(adi_gyro_t gyro);
  * ENXIO - The given value is not within the range of ADI Ports
  * EADDRINUSE - The port is not configured as a gyro
  *
- * \param port
+ * \param smart_port
+ *         The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+ * \param adi_port
  *        The ADI port to initialize as a gyro (from 1-8, 'a'-'h', 'A'-'H')
  * \param multiplier
  *        A scalar value that will be multiplied by the gyro heading value

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -31,13 +31,15 @@ class ADIPort {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENXIO - The given value is not within the range of ADI Ports
-	 *
-	 * \param port
+	 * 
+	 * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param type
 	 *        The configuration type for the port
 	 */
-	ADIPort(std::uint8_t port, adi_port_config_e_t type = E_ADI_TYPE_UNDEFINED);
+	ADIPort(std::uint8_t smart_port, std::uint8_t adi_port, adi_port_config_e_t type = E_ADI_TYPE_UNDEFINED);
 
 	virtual ~ADIPort(void) = default;
 
@@ -82,7 +84,8 @@ class ADIPort {
 
 	protected:
 	ADIPort(void);
-	std::uint8_t _port;
+	std::uint8_t _adi_port;
+	std::uint8_t _smart_port
 };
 
 class ADIAnalogIn : private ADIPort {
@@ -94,7 +97,9 @@ class ADIAnalogIn : private ADIPort {
 	 * reached:
 	 * ENXIO - The given value is not within the range of ADI Ports
 	 *
-	 * \param port
+	 * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param type
 	 *        The configuration type for the port
@@ -102,7 +107,7 @@ class ADIAnalogIn : private ADIPort {
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 */
-	ADIAnalogIn(std::uint8_t port);
+	ADIAnalogIn(std::uint8_t smart_port, std::uint8_t adi_port);
 
 	/**
 	 * Calibrates the analog sensor on the specified port and returns the new
@@ -198,12 +203,14 @@ class ADIAnalogOut : private ADIPort {
 	 * reached:
 	 * ENXIO - The given value is not within the range of ADI Ports.
 	 *
-	 * \param port
+	 * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param type
 	 *        The configuration type for the port
 	 */
-	ADIAnalogOut(std::uint8_t port);
+	ADIAnalogOut(std::uint8_t smart_port, std::uint8_t adi_port);
 
 	/**
 	 * Sets the value for the given ADI port.
@@ -233,12 +240,14 @@ class ADIDigitalOut : private ADIPort {
 	 * reached:
 	 * ENXIO - The given value is not within the range of ADI Ports.
 	 *
-	 * \param port
+	 * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param type
 	 *        The configuration type for the port
 	 */
-	ADIDigitalOut(std::uint8_t port, bool init_state = LOW);
+	ADIDigitalOut(std::uint8_t smart_port, std::uint8_t adi_port, bool init_state = LOW);
 
 	/**
 	 * Sets the value for the given ADI port.
@@ -268,12 +277,14 @@ class ADIDigitalIn : private ADIPort {
 	 * reached:
 	 * ENXIO - The given value is not within the range of ADI Ports.
 	 *
-	 * \param port
+	 * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param type
 	 *        The configuration type for the port
 	 */
-	ADIDigitalIn(std::uint8_t port);
+	ADIDigitalIn(std::uint8_t smart_port, std::uint8_t adi_port);
 
 	/**
 	 * Gets a rising-edge case for a digital button press.
@@ -318,12 +329,14 @@ class ADIMotor : private ADIPort {
 	 * reached:
 	 * ENXIO - The given value is not within the range of ADI Ports.
 	 *
-	 * \param port
+	 * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param type
 	 *        The configuration type for the port
 	 */
-	ADIMotor(std::uint8_t port);
+	ADIMotor(std::uint8_t smart_port, std::uint8_t adi_port);
 
 	/**
 	 * Stops the motor on the given port.
@@ -373,16 +386,18 @@ class ADIEncoder : private ADIPort {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENXIO - The given value is not within the range of ADI Ports.
-	 *
-	 * \param port_top
-	 *        The "top" wire from the encoder sensor with the removable cover side
+	 * 
+	 * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port_top
+	 *        The "top" ADI wire from the encoder sensor with the removable cover side
 	 *        UP
-	 * \param port_bottom
-	 *        The "bottom" wire from the encoder sensor
+	 * \param adi_port_bottom
+	 *        The "bottom" ADI wire from the encoder sensor
 	 * \param reverse
 	 *        If "true", the sensor will count in the opposite direction
 	 */
-	ADIEncoder(std::uint8_t port_top, std::uint8_t port_bottom, bool reversed = false);
+	ADIEncoder(std::uint8_t smart_port, std::uint8_t adi_port_top, std::uint8_t adi_port_bottom, bool reversed = false);
 
 	/**
 	 * Sets the encoder value to zero.
@@ -423,14 +438,16 @@ class ADIUltrasonic : private ADIPort {
 	 * reached:
 	 * ENXIO - The given value is not within the range of ADI Ports.
 	 *
-	 * \param port_ping
+	 * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port_ping
 	 *        The port connected to the orange OUTPUT cable. This should be in port
 	 *        1, 3, 5, or 7 ('A', 'C', 'E', 'G').
-	 * \param port_echo
+	 * \param adi_port_echo
 	 *        The port connected to the yellow INPUT cable. This should be in the
 	 *        next highest port following port_ping.
 	 */
-	ADIUltrasonic(std::uint8_t port_ping, std::uint8_t port_echo);
+	ADIUltrasonic(std::uint8_t smart_port, std::uint8_t adi_port_ping, std::uint8_t adi_port_echo);
 
 	/**
 	 * Gets the current ultrasonic sensor value in centimeters.
@@ -466,13 +483,15 @@ class ADIGyro : private ADIPort {
 	 * reached:
 	 * ENXIO - The given value is not within the range of ADI Ports
 	 *
-	 * \param port
-	 *        The ADI port to initialize as a gyro (from 1-8, 'a'-'h', 'A'-'H')
+	 * \param smart_port
+	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
+	 * \param adi_port
+	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param multiplier
 	 *        A scalar value that will be multiplied by the gyro heading value
 	 *        supplied by the ADI
 	 */
-	ADIGyro(std::uint8_t port, double multiplier = 1);
+	ADIGyro(std::uint8_t smart_port, std::uint8_t adi_port, double multiplier = 1);
 
 	/**
 	 * Gets the current gyro angle in tenths of a degree. Unless a multiplier is

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -18,9 +18,9 @@
 #ifndef _PROS_ADI_HPP_
 #define _PROS_ADI_HPP_
 
-#include "pros/adi.h"
-
 #include <cstdint>
+
+#include "pros/adi.h"
 
 namespace pros {
 class ADIPort {
@@ -31,7 +31,7 @@ class ADIPort {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENXIO - The given value is not within the range of ADI Ports
-	 * 
+	 *
 	 * \param smart_port
 	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
 	 * \param adi_port
@@ -386,7 +386,7 @@ class ADIEncoder : private ADIPort {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENXIO - The given value is not within the range of ADI Ports.
-	 * 
+	 *
 	 * \param smart_port
 	 *        The smart port number that the ADI Expander is on (INTERNAL_ADI_PORT for ADI ports on the brain)
 	 * \param adi_port_top

--- a/src/devices/vdml_adi.c
+++ b/src/devices/vdml_adi.c
@@ -37,7 +37,7 @@ typedef union adi_data {
 	struct {
 		bool was_pressed;
 	} digital_data;
-	struct {
+	struct {;
 		bool reversed;
 	} encoder_data;
 	struct __attribute__((packed)) {
@@ -91,123 +91,123 @@ typedef union adi_data {
 		return PROS_ERR;                            \
 	}
 
-adi_port_config_e_t adi_port_get_config(uint8_t port) {
-	transform_adi_port(port);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	adi_port_config_e_t rtn = (adi_port_config_e_t)vexDeviceAdiPortConfigGet(device->device_info, port);
-	return_port(INTERNAL_ADI_PORT, rtn);
+adi_port_config_e_t adi_port_get_config(uint8_t smart_port, uint8_t adi_port) {
+	transform_adi_port(adi_port);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI);
+	adi_port_config_e_t rtn = (adi_port_config_e_t)vexDeviceAdiPortConfigGet(device->device_info, adi_port);
+	return_port(smart_port - 1, rtn);
 }
 
-int32_t adi_port_get_value(uint8_t port) {
-	transform_adi_port(port);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	int32_t rtn = vexDeviceAdiValueGet(device->device_info, port);
-	return_port(INTERNAL_ADI_PORT, rtn);
+int32_t adi_port_get_value(uint8_t smart_port, uint8_t adi_port) {
+	transform_adi_port(adi_port);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI);
+	int32_t rtn = vexDeviceAdiValueGet(device->device_info, adi_port);
+	return_port(smart_port - 1, rtn);
 }
 
-int32_t adi_port_set_config(uint8_t port, adi_port_config_e_t type) {
-	transform_adi_port(port);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	vexDeviceAdiPortConfigSet(device->device_info, port, (V5_AdiPortConfiguration)type);
-	return_port(INTERNAL_ADI_PORT, 1);
+int32_t adi_port_set_config(uint8_t smart_port, uint8_t adi_port, adi_port_config_e_t type) {
+	transform_adi_port(adi_port);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI);
+	vexDeviceAdiPortConfigSet(device->device_info, adi_port, (V5_AdiPortConfiguration)type);
+	return_port(smart_port - 1, 1);
 }
 
-int32_t adi_port_set_value(uint8_t port, int32_t value) {
-	transform_adi_port(port);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	vexDeviceAdiValueSet(device->device_info, port, value);
-	return_port(INTERNAL_ADI_PORT, 1);
+int32_t adi_port_set_value(uint8_t smart_port, uint8_t adi_port, int32_t value) {
+	transform_adi_port(adi_port);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI);
+	vexDeviceAdiValueSet(device->device_info, adi_port, value);
+	return_port(smart_port - 1, 1);
 }
 
-int32_t adi_analog_calibrate(uint8_t port) {
-	transform_adi_port(port);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_type(device, port, E_ADI_ANALOG_IN);
+int32_t adi_analog_calibrate(uint8_t smart_port, uint8_t adi_port) {
+	transform_adi_port(adi_port);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI);
+	validate_type(device, adi_port, E_ADI_ANALOG_IN);
 	uint32_t total = 0;
 	for (uint32_t i = 0; i < 512; i++) {
-		total += vexDeviceAdiValueGet(device->device_info, port);
+		total += vexDeviceAdiValueGet(device->device_info, adi_port);
 		task_delay(1); // TODO: If smart ports (and the ADI) only update every 10ms, this really only reads 56 samples, maybe change to a 10ms
 	}
-	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[port];
+	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[adi_port];
 	adi_data->analog_data.calib = (int32_t)((total + 16) >> 5);
-	return_port(INTERNAL_ADI_PORT, (int32_t)((total + 256) >> 9));
+	return_port(smart_port - 1, (int32_t)((total + 256) >> 9));
 }
 
-int32_t adi_analog_read(uint8_t port) {
-	transform_adi_port(port);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_type(device, port, E_ADI_ANALOG_IN);
-	int32_t rtn = vexDeviceAdiValueGet(device->device_info, port);
-	return_port(INTERNAL_ADI_PORT, rtn);
+int32_t adi_analog_read(uint8_t smart_port, uint8_t adi_port) {
+	transform_adi_port(adi_port);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI);
+	validate_type(device, adi_port, E_ADI_ANALOG_IN);
+	int32_t rtn = vexDeviceAdiValueGet(device->device_info, adi_port);
+	return_port(smart_port - 1, rtn);
 }
 
-int32_t adi_analog_read_calibrated(uint8_t port) {
-	transform_adi_port(port);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_type(device, port, E_ADI_ANALOG_IN);
-	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[port];
-	int32_t rtn = (vexDeviceAdiValueGet(device->device_info, port) - (adi_data->analog_data.calib >> 4));
-	return_port(INTERNAL_ADI_PORT, rtn);
+int32_t adi_analog_read_calibrated(uint8_t smart_port, uint8_t adi_port) {
+	transform_adi_port(adi_port);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI);
+	validate_type(device, adi_port, E_ADI_ANALOG_IN);
+	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[adi_port];
+	int32_t rtn = (vexDeviceAdiValueGet(device->device_info, adi_port) - (adi_data->analog_data.calib >> 4));
+	return_port(smart_port - 1, rtn);
 }
 
-int32_t adi_analog_read_calibrated_HR(uint8_t port) {
-	transform_adi_port(port);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_type(device, port, E_ADI_ANALOG_IN);
-	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[port];
-	int32_t rtn = ((vexDeviceAdiValueGet(device->device_info, port) << 4) - adi_data->analog_data.calib);
-	return_port(INTERNAL_ADI_PORT, rtn);
+int32_t adi_analog_read_calibrated_HR(uint8_t smart_port, uint8_t adi_port) {
+	transform_adi_port(adi_port);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI);
+	validate_type(device, adi_port, E_ADI_ANALOG_IN);
+	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[adi_port];
+	int32_t rtn = ((vexDeviceAdiValueGet(device->device_info, adi_port) << 4) - adi_data->analog_data.calib);
+	return_port(smart_port - 1, rtn);
 }
 
-int32_t adi_digital_read(uint8_t port) {
-	transform_adi_port(port);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_type(device, port, E_ADI_DIGITAL_IN);
-	int32_t rtn = vexDeviceAdiValueGet(device->device_info, port);
-	return_port(INTERNAL_ADI_PORT, rtn);
+int32_t adi_digital_read(uint8_t smart_port, uint8_t adi_port) {
+	transform_adi_port(adi_port);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI);
+	validate_type(device, adi_port, E_ADI_DIGITAL_IN);
+	int32_t rtn = vexDeviceAdiValueGet(device->device_info, adi_port);
+	return_port(smart_port - 1, rtn);
 }
 
-int32_t adi_digital_get_new_press(uint8_t port) {
-	transform_adi_port(port);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_type(device, port, E_ADI_DIGITAL_IN);
+int32_t adi_digital_get_new_press(uint8_t smart_port, uint8_t adi_port) {
+	transform_adi_port(adi_port);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI);
+	validate_type(device, adi_port, E_ADI_DIGITAL_IN);
 
-	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[port];
+	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[adi_port];
 
-	int32_t pressed = vexDeviceAdiValueGet(device->device_info, port);
+	int32_t pressed = vexDeviceAdiValueGet(device->device_info, adi_port);
 
 	if (!pressed)
 		adi_data->digital_data.was_pressed = false;
 	else if (!adi_data->digital_data.was_pressed) {
 		// Button is currently pressed and was not detected as being pressed during last check
 		adi_data->digital_data.was_pressed = true;
-		return_port(INTERNAL_ADI_PORT, true);
+		return_port(smart_port - 1, true);
 	}
 
-	return_port(INTERNAL_ADI_PORT, false);
+	return_port(smart_port - 1, false);
 }
 
-int32_t adi_digital_write(uint8_t port, const bool value) {
-	transform_adi_port(port);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_type(device, port, E_ADI_DIGITAL_OUT);
-	vexDeviceAdiValueSet(device->device_info, port, (int32_t)value);
-	return_port(INTERNAL_ADI_PORT, 1);
+int32_t adi_digital_write(uint8_t smart_port, uint8_t adi_port, const bool value) {
+	transform_adi_port(adi_port);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI);
+	validate_type(device, adi_port, E_ADI_DIGITAL_OUT);
+	vexDeviceAdiValueSet(device->device_info, adi_port, (int32_t)value);
+	return_port(smart_port, 1);
 }
 
-int32_t adi_pin_mode(uint8_t port, uint8_t mode) {
+int32_t adi_pin_mode(uint8_t smart_port, uint8_t adi_port, uint8_t mode) {
 	switch (mode) {
 		case INPUT:
-			adi_port_set_config(port, E_ADI_DIGITAL_IN);
+			adi_port_set_config(smart_port, adi_port, E_ADI_DIGITAL_IN);
 			break;
 		case OUTPUT:
-			adi_port_set_config(port, E_ADI_DIGITAL_OUT);
+			adi_port_set_config(smart_port, adi_port, E_ADI_DIGITAL_OUT);
 			break;
 		case INPUT_ANALOG:
-			adi_port_set_config(port, E_ADI_ANALOG_IN);
+			adi_port_set_config(smart_port, adi_port, E_ADI_ANALOG_IN);
 			break;
 		case OUTPUT_ANALOG:
-			adi_port_set_config(port, E_ADI_ANALOG_OUT);
+			adi_port_set_config(smart_port, adi_port, E_ADI_ANALOG_OUT);
 			break;
 		default:
 			errno = EINVAL;
@@ -216,120 +216,120 @@ int32_t adi_pin_mode(uint8_t port, uint8_t mode) {
 	return 1;
 }
 
-int32_t adi_motor_set(uint8_t port, int8_t speed) {
-	transform_adi_port(port);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_motor(device, port);
+int32_t adi_motor_set(uint8_t smart_port, uint8_t adi_port, int8_t speed) {
+	transform_adi_port(adi_port);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI);
+	validate_motor(device, adi_port);
 	if (speed > ADI_MOTOR_MAX_SPEED)
 		speed = ADI_MOTOR_MAX_SPEED;
 	else if (speed < ADI_MOTOR_MIN_SPEED)
 		speed = ADI_MOTOR_MIN_SPEED;
-	vexDeviceAdiValueSet(device->device_info, port, speed);
-	return_port(INTERNAL_ADI_PORT, 1);
+	vexDeviceAdiValueSet(device->device_info, adi_port, speed);
+	return_port(smart_port - 1, 1);
 }
 
-int32_t adi_motor_get(uint8_t port) {
-	transform_adi_port(port);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_motor(device, port);
-	int32_t rtn = vexDeviceAdiValueGet(device->device_info, port) - ADI_MOTOR_MAX_SPEED;
-	return_port(INTERNAL_ADI_PORT, rtn);
+int32_t adi_motor_get(uint8_t smart_port, uint8_t adi_port) {
+	transform_adi_port(adi_port);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI);
+	validate_motor(device, adi_port);
+	int32_t rtn = vexDeviceAdiValueGet(device->device_info, adi_port) - ADI_MOTOR_MAX_SPEED;
+	return_port(smart_port - 1, rtn);
 }
 
-int32_t adi_motor_stop(uint8_t port) {
-	return adi_motor_set(port, 0);
+int32_t adi_motor_stop(uint8_t smart_port, uint8_t adi_port) {
+	return adi_motor_set(smart_port, adi_port, 0);
 }
 
-adi_encoder_t adi_encoder_init(uint8_t port_top, uint8_t port_bottom, const bool reverse) {
-	transform_adi_port(port_top);
-	transform_adi_port(port_bottom);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_twowire(port_top, port_bottom);
+adi_encoder_t adi_encoder_init(uint8_t smart_port, uint8_t adi_port_top, uint8_t adi_port_bottom, const bool reverse) {
+	transform_adi_port(adi_port_top);
+	transform_adi_port(adi_port_bottom);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI);
+	validate_twowire(adi_port_top, adi_port_bottom);
 
 	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[port];
 	adi_data->encoder_data.reversed = reverse;
 	vexDeviceAdiPortConfigSet(device->device_info, port, E_ADI_LEGACY_ENCODER);
-	return_port(INTERNAL_ADI_PORT, port + 1);
+	return_port(smart_port - 1, (adi_encoder_t){smart_port, port + 1});
 }
 
 int32_t adi_encoder_get(adi_encoder_t enc) {
-	transform_adi_port(enc);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_type(device, enc, E_ADI_LEGACY_ENCODER);
+	transform_adi_port(enc.adi_port);
+	claim_port_i(enc.smart_port - 1, E_DEVICE_ADI);
+	validate_type(device, enc.adi_port, E_ADI_LEGACY_ENCODER);
 	
 	int32_t rtn;
-	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[enc];
-	if (adi_data->encoder_data.reversed) rtn = -vexDeviceAdiValueGet(device->device_info, enc);
-	else rtn = vexDeviceAdiValueGet(device->device_info, enc);
-	return_port(INTERNAL_ADI_PORT, rtn);
+	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[enc.adi_port];
+	if (adi_data->encoder_data.reversed) rtn = -vexDeviceAdiValueGet(device->device_info, enc.adi_port);
+	else rtn = vexDeviceAdiValueGet(device->device_info, enc.adi_port);
+	return_port(enc.smart_port - 1, rtn);
 }
 
 int32_t adi_encoder_reset(adi_encoder_t enc) {
-	transform_adi_port(enc);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_type(device, enc, E_ADI_LEGACY_ENCODER);
+	transform_adi_port(enc.adi_port);
+	claim_port_i(enc.smart_port - 1, E_DEVICE_ADI);
+	validate_type(device, enc.adi_port, E_ADI_LEGACY_ENCODER);
 	
-	vexDeviceAdiValueSet(device->device_info, enc, 0);
-	return_port(INTERNAL_ADI_PORT, 1);
+	vexDeviceAdiValueSet(device->device_info, enc.adi_port, 0);
+	return_port(enc.smart_port - 1, 1);
 }
 
 int32_t adi_encoder_shutdown(adi_encoder_t enc) {
-	transform_adi_port(enc);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_type(device, enc, E_ADI_LEGACY_ENCODER);
+	transform_adi_port(enc.adi_port);
+	claim_port_i(enc.smart_port - 1, E_DEVICE_ADI);
+	validate_type(device, enc.adi_port, E_ADI_LEGACY_ENCODER);
 
-	vexDeviceAdiPortConfigSet(device->device_info, enc, E_ADI_TYPE_UNDEFINED);
-	return_port(INTERNAL_ADI_PORT, 1);
+	vexDeviceAdiPortConfigSet(device->device_info, enc.adi_port, E_ADI_TYPE_UNDEFINED);
+	return_port(enc.smart_port - 1, 1);
 }
 
-adi_ultrasonic_t adi_ultrasonic_init(uint8_t port_ping, uint8_t port_echo) {
-	transform_adi_port(port_ping);
-	transform_adi_port(port_echo);
-	validate_twowire(port_ping, port_echo);
-	if (port != port_ping) {
+adi_ultrasonic_t adi_ultrasonic_init(uint8_t smart_port, uint8_t adi_port_ping, uint8_t adi_port_echo) {
+	transform_adi_port(adi_port_ping);
+	transform_adi_port(adi_port_echo);
+	validate_twowire(adi_port_ping, adi_port_echo);
+	if (port != adi_port_ping) {
 		errno = EINVAL;
 		return PROS_ERR;
 	}
 
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI);
 	vexDeviceAdiPortConfigSet(device->device_info, port, E_ADI_LEGACY_ULTRASONIC);
-	return_port(INTERNAL_ADI_PORT, port + 1);
+	return_port(smart_port - 1, (adi_ultrasonic_t){smart_port - 1, port + 1});
 }
 
 int32_t adi_ultrasonic_get(adi_ultrasonic_t ult) {
-	transform_adi_port(ult);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_type(device, ult, E_ADI_LEGACY_ULTRASONIC);
+	transform_adi_port(ult.adi_port);
+	claim_port_i(ult.smart_port - 1, E_DEVICE_ADI);
+	validate_type(device, ult.adi_port, E_ADI_LEGACY_ULTRASONIC);
 	
-	int32_t rtn = vexDeviceAdiValueGet(device->device_info, ult);
-	return_port(ult, rtn);
+	int32_t rtn = vexDeviceAdiValueGet(device->device_info, ult.adi_port);
+	return_port(ult.smart_port - 1, rtn);
 }
 
 int32_t adi_ultrasonic_shutdown(adi_ultrasonic_t ult) {
-	transform_adi_port(ult);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_type(device, ult, E_ADI_LEGACY_ULTRASONIC);
+	transform_adi_port(ult.adi_port);
+	claim_port_i(ult.smart_port - 1, E_DEVICE_ADI);
+	validate_type(device, ult.adi_port, E_ADI_LEGACY_ULTRASONIC);
 
-	vexDeviceAdiPortConfigSet(device->device_info, ult, E_ADI_TYPE_UNDEFINED);
-	return_port(INTERNAL_ADI_PORT, 1);
+	vexDeviceAdiPortConfigSet(device->device_info, ult.adi_port, E_ADI_TYPE_UNDEFINED);
+	return_port(ult.smart_port - 1, 1);
 }
 
-adi_gyro_t adi_gyro_init(uint8_t port, double multiplier) {
-	transform_adi_port(port);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
+adi_gyro_t adi_gyro_init(uint8_t smart_port, uint8_t adi_port, double multiplier) {
+	transform_adi_port(adi_port);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI);
 
 	if (multiplier == 0) multiplier = 1;
-	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[port];
+	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[adi_port];
 	adi_data->gyro_data.multiplier = multiplier;
 	adi_data->gyro_data.tare_value = 0;
 
-	adi_port_config_e_t config = vexDeviceAdiPortConfigGet(device->device_info, port);
+	adi_port_config_e_t config = vexDeviceAdiPortConfigGet(device->device_info, adi_port);
 	if (config == E_ADI_LEGACY_GYRO) {
 		// Port has already been calibrated, no need to do that again
-		return_port(INTERNAL_ADI_PORT, port + 1);
+		return_port(smart_port - 1, adi_port + 1);
 	}
 
-	vexDeviceAdiPortConfigSet(device->device_info, port, E_ADI_LEGACY_GYRO);
+	vexDeviceAdiPortConfigSet(device->device_info, adi_port, E_ADI_LEGACY_GYRO);
 	if (xTaskGetSchedulerState() == taskSCHEDULER_RUNNING) {
 		// If the scheduler is currently running (meaning that this is not called
 		// from a global constructor, for example) then delay for the duration of
@@ -337,21 +337,21 @@ adi_gyro_t adi_gyro_init(uint8_t port, double multiplier) {
 		delay(GYRO_CALIBRATION_TIME);
 	}
 
-	return_port(INTERNAL_ADI_PORT, port + 1);
+	return_port(smart_port - 1, (adi_gyro_t){smart_port - 1, adi_port + 1});
 }
 
 // Internal wrapper for adi_gyro_get to get around transform_adi_port, claim_port_i, validate_type and return_port possibly returning PROS_ERR, not PROS_ERR_F
 int32_t _adi_gyro_get(adi_gyro_t gyro, double* out) {
-	transform_adi_port(gyro);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_type(device, gyro, E_ADI_LEGACY_GYRO);
+	transform_adi_port(gyro.adi_port);
+	claim_port_i(gyro.smart_port - 1, E_DEVICE_ADI);
+	validate_type(device, gyro.adi_port, E_ADI_LEGACY_GYRO);
 
-	double rtn = (double)vexDeviceAdiValueGet(device->device_info, gyro);
-	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[gyro];
+	double rtn = (double)vexDeviceAdiValueGet(device->device_info, gyro.adi_port);
+	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[gyro.adi_port];
 	rtn -= adi_data->gyro_data.tare_value;
 	rtn *= adi_data->gyro_data.multiplier;
 	*out = rtn;
-	return_port(INTERNAL_ADI_PORT, 1);
+	return_port(gyro_smart_port - 1, 1);
 }
 
 double adi_gyro_get(adi_gyro_t gyro) {
@@ -361,20 +361,20 @@ double adi_gyro_get(adi_gyro_t gyro) {
 }
 
 int32_t adi_gyro_reset(adi_gyro_t gyro) {
-	transform_adi_port(gyro);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_type(device, gyro, E_ADI_LEGACY_GYRO);
+	transform_adi_port(gyro.adi_port);
+	claim_port_i(gyro.smart_port - 1, E_DEVICE_ADI);
+	validate_type(device, gyro.adi_port, E_ADI_LEGACY_GYRO);
 
-	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[gyro];
-	adi_data->gyro_data.tare_value = vexDeviceAdiValueGet(device->device_info, gyro);
-	return_port(INTERNAL_ADI_PORT, 1);
+	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[gyro.adi_port];
+	adi_data->gyro_data.tare_value = vexDeviceAdiValueGet(device->device_info, gyro.adi_port);
+	return_port(gyro.smart_port - 1, 1);
 }
 
 int32_t adi_gyro_shutdown(adi_gyro_t gyro) {
-	transform_adi_port(gyro);
-	claim_port_i(INTERNAL_ADI_PORT, E_DEVICE_ADI);
-	validate_type(device, gyro, E_ADI_LEGACY_GYRO);
+	transform_adi_port(gyro.adi_port);
+	claim_port_i(gyro.smart_port - 1, E_DEVICE_ADI);
+	validate_type(device, gyro.adi_port, E_ADI_LEGACY_GYRO);
 
-	vexDeviceAdiPortConfigSet(device->device_info, gyro, E_ADI_TYPE_UNDEFINED);
-	return_port(INTERNAL_ADI_PORT, 1);
+	vexDeviceAdiPortConfigSet(device->device_info, gyro.adi_port, E_ADI_TYPE_UNDEFINED);
+	return_port(gyro.smart_port - 1, 1);
 }

--- a/src/devices/vdml_adi.c
+++ b/src/devices/vdml_adi.c
@@ -37,7 +37,8 @@ typedef union adi_data {
 	struct {
 		bool was_pressed;
 	} digital_data;
-	struct {;
+	struct {
+		;
 		bool reversed;
 	} encoder_data;
 	struct __attribute__((packed)) {
@@ -126,7 +127,8 @@ int32_t adi_analog_calibrate(uint8_t smart_port, uint8_t adi_port) {
 	uint32_t total = 0;
 	for (uint32_t i = 0; i < 512; i++) {
 		total += vexDeviceAdiValueGet(device->device_info, adi_port);
-		task_delay(1); // TODO: If smart ports (and the ADI) only update every 10ms, this really only reads 56 samples, maybe change to a 10ms
+		task_delay(1);  // TODO: If smart ports (and the ADI) only update every 10ms, this really only reads 56 samples,
+		                // maybe change to a 10ms
 	}
 	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[adi_port];
 	adi_data->analog_data.calib = (int32_t)((total + 16) >> 5);
@@ -256,11 +258,13 @@ int32_t adi_encoder_get(adi_encoder_t enc) {
 	transform_adi_port(enc.adi_port);
 	claim_port_i(enc.smart_port - 1, E_DEVICE_ADI);
 	validate_type(device, enc.adi_port, E_ADI_LEGACY_ENCODER);
-	
+
 	int32_t rtn;
 	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[enc.adi_port];
-	if (adi_data->encoder_data.reversed) rtn = -vexDeviceAdiValueGet(device->device_info, enc.adi_port);
-	else rtn = vexDeviceAdiValueGet(device->device_info, enc.adi_port);
+	if (adi_data->encoder_data.reversed)
+		rtn = -vexDeviceAdiValueGet(device->device_info, enc.adi_port);
+	else
+		rtn = vexDeviceAdiValueGet(device->device_info, enc.adi_port);
 	return_port(enc.smart_port - 1, rtn);
 }
 
@@ -268,7 +272,7 @@ int32_t adi_encoder_reset(adi_encoder_t enc) {
 	transform_adi_port(enc.adi_port);
 	claim_port_i(enc.smart_port - 1, E_DEVICE_ADI);
 	validate_type(device, enc.adi_port, E_ADI_LEGACY_ENCODER);
-	
+
 	vexDeviceAdiValueSet(device->device_info, enc.adi_port, 0);
 	return_port(enc.smart_port - 1, 1);
 }
@@ -300,7 +304,7 @@ int32_t adi_ultrasonic_get(adi_ultrasonic_t ult) {
 	transform_adi_port(ult.adi_port);
 	claim_port_i(ult.smart_port - 1, E_DEVICE_ADI);
 	validate_type(device, ult.adi_port, E_ADI_LEGACY_ULTRASONIC);
-	
+
 	int32_t rtn = vexDeviceAdiValueGet(device->device_info, ult.adi_port);
 	return_port(ult.smart_port - 1, rtn);
 }
@@ -340,7 +344,8 @@ adi_gyro_t adi_gyro_init(uint8_t smart_port, uint8_t adi_port, double multiplier
 	return_port(smart_port - 1, (adi_gyro_t){smart_port - 1, adi_port + 1});
 }
 
-// Internal wrapper for adi_gyro_get to get around transform_adi_port, claim_port_i, validate_type and return_port possibly returning PROS_ERR, not PROS_ERR_F
+// Internal wrapper for adi_gyro_get to get around transform_adi_port, claim_port_i, validate_type and return_port
+// possibly returning PROS_ERR, not PROS_ERR_F
 int32_t _adi_gyro_get(adi_gyro_t gyro, double* out) {
 	transform_adi_port(gyro.adi_port);
 	claim_port_i(gyro.smart_port - 1, E_DEVICE_ADI);
@@ -356,8 +361,10 @@ int32_t _adi_gyro_get(adi_gyro_t gyro, double* out) {
 
 double adi_gyro_get(adi_gyro_t gyro) {
 	double rtn;
-	if (_adi_gyro_get(gyro, &rtn) == PROS_ERR) return PROS_ERR_F;
-	else return rtn;
+	if (_adi_gyro_get(gyro, &rtn) == PROS_ERR)
+		return PROS_ERR_F;
+	else
+		return rtn;
 }
 
 int32_t adi_gyro_reset(adi_gyro_t gyro) {

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -16,7 +16,8 @@
 namespace pros {
 using namespace pros::c;
 
-ADIPort::ADIPort(std::uint8_t smart_port, std::uint8_t adi_port, adi_port_config_e_t type) : _smart_port(smart_port), _adi_port(adi_port) {
+ADIPort::ADIPort(std::uint8_t smart_port, std::uint8_t adi_port, adi_port_config_e_t type)
+    : _smart_port(smart_port), _adi_port(adi_port) {
 	adi_port_set_config(_smart_port, _adi_port, type);
 }
 
@@ -40,9 +41,11 @@ std::int32_t ADIPort::get_value(void) const {
 	return adi_port_get_value(_smart_port, _adi_port);
 }
 
-ADIAnalogIn::ADIAnalogIn(std::uint8_t smart_port, std::uint8_t adi_port) : ADIPort(smart_port, adi_port, E_ADI_ANALOG_IN) {}
+ADIAnalogIn::ADIAnalogIn(std::uint8_t smart_port, std::uint8_t adi_port)
+    : ADIPort(smart_port, adi_port, E_ADI_ANALOG_IN) {}
 
-ADIAnalogOut::ADIAnalogOut(std::uint8_t smart_port, std::uint8_t adi_port) : ADIPort(smart_port, adi_port, E_ADI_ANALOG_OUT) {}
+ADIAnalogOut::ADIAnalogOut(std::uint8_t smart_port, std::uint8_t adi_port)
+    : ADIPort(smart_port, adi_port, E_ADI_ANALOG_OUT) {}
 
 std::int32_t ADIAnalogIn::calibrate(void) const {
 	return adi_analog_calibrate(_smart_port, _adi_port);
@@ -56,11 +59,13 @@ std::int32_t ADIAnalogIn::get_value_calibrated_HR(void) const {
 	return adi_analog_read_calibrated_HR(_smart_port, _adi_port);
 }
 
-ADIDigitalOut::ADIDigitalOut(std::uint8_t smart_port, std::uint8_t adi_port, bool init_state) : ADIPort(smart_port, adi_port, E_ADI_DIGITAL_OUT) {
+ADIDigitalOut::ADIDigitalOut(std::uint8_t smart_port, std::uint8_t adi_port, bool init_state)
+    : ADIPort(smart_port, adi_port, E_ADI_DIGITAL_OUT) {
 	set_value(init_state);
 }
 
-ADIDigitalIn::ADIDigitalIn(std::uint8_t smart_port, std::uint8_t adi_port) : ADIPort(smart_port, adi_port, E_ADI_DIGITAL_IN) {}
+ADIDigitalIn::ADIDigitalIn(std::uint8_t smart_port, std::uint8_t adi_port)
+    : ADIPort(smart_port, adi_port, E_ADI_DIGITAL_IN) {}
 
 std::int32_t ADIDigitalIn::get_new_press(void) const {
 	return adi_digital_get_new_press(_smart_port, _adi_port);
@@ -74,7 +79,8 @@ std::int32_t ADIMotor::stop(void) const {
 	return adi_motor_stop(_smart_port, _adi_port);
 }
 
-ADIEncoder::ADIEncoder(std::uint8_t smart_port, std::uint8_t adi_port_top, std::uint8_t adi_port_bottom, bool reversed) {
+ADIEncoder::ADIEncoder(std::uint8_t smart_port, std::uint8_t adi_port_top, std::uint8_t adi_port_bottom,
+                       bool reversed) {
 	_port = adi_encoder_init(smart_port, adi_port_top, adi_port_bottom, reversed);
 }
 

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -16,8 +16,8 @@
 namespace pros {
 using namespace pros::c;
 
-ADIPort::ADIPort(std::uint8_t port, adi_port_config_e_t type) : _port(port) {
-	adi_port_set_config(_port, type);
+ADIPort::ADIPort(std::uint8_t smart_port, std::uint8_t adi_port, adi_port_config_e_t type) : _smart_port(smart_port), _adi_port(adi_port) {
+	adi_port_set_config(_smart_port, _adi_port, type);
 }
 
 ADIPort::ADIPort(void) {
@@ -25,80 +25,80 @@ ADIPort::ADIPort(void) {
 }
 
 std::int32_t ADIPort::set_config(adi_port_config_e_t type) const {
-	return adi_port_set_config(_port, type);
+	return adi_port_set_config(_smart_port, _adi_port, type);
 }
 
 std::int32_t ADIPort::get_config(void) const {
-	return adi_port_get_config(_port);
+	return adi_port_get_config(_smart_port, _adi_port);
 }
 
 std::int32_t ADIPort::set_value(std::int32_t value) const {
-	return adi_port_set_value(_port, value);
+	return adi_port_set_value(_smart_port, _adi_port, value);
 }
 
 std::int32_t ADIPort::get_value(void) const {
-	return adi_port_get_value(_port);
+	return adi_port_get_value(_smart_port, _adi_port);
 }
 
-ADIAnalogIn::ADIAnalogIn(std::uint8_t port) : ADIPort(port, E_ADI_ANALOG_IN) {}
+ADIAnalogIn::ADIAnalogIn(std::uint8_t smart_port, std::uint8_t adi_port) : ADIPort(smart_port, adi_port, E_ADI_ANALOG_IN) {}
 
-ADIAnalogOut::ADIAnalogOut(std::uint8_t port) : ADIPort(port, E_ADI_ANALOG_OUT) {}
+ADIAnalogOut::ADIAnalogOut(std::uint8_t smart_port, std::uint8_t adi_port) : ADIPort(smart_port, adi_port, E_ADI_ANALOG_OUT) {}
 
 std::int32_t ADIAnalogIn::calibrate(void) const {
-	return adi_analog_calibrate(_port);
+	return adi_analog_calibrate(_smart_port, _adi_port);
 }
 
 std::int32_t ADIAnalogIn::get_value_calibrated(void) const {
-	return adi_analog_read_calibrated(_port);
+	return adi_analog_read_calibrated(_smart_port, _adi_port);
 }
 
 std::int32_t ADIAnalogIn::get_value_calibrated_HR(void) const {
-	return adi_analog_read_calibrated_HR(_port);
+	return adi_analog_read_calibrated_HR(_smart_port, _adi_port);
 }
 
-ADIDigitalOut::ADIDigitalOut(std::uint8_t port, bool init_state) : ADIPort(port, E_ADI_DIGITAL_OUT) {
+ADIDigitalOut::ADIDigitalOut(std::uint8_t smart_port, std::uint8_t adi_port, bool init_state) : ADIPort(smart_port, adi_port, E_ADI_DIGITAL_OUT) {
 	set_value(init_state);
 }
 
-ADIDigitalIn::ADIDigitalIn(std::uint8_t port) : ADIPort(port, E_ADI_DIGITAL_IN) {}
+ADIDigitalIn::ADIDigitalIn(std::uint8_t smart_port, std::uint8_t adi_port) : ADIPort(smart_port, adi_port, E_ADI_DIGITAL_IN) {}
 
 std::int32_t ADIDigitalIn::get_new_press(void) const {
-	return adi_digital_get_new_press(_port);
+	return adi_digital_get_new_press(_smart_port, _adi_port);
 }
 
-ADIMotor::ADIMotor(std::uint8_t port) : ADIPort(port, E_ADI_LEGACY_PWM) {
+ADIMotor::ADIMotor(std::uint8_t smart_port, std::uint8_t adi_port) : ADIPort(smart_port, adi_port, E_ADI_LEGACY_PWM) {
 	stop();
 }
 
 std::int32_t ADIMotor::stop(void) const {
-	return adi_motor_stop(_port);
+	return adi_motor_stop(_smart_port, _adi_port);
 }
 
-ADIEncoder::ADIEncoder(std::uint8_t port_top, std::uint8_t port_bottom, bool reversed) {
-	_port = adi_encoder_init(port_top, port_bottom, reversed);
+ADIEncoder::ADIEncoder(std::uint8_t smart_port, std::uint8_t adi_port_top, std::uint8_t adi_port_bottom, bool reversed) {
+	_port = adi_encoder_init(smart_port, adi_port_top, adi_port_bottom, reversed);
 }
 
 std::int32_t ADIEncoder::reset(void) const {
-	return adi_encoder_reset(_port);
+	return adi_encoder_reset(_smart_port, _adi_port);
 }
 
 std::int32_t ADIEncoder::get_value(void) const {
-	return adi_encoder_get(_port);
+	return adi_encoder_get(_smart_port, _adi_port);
 }
 
-ADIUltrasonic::ADIUltrasonic(std::uint8_t port_ping, std::uint8_t port_echo) {
-	_port = adi_ultrasonic_init(port_ping, port_echo);
+ADIUltrasonic::ADIUltrasonic(std::uint8_t smart_port, std::uint8_t adi_port_ping, std::uint8_t adi_port_echo) {
+	_port = adi_ultrasonic_init(smart_port, adi_port_ping, adi_port_echo);
 }
 
-ADIGyro::ADIGyro(std::uint8_t port, double multiplier) {
-	_port = adi_gyro_init(port, multiplier);
+ADIGyro::ADIGyro(std::uint8_t smart_port, std::uint8_t adi_port, double multiplier) {
+	_port = adi_gyro_init(smart_port, adi_port, multiplier);
 }
 
 double ADIGyro::get_value(void) const {
-	return adi_gyro_get(_port);
+	return adi_gyro_get(_smart_port, _adi_port);
 }
 
 std::int32_t ADIGyro::reset(void) const {
-	return adi_gyro_reset(_port);
+	return adi_gyro_reset(_smart_port, _adi_port);
 }
 }  // namespace pros


### PR DESCRIPTION
#### Summary:
Changed the C and C++ API for ADI devices to support changing the selected smart port, which lets you use the ADI Expander.

I used the format `function(smart_port, adi_port)`, i.e.  `int32_t adi_port_get_value(uint8_t smart_port, uint8_t adi_port);`, as was suggested by @kunwarsahni01 
The intention is for people to use the `INTERNAL_ADI_PORT` macro for those ports.
I changed the C types for ADI Devices (i.e. `adi_encoder_t`) from`typedef int32_t adi_encoder_t` to 
`
typedef struct {
	int32_t smart_port;
	int32_t adi_port;
} adi_encoder_t;
` to include the smart port and the adi port, since now we have to worry about storing both.


#### Motivation:
PROS should support the 3-wire expander because it's a VRC-legal electronic part and PROS supports all the VRC-legal electronics parts.

#### Test Plan:
Try all the ADI devices through a 3-wire expander and through the internal brain ports.