### PR TITLE
✨Define mutex_take default instructor

### DIFF
--- a/include/pros/rtos.h
+++ b/include/pros/rtos.h
@@ -376,6 +376,21 @@ bool task_notify_clear(task_t task);
 mutex_t mutex_create(void);
 
 /**
+ * Takes and locks a mutex indefinetly.
+ *
+ * See https://pros.cs.purdue.edu/v5/tutorials/topical/multitasking.html#mutexes
+ * for details.
+ *
+ * \param mutex
+ *        Mutex to attempt to lock.
+ *
+ * \return True if the mutex was successfully taken, false otherwise. If false
+ * is returned, then errno is set with a hint about why the the mutex
+ * couldn't be taken.
+ */
+bool mutex_take(mutex_t mutex);
+
+/**
  * Takes and locks a mutex, waiting for up to a certain number of milliseconds
  * before timing out.
  *

--- a/include/pros/rtos.h
+++ b/include/pros/rtos.h
@@ -376,21 +376,6 @@ bool task_notify_clear(task_t task);
 mutex_t mutex_create(void);
 
 /**
- * Takes and locks a mutex indefinetly.
- *
- * See https://pros.cs.purdue.edu/v5/tutorials/topical/multitasking.html#mutexes
- * for details.
- *
- * \param mutex
- *        Mutex to attempt to lock.
- *
- * \return True if the mutex was successfully taken, false otherwise. If false
- * is returned, then errno is set with a hint about why the the mutex
- * couldn't be taken.
- */
-bool mutex_take(mutex_t mutex);
-
-/**
  * Takes and locks a mutex, waiting for up to a certain number of milliseconds
  * before timing out.
  *

--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -370,6 +370,19 @@ class Mutex {
 	Mutex(void);
 
 	/**
+	 * Takes and locks a mutex indefinetly.
+	 *
+	 * See
+	 * https://pros.cs.purdue.edu/v5/tutorials/topical/multitasking.html#mutexes
+	 * for details.
+	 *
+	 * \return True if the mutex was successfully taken, false otherwise. If false
+	 * is returned, then errno is set with a hint about why the the mutex
+	 * couldn't be taken.
+	 */
+	bool take(void);
+
+	/**
 	 * Takes and locks a mutex, waiting for up to a certain number of milliseconds
 	 * before timing out.
 	 *

--- a/src/rtos/rtos.cpp
+++ b/src/rtos/rtos.cpp
@@ -99,6 +99,10 @@ using namespace pros::c;
 
   Mutex::Mutex(void) : mutex(mutex_create(), mutex_delete) { }
 
+  bool Mutex::take(void) {
+    return mutex_take(mutex.get(), TIMEOUT_MAX);
+  }
+
   bool Mutex::take(std::uint32_t timeout) {
     return mutex_take(mutex.get(), timeout);
   }


### PR DESCRIPTION
#### Summary:
Added a default constructor for mutex_take that initializes the timeout to TIMEOUT_MAX

#### Motivation:
users should be able to call pros::Mutex::take with no arguments and have it wait forever

##### References (optional):
https://github.com/purduesigbots/pros/issues/316

#### Test Plan:
Call Mutex::take with no arguments & see if it doesn't time out.

