### PR TITLE
🔥 Deprecate PID setting functions

### DIFF
--- a/include/pros/motors.h
+++ b/include/pros/motors.h
@@ -780,7 +780,7 @@ int32_t motor_set_gearing(uint8_t port, const motor_gearset_e_t gearset);
  *
  * \return A motor_pid_s_t struct formatted properly in 4.4.
  */
-motor_pid_s_t motor_convert_pid(double kf, double kp, double ki, double kd);
+motor_pid_s_t __attribute__((deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage."))) motor_convert_pid(double kf, double kp, double ki, double kd);
 
 /**
  * Takes in floating point values and returns a properly formatted pid struct.
@@ -814,7 +814,7 @@ motor_pid_s_t motor_convert_pid(double kf, double kp, double ki, double kd);
  *
  * \return A motor_pid_s_t struct formatted properly in 4.4.
  */
-motor_pid_full_s_t motor_convert_pid_full(double kf, double kp, double ki, double kd, double filter, double limit,
+motor_pid_full_s_t __attribute__((deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage."))) motor_convert_pid_full(double kf, double kp, double ki, double kd, double filter, double limit,
                                           double threshold, double loopspeed);
 
 /**
@@ -1034,7 +1034,7 @@ motor_gearset_e_t motor_get_gearing(uint8_t port);
  * \return A motor_pid_full_s_t containing the position PID constants last set
  * to the given motor
  */
-motor_pid_full_s_t motor_get_pos_pid(uint8_t port);
+motor_pid_full_s_t __attribute__((deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage."))) motor_get_pos_pid(uint8_t port);
 
 /**
  * Gets the velocity PID that was set for the motor. This function will return
@@ -1055,7 +1055,7 @@ motor_pid_full_s_t motor_get_pos_pid(uint8_t port);
  * \return A motor_pid_full_s_t containing the velocity PID constants last set
  * to the given motor
  */
-motor_pid_full_s_t motor_get_vel_pid(uint8_t port);
+motor_pid_full_s_t __attribute__((deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage."))) motor_get_vel_pid(uint8_t port);
 
 /**
  * Gets the operation direction of the motor as set by the user.

--- a/include/pros/motors.h
+++ b/include/pros/motors.h
@@ -839,7 +839,7 @@ motor_pid_full_s_t motor_convert_pid_full(double kf, double kp, double ki, doubl
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.
  */
-int32_t __attribute__((deprecated)) motor_set_pos_pid(uint8_t port, const motor_pid_s_t pid);
+int32_t __attribute__((deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage."))) motor_set_pos_pid(uint8_t port, const motor_pid_s_t pid);
 
 /**
  * Sets one of motor_pid_full_s_t for the motor.
@@ -862,7 +862,7 @@ int32_t __attribute__((deprecated)) motor_set_pos_pid(uint8_t port, const motor_
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.
  */
-int32_t __attribute__((deprecated)) motor_set_pos_pid_full(uint8_t port, const motor_pid_full_s_t pid);
+int32_t __attribute__((deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage."))) motor_set_pos_pid_full(uint8_t port, const motor_pid_full_s_t pid);
 
 /**
  * Sets one of motor_pid_s_t for the motor. This intended to just modify the
@@ -886,7 +886,7 @@ int32_t __attribute__((deprecated)) motor_set_pos_pid_full(uint8_t port, const m
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.
  */
-int32_t __attribute__((deprecated)) motor_set_vel_pid(uint8_t port, const motor_pid_s_t pid);
+int32_t __attribute__((deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage."))) motor_set_vel_pid(uint8_t port, const motor_pid_s_t pid);
 
 /**
  * Sets one of motor_pid_full_s_t for the motor.
@@ -909,7 +909,7 @@ int32_t __attribute__((deprecated)) motor_set_vel_pid(uint8_t port, const motor_
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.
  */
-int32_t __attribute__((deprecated)) motor_set_vel_pid_full(uint8_t port, const motor_pid_full_s_t pid);
+int32_t __attribute__((deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage."))) motor_set_vel_pid_full(uint8_t port, const motor_pid_full_s_t pid);
 
 /**
  * Sets the reverse flag for the motor.

--- a/include/pros/motors.h
+++ b/include/pros/motors.h
@@ -839,7 +839,7 @@ motor_pid_full_s_t motor_convert_pid_full(double kf, double kp, double ki, doubl
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.
  */
-int32_t motor_set_pos_pid(uint8_t port, const motor_pid_s_t pid);
+int32_t __attribute__((deprecated)) motor_set_pos_pid(uint8_t port, const motor_pid_s_t pid);
 
 /**
  * Sets one of motor_pid_full_s_t for the motor.
@@ -862,7 +862,7 @@ int32_t motor_set_pos_pid(uint8_t port, const motor_pid_s_t pid);
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.
  */
-int32_t motor_set_pos_pid_full(uint8_t port, const motor_pid_full_s_t pid);
+int32_t __attribute__((deprecated)) motor_set_pos_pid_full(uint8_t port, const motor_pid_full_s_t pid);
 
 /**
  * Sets one of motor_pid_s_t for the motor. This intended to just modify the
@@ -886,7 +886,7 @@ int32_t motor_set_pos_pid_full(uint8_t port, const motor_pid_full_s_t pid);
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.
  */
-int32_t motor_set_vel_pid(uint8_t port, const motor_pid_s_t pid);
+int32_t __attribute__((deprecated)) motor_set_vel_pid(uint8_t port, const motor_pid_s_t pid);
 
 /**
  * Sets one of motor_pid_full_s_t for the motor.
@@ -909,7 +909,7 @@ int32_t motor_set_vel_pid(uint8_t port, const motor_pid_s_t pid);
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.
  */
-int32_t motor_set_vel_pid_full(uint8_t port, const motor_pid_full_s_t pid);
+int32_t __attribute__((deprecated)) motor_set_vel_pid_full(uint8_t port, const motor_pid_full_s_t pid);
 
 /**
  * Sets the reverse flag for the motor.

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -614,6 +614,7 @@ class Motor {
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 */
+	[[deprecated]]
 	virtual std::int32_t set_pos_pid(const motor_pid_s_t pid) const;
 
 	/**
@@ -632,6 +633,7 @@ class Motor {
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 */
+	[[deprecated]]
 	virtual std::int32_t set_pos_pid_full(const motor_pid_full_s_t pid) const;
 
 	/**
@@ -651,6 +653,7 @@ class Motor {
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 */
+	[[deprecated]]
 	virtual std::int32_t set_vel_pid(const motor_pid_s_t pid) const;
 
 	/**
@@ -669,6 +672,7 @@ class Motor {
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 */
+	[[deprecated]]
 	virtual std::int32_t set_vel_pid_full(const motor_pid_full_s_t pid) const;
 
 	/**

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -20,6 +20,7 @@
 #define _PROS_MOTORS_HPP_
 
 #include <cstdint>
+
 #include "pros/motors.h"
 
 namespace pros {
@@ -565,6 +566,7 @@ class Motor {
 	 *
 	 * \return A motor_pid_s_t struct formatted properly in 4.4.
 	 */
+	[[deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage.")]]
 	static motor_pid_s_t convert_pid(double kf, double kp, double ki, double kd);
 
 	/**
@@ -594,8 +596,9 @@ class Motor {
 	 *
 	 * \return A motor_pid_s_t struct formatted properly in 4.4.
 	 */
-	static motor_pid_full_s_t convert_pid_full(double kf, double kp, double ki, double kd, double filter, double limit,
-	                                           double threshold, double loopspeed);
+	[[deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage.")]] 
+	static motor_pid_full_s_t convert_pid_full(double kf, double kp, double ki, double kd, double filter, double limit, double threshold,
+	                 double loopspeed);
 
 	/**
 	 * Sets one of motor_pid_s_t for the motor. This intended to just modify the
@@ -633,7 +636,7 @@ class Motor {
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 */
-	[[deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage.")]]
+	[[deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage.")]] 
 	virtual std::int32_t set_pos_pid_full(const motor_pid_full_s_t pid) const;
 
 	/**
@@ -653,7 +656,7 @@ class Motor {
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 */
-	[[deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage.")]]
+	[[deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage.")]] 
 	virtual std::int32_t set_vel_pid(const motor_pid_s_t pid) const;
 
 	/**
@@ -672,7 +675,7 @@ class Motor {
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 */
-	[[deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage.")]]
+	[[deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage.")]] 
 	virtual std::int32_t set_vel_pid_full(const motor_pid_full_s_t pid) const;
 
 	/**
@@ -772,6 +775,7 @@ class Motor {
 	 * \return A motor_pid_full_s_t containing the position PID constants last set
 	 * to the given motor
 	 */
+	[[deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage.")]] 
 	virtual motor_pid_full_s_t get_pos_pid(void) const;
 
 	/**
@@ -789,6 +793,7 @@ class Motor {
 	 * \return A motor_pid_full_s_t containing the velocity PID constants last set
 	 * to the given motor
 	 */
+	[[deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage.")]]
 	virtual motor_pid_full_s_t get_vel_pid(void) const;
 
 	/**

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -614,7 +614,7 @@ class Motor {
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 */
-	[[deprecated]]
+	[[deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage.")]]
 	virtual std::int32_t set_pos_pid(const motor_pid_s_t pid) const;
 
 	/**
@@ -633,7 +633,7 @@ class Motor {
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 */
-	[[deprecated]]
+	[[deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage.")]]
 	virtual std::int32_t set_pos_pid_full(const motor_pid_full_s_t pid) const;
 
 	/**
@@ -653,7 +653,7 @@ class Motor {
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 */
-	[[deprecated]]
+	[[deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage.")]]
 	virtual std::int32_t set_vel_pid(const motor_pid_s_t pid) const;
 
 	/**
@@ -672,7 +672,7 @@ class Motor {
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 */
-	[[deprecated]]
+	[[deprecated("Changing these values is not supported by VEX and may lead to permanent motor damage.")]]
 	virtual std::int32_t set_vel_pid_full(const motor_pid_full_s_t pid) const;
 
 	/**

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -112,11 +112,17 @@ motor_gearset_e_t Motor::get_gearing(void) const {
 }
 
 motor_pid_full_s_t Motor::get_pos_pid(void) const {
+	#pragma GCC diagnostic push
+  	#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return motor_get_pos_pid(_port);
+	#pragma GCC diagnostic pop
 }
 
 motor_pid_full_s_t Motor::get_vel_pid(void) const {
+	#pragma GCC diagnostic push
+  	#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return motor_get_vel_pid(_port);
+	#pragma GCC diagnostic pop
 }
 
 std::int32_t Motor::get_raw_position(std::uint32_t* const timestamp) const {
@@ -196,12 +202,18 @@ std::int32_t Motor::set_gearing(const motor_gearset_e_t gearset) const {
 }
 
 motor_pid_s_t Motor::convert_pid(double kf, double kp, double ki, double kd) {
+	#pragma GCC diagnostic push
+  	#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return motor_convert_pid(kf, kp, ki, kd);
+	#pragma GCC diagnostic pop
 }
 
 motor_pid_full_s_t Motor::convert_pid_full(double kf, double kp, double ki, double kd, double filter, double limit,
                                            double threshold, double loopspeed) {
+	#pragma GCC diagnostic push
+  	#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return motor_convert_pid_full(kf, kp, ki, kd, filter, limit, threshold, loopspeed);
+	#pragma GCC diagnostic pop
 }
 
 std::int32_t Motor::set_pos_pid(const motor_pid_s_t pid) const {

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -205,19 +205,31 @@ motor_pid_full_s_t Motor::convert_pid_full(double kf, double kp, double ki, doub
 }
 
 std::int32_t Motor::set_pos_pid(const motor_pid_s_t pid) const {
+	#pragma GCC diagnostic push
+  	#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return motor_set_pos_pid(_port, pid);
+	#pragma GCC diagnostic pop
 }
 
 std::int32_t Motor::set_pos_pid_full(const motor_pid_full_s_t pid) const {
+	#pragma GCC diagnostic push
+  	#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return motor_set_pos_pid_full(_port, pid);
+	#pragma GCC diagnostic pop
 }
 
 std::int32_t Motor::set_vel_pid(const motor_pid_s_t pid) const {
+	#pragma GCC diagnostic push
+  	#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return motor_set_vel_pid(_port, pid);
+	#pragma GCC diagnostic pop
 }
 
 std::int32_t Motor::set_vel_pid_full(const motor_pid_full_s_t pid) const {
+	#pragma GCC diagnostic push
+  	#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	return motor_set_vel_pid_full(_port, pid);
+	#pragma GCC diagnostic pop
 }
 
 std::int32_t Motor::set_zero_position(const double position) const {


### PR DESCRIPTION
#### Summary:
Removed the functionality of pid setting functions and added deprecation warnings to them. The functions included are:

for the c implementation--
`pros::c::motor_set_pos_pid`
`pros::c::motor_set_pos_pid_full`
`pros::c::motor_set_vel_pid`
`pros::c::motor_set_vel_pid_full`

for the C++ implementation--
`pros::Motor::set_pos_pid`
`pros::Motor::set_pos_pid_full`
`pros::Motor::set_vel_pid`
`pros::Motor::set_vel_pid_full`

#### Motivation:
As stated in #291 motors can be broken using the pid setting functions therefore they should be removed.

##### References (optional):
closes #291

#### Test Plan:
Unfortunately, I do not have access to a brain, so I tested these functions by calling them in main.cpp in a main() method.

For each method I wrote--
```C++
int main() {
	// set_pos_pid
	pros::Motor motor(1);
	pros::motor_pid_s_t pid = pros::Motor::convert_pid(KF, KP, KI, KD);
	motor.set_pos_pid(pid);
}
```
And at compile time we receive the following warning--
```
src/main.cpp:16:23: warning: 'virtual int32_t pros::Motor::set_pos_pid(pros::motor_pid_s_t) const' is deprecated [-Wdeprecated-declarations]
  motor.set_pos_pid(pid);
                       ^
In file included from ./include/api.h:69:0,
                 from ./include/main.h:37,
                 from src/main.cpp:1:
./include/pros/motors.hpp:618:23: note: declared here
  virtual std::int32_t set_pos_pid(const motor_pid_s_t pid) const;
                       ^~~~~~~~~~~
```
All of the other methods printed the same warnings.
