### PR TITLE
Fix ADI encoder docs missing a comment about allowed top port

### DIFF
--- a/include/pros/adi.h
+++ b/include/pros/adi.h
@@ -494,7 +494,7 @@ int32_t adi_encoder_get(adi_encoder_t enc);
  *
  * \param port_top
  *        The "top" wire from the encoder sensor with the removable cover side
- *        up
+ *        up. This should be in port 1, 3, 5, or 7 ('A', 'C', 'E', or 'G').
  * \param port_bottom
  *        The "bottom" wire from the encoder sensor
  * \param reverse

--- a/include/pros/ext_adi.h
+++ b/include/pros/ext_adi.h
@@ -421,7 +421,7 @@ int32_t ext_adi_encoder_get(ext_adi_encoder_t enc);
  *        The smart port number that the ADI Expander is in
  * \param adi_port_top
  *        The "top" wire from the encoder sensor with the removable cover side
- *        up
+ *        up. This should be in port 1, 3, 5, or 7 ('A', 'C', 'E', or 'G').
  * \param adi_port_bottom
  *        The "bottom" wire from the encoder sensor
  * \param reverse


### PR DESCRIPTION
#### Summary:
This PR adds documentation about the allow ADI ports for an encoder's top wire.

#### Motivation:
This is currently only documented on the website.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

