### PR TITLE
🐛 Fix deleted VM Image for Azure Pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ jobs:
     toolchain_update: 8-2019-q3
     toolchain: https://developer.arm.com/-/media/Files/downloads/gnu-rm/$(toolchain_update_short)/RC1.1/gcc-arm-none-eabi-$(toolchain_update)-update-linux.tar.bz2
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-latest'
   steps:
   - task: InstallSSHKey@0
     inputs:


### PR DESCRIPTION
Our current image ubuntu-16.04 no longer exists, pipeline runs are giving this warning: `##[warning]An image label with the label ubuntu-16.04 does not exist.` Have changed it to `ubuntu-latest` we could also use `ubuntu-20.04` if pinning is preferred. 