### PR TITLE
✨ Allow user code to query registry status

### DIFF
--- a/include/pros/apix.h
+++ b/include/pros/apix.h
@@ -417,6 +417,36 @@ int registry_bind_port(uint8_t port, v5_device_e_t device_type);
  */
 int registry_unbind_port(uint8_t port);
 
+/*
+ * Returns the type of device registered to the port.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * ENXIO - The given value is not within the range of V5 ports (1-21).
+ *
+ * \param port
+ *        The V5 port number from 1-21
+ *
+ * \return The type of device that is registered into the port (NOT what is
+ * plugged in)
+ */
+v5_device_e_t registry_get_bound_type(uint8_t port);
+
+/*
+ * Returns the type of the device plugged into the port.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * ENXIO - The given value is not within the range of V5 ports (1-21).
+ *
+ * \param port
+ *        The V5 port number from 1-21
+ *
+ * \return The type of device that is plugged into the port (NOT what is
+ * registered)
+ */
+v5_device_e_t registry_get_plugged_type(uint8_t port);
+
 /******************************************************************************/
 /**                               Filesystem                                 **/
 /******************************************************************************/

--- a/include/pros/apix.h
+++ b/include/pros/apix.h
@@ -381,14 +381,14 @@ typedef enum v5_device_e {
 } v5_device_e_t;
 
 /*
- * Registers a device in the given port
+ * Registers a device in the given zero-indexed port
  *
  * Registers a device of the given type in the given port into the registry, if
  * that type of device is detected to be plugged in to that port.
  *
  * This function uses the following values of errno when an error state is
  * reached:
- * ENXIO - The given value is not within the range of V5 ports (1-21), or a
+ * ENXIO - The given value is not within the range of V5 ports (0-20), or a
  * a different device than specified is plugged in.
  * EADDRINUSE - The port is already registered to another device.
  *
@@ -402,13 +402,13 @@ typedef enum v5_device_e {
 int registry_bind_port(uint8_t port, v5_device_e_t device_type);
 
 /*
- * Deregisters a devices from the given port
+ * Deregisters a devices from the given zero-indexed port
  *
  * Removes the device registed in the given port, if there is one.
  *
  * This function uses the following values of errno when an error state is
  * reached:
- * ENXIO - The given value is not within the range of V5 ports (1-21).
+ * ENXIO - The given value is not within the range of V5 ports (0-20).
  *
  * \param port
  *        The port number to deregister
@@ -418,14 +418,14 @@ int registry_bind_port(uint8_t port, v5_device_e_t device_type);
 int registry_unbind_port(uint8_t port);
 
 /*
- * Returns the type of device registered to the port.
+ * Returns the type of device registered to the zero-indexed port.
  *
  * This function uses the following values of errno when an error state is
  * reached:
- * ENXIO - The given value is not within the range of V5 ports (1-21).
+ * ENXIO - The given value is not within the range of V5 ports (0-20).
  *
  * \param port
- *        The V5 port number from 1-21
+ *        The V5 port number from 0-20
  *
  * \return The type of device that is registered into the port (NOT what is
  * plugged in)
@@ -433,14 +433,14 @@ int registry_unbind_port(uint8_t port);
 v5_device_e_t registry_get_bound_type(uint8_t port);
 
 /*
- * Returns the type of the device plugged into the port.
+ * Returns the type of the device plugged into the zero-indexed port.
  *
  * This function uses the following values of errno when an error state is
  * reached:
- * ENXIO - The given value is not within the range of V5 ports (1-21).
+ * ENXIO - The given value is not within the range of V5 ports (0-20).
  *
  * \param port
- *        The V5 port number from 1-21
+ *        The V5 port number from 0-20
  *
  * \return The type of device that is plugged into the port (NOT what is
  * registered)

--- a/include/vdml/registry.h
+++ b/include/vdml/registry.h
@@ -66,36 +66,6 @@ v5_smart_device_s_t* registry_get_device(uint8_t port);
 v5_smart_device_s_t* registry_get_device_internal(uint8_t port);
 
 /*
- * Returns the type of device registered to the port.
- *
- * This function uses the following values of errno when an error state is
- * reached:
- * ENXIO - The given value is not within the range of V5 ports (1-21).
- *
- * \param port
- *        The V5 port number from 1-21
- *
- * \return The type of device that is registered into the port (NOT what is
- * plugged in)
- */
-v5_device_e_t registry_get_bound_type(uint8_t port);
-
-/*
- * Returns the type of the device plugged into the port.
- *
- * This function uses the following values of errno when an error state is
- * reached:
- * ENXIO - The given value is not within the range of V5 ports (1-21).
- *
- * \param port
- *        The V5 port number from 1-21
- *
- * \return The type of device that is plugged into the port (NOT what is
- * registered)
- */
-v5_device_e_t registry_get_plugged_type(uint8_t port);
-
-/*
  * Checks whether there is a discrepancy between the binding of the port and
  * what is actually plugged in.
  *

--- a/src/devices/registry.c
+++ b/src/devices/registry.c
@@ -68,7 +68,6 @@ int registry_bind_port(uint8_t port, v5_device_e_t device_type) {
 }
 
 int registry_unbind_port(uint8_t port) {
-	port--;
 	if (!VALIDATE_PORT_NO(port)) {
 		errno = ENXIO;
 		return PROS_ERR;


### PR DESCRIPTION
#### Summary:
Move the decelerations of `registry_get_bound_type` and `registry_get_plugged_type` from `registry.h` to `apix.h` to expose them to users.

#### Motivation:
Currently there is no way for user code to query the bound and plugged status of each port. This is useful to make sure devices are ready to use before they are accessed.

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [x] Ensure that registry_get_bound_type and registry_get_plugged_type return the expected values
