### PR TITLE
 ✨ Add microsecond timing

### DIFF
--- a/include/pros/rtos.h
+++ b/include/pros/rtos.h
@@ -126,6 +126,13 @@ namespace c {
 uint32_t millis(void);
 
 /**
+ * Gets the number of microseconds since PROS initialized,
+ * 
+ * \return The number of microseconds since PROS initialized
+ */
+uint64_t micros(void);
+
+/**
  * Creates a new task and add it to the list of tasks that are ready to run.
  *
  * This function uses the following values of errno when an error state is

--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -368,6 +368,13 @@ class Mutex {
 using pros::c::millis;
 
 /**
+ * @brief Gets the number of microseconds since PROS initialized.
+ * 
+ * \return The number of microseconds since PROS initialized
+ */
+using pros::c::micros;
+
+/**
  * Delays a task for a given number of milliseconds.
  *
  * This is not the best method to have a task execute code at predefined

--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -368,7 +368,7 @@ class Mutex {
 using pros::c::millis;
 
 /**
- * @brief Gets the number of microseconds since PROS initialized.
+ * Gets the number of microseconds since PROS initialized.
  * 
  * \return The number of microseconds since PROS initialized
  */

--- a/src/rtos/tasks.c
+++ b/src/rtos/tasks.c
@@ -2060,6 +2060,11 @@ uint32_t xTicks;
 
 	return xTicks * (configTICK_RATE_HZ / 1000);
 }
+
+uint64_t micros(void)
+{
+	return vexSystemHighResTimeGet();
+}
 /*-----------------------------------------------------------*/
 
 uint32_t xTaskGetTickCountFromISR( void )

--- a/src/rtos/tasks.c
+++ b/src/rtos/tasks.c
@@ -29,6 +29,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "v5_api.h"
+
 /* Defining MPU_WRAPPERS_INCLUDED_FROM_API_FILE prevents task.h from redefining
 all the API functions to use the MPU wrappers.  That should only be done when
 task.h is included from an application file. */


### PR DESCRIPTION
#### Summary:
Adds `pros::micros()` to return the time since program start in microseconds.

I noticed `pros::millis()` didn't use `vexSystemTimeGet()` but I'm not familiar enough with FreeRTOS to know what it's doing and if that'd be better then wrapping `vexSystemHighResTimeGet()`.

#### Motivation:
There is currently no sub-millisecond timing. 

##### References:
Closes #280

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [x] Call `pros::micros()` and ensure it returns the time since program start in microseconds
