### PR TITLE
👽 Add missing filesystem syscalls

### DIFF
--- a/src/system/dev/file_system_stubs.c
+++ b/src/system/dev/file_system_stubs.c
@@ -56,3 +56,28 @@ int _stat(const char* file, struct stat* st) {
 	errno = ENOSYS;
 	return -1;
 }
+
+int symlink(const char* file, const char* linkpath) {
+	errno = ENOSYS;
+	return -1;
+}
+
+ssize_t readlink(const char* pathname, char* buf, size_t bufsiz) {
+	errno = ENOSYS;
+	return NULL;
+}
+
+int truncate(const char* path, off_t length) {
+	errno = ENOSYS;
+	return -1;
+}
+
+int fchmod(int fd, mode_t mode) {
+	errno = ENOSYS;
+	return -1;
+}
+
+int fchmodat(int dirfd, const char* pathname, mode_t mode, int flags) {
+	errno = ENOSYS;
+	return -1;
+}

--- a/src/system/dev/file_system_stubs.c
+++ b/src/system/dev/file_system_stubs.c
@@ -64,7 +64,8 @@ int symlink(const char* file, const char* linkpath) {
 
 ssize_t readlink(const char* pathname, char* buf, size_t bufsiz) {
 	errno = ENOSYS;
-	return NULL;
+	return -1;
+
 }
 
 int truncate(const char* path, off_t length) {

--- a/src/system/dev/file_system_stubs.c
+++ b/src/system/dev/file_system_stubs.c
@@ -32,6 +32,16 @@ int chmod(const char* pathname, mode_t mode) {
 	return -1;
 }
 
+int fchmod(int fd, mode_t mode) {
+	errno = ENOSYS;
+	return -1;
+}
+
+int fchmodat(int dirfd, const char* pathname, mode_t mode, int flags) {
+	errno = ENOSYS;
+	return -1;
+}
+
 long pathconf(const char* path, int name) {
 	errno = ENOSYS;
 	return -1;
@@ -65,20 +75,9 @@ int symlink(const char* file, const char* linkpath) {
 ssize_t readlink(const char* pathname, char* buf, size_t bufsiz) {
 	errno = ENOSYS;
 	return -1;
-
 }
 
 int truncate(const char* path, off_t length) {
-	errno = ENOSYS;
-	return -1;
-}
-
-int fchmod(int fd, mode_t mode) {
-	errno = ENOSYS;
-	return -1;
-}
-
-int fchmodat(int dirfd, const char* pathname, mode_t mode, int flags) {
 	errno = ENOSYS;
 	return -1;
 }


### PR DESCRIPTION
#### Summary:
Adds missing File System stubs: symlink, readlink, truncate, fchmod, fchmodat.

#### Motivation:
Dependencies on these syscalls were added with the gcc-arm-none-eabi-10-2020-q4-major update (in c++20-compliant std::filesystem functions)

##### References (optional):
Closes #273 
