### PR TITLE
✨Added Delay to IMU Reset

### DIFF
--- a/include/pros/imu.h
+++ b/include/pros/imu.h
@@ -61,7 +61,8 @@ typedef struct __attribute__((__packed__)) euler_s {
 /**
  * Calibrate IMU
  *
- * This takes approximately 2 seconds, and is a non-blocking operation.
+ * Calibration takes approximately 2 seconds, but this function only blocks
+ * until the IMU status flag is set properly to E_IMU_STATUS_CALIBRATING.
  *
  * This function uses the following values of errno when an error state is
  * reached:

--- a/include/pros/imu.hpp
+++ b/include/pros/imu.hpp
@@ -31,7 +31,8 @@ class Imu {
 	/**
 	 * Calibrate IMU
 	 *
-	 * This takes approximately 2 seconds, and is a non-blocking operation.
+	 * Calibration takes approximately 2 seconds, but this function only blocks
+ 	 * until the IMU status flag is set properly to E_IMU_STATUS_CALIBRATING.
 	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:

--- a/src/devices/vdml_imu.c
+++ b/src/devices/vdml_imu.c
@@ -40,7 +40,7 @@ int32_t imu_reset(uint8_t port) {
 	ERROR_IMU_STILL_CALIBRATING(port, device, PROS_ERR);
 	vexDeviceImuReset(device->device_info);
 	// delay for vexos to set calibration flag
-	delay(20);
+	while(!(vexDeviceImuStatusGet(device->device_info) & E_IMU_STATUS_CALIBRATING)) delay(1);
 	return_port(port - 1, 1);
 }
 

--- a/src/devices/vdml_imu.c
+++ b/src/devices/vdml_imu.c
@@ -40,7 +40,7 @@ int32_t imu_reset(uint8_t port) {
 	ERROR_IMU_STILL_CALIBRATING(port, device, PROS_ERR);
 	vexDeviceImuReset(device->device_info);
 	// delay for vexos to set calibration flag
-	while(!(vexDeviceImuStatusGet(device->device_info) & E_IMU_STATUS_CALIBRATING)) delay(1);
+	while(!(vexDeviceImuStatusGet(device->device_info) & E_IMU_STATUS_CALIBRATING)) delay(5);
 	return_port(port - 1, 1);
 }
 

--- a/src/devices/vdml_imu.c
+++ b/src/devices/vdml_imu.c
@@ -39,6 +39,8 @@ int32_t imu_reset(uint8_t port) {
 	claim_port_i(port - 1, E_DEVICE_IMU);
 	ERROR_IMU_STILL_CALIBRATING(port, device, PROS_ERR);
 	vexDeviceImuReset(device->device_info);
+	// delay for vexos to set calibration flag
+	delay(20);
 	return_port(port - 1, 1);
 }
 


### PR DESCRIPTION
#### Summary:
The calibration flag is not set immediately after a call to `imu_reset` necessitating user code to add a delay before polling the status of the IMU. By adding a 20 ms delay after calling `vexDeviceImuReset` in `imu_reset`, the calibration flag is correctly set once the function returns.

#### Motivation:
`imu_get_status` should reflect that the IMU is calibrating immediately upon the return of `imu_reset`.

#### Test Plan:
- [x] find the delay necessary for the calibration flag to be set
- [x] make sure `imu_reset` and `imu_get_status` still work

The delay between `vexDeviceImuReset` and the calibration flag being set was found by running 

```c
void initialize() {
  imu_reset(IMU_PORT);
  uint32_t start_time = millis();
  while (!(imu_get_status(IMU_PORT) & E_IMU_STATUS_CALIBRATING)) {

  }
  uint32_t delta = millis() - start_time;

  FILE* file = fopen("/usd/logging.csv", "a");
  char str[100];
  sprintf(str, "%d, ", delta);
  fputs(str, file);
  fclose(file);
}
```

The resulting log file after running the program 100 times showed that the delay was a consistent 12 ms.