### PR TITLE
🐛 supply -nostartfiles to g++ instead of to ld

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ temp.log
 temp.errors
 .d/
 .clangd/
+.cache/

--- a/common.mk
+++ b/common.mk
@@ -236,7 +236,7 @@ $(HOT_BIN): $(HOT_ELF) $(COLD_BIN)
 
 $(HOT_ELF): $(COLD_ELF) $(ELF_DEPS)
 	$(call _pros_ld_timestamp)
-	$(call test_output_2,Linking hot project with $(COLD_ELF) and $(ARCHIVE_TEXT_LIST) ,$(LD) $(LDFLAGS) $(call wlprefix,-nostartfiles -R $<) $(filter-out $<,$^) $(LDTIMEOBJ) $(LIBRARIES) $(call wlprefix,-T$(FWDIR)/v5-hot.ld $(LNK_FLAGS) -o $@),$(OK_STRING))
+	$(call test_output_2,Linking hot project with $(COLD_ELF) and $(ARCHIVE_TEXT_LIST) ,$(LD) -nostartfiles $(LDFLAGS) $(call wlprefix,-R $<) $(filter-out $<,$^) $(LDTIMEOBJ) $(LIBRARIES) $(call wlprefix,-T$(FWDIR)/v5-hot.ld $(LNK_FLAGS) -o $@),$(OK_STRING))
 	@printf "%s\n" "Section sizes:"
 	-$(VV)$(SIZETOOL) $(SIZEFLAGS) $@ $(SIZES_SED) $(SIZES_NUMFMT)
 


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
`-nostartfiles` is an option consumed by \*g++, not \*ld. this change moves the flag out of the `-Wl` group (options passed from \*g++ to \*ld) to fix issues with linking the hot package.

#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
technically this option was never being passed as we expected. recent versions of the toolchain have updated how \*ld handles erroneous input, so we were never alerted to this fact before.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
fixes #312 

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->
- [x] tested hot/cold linking on gcc-arm-none-eabi 10.3-2021-10
- [x] tested hot/cold linking on gcc-arm-none-eabi 9-2020-q2-update
- [x] test project on v5 compiled and linked with 10.3-2021-10
- [x] test project on v5 compiled and linked with 9-2020-q2-update
