### PR TITLE
:bug: Bugfix ADI Digital Out constructor

### DIFF
--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -72,7 +72,7 @@ ADIDigitalOut::ADIDigitalOut(std::uint8_t adi_port, bool init_state) : ADIPort(a
 	set_value(init_state);
 }
 
-ADIDigitalOut::ADIDigitalOut(ext_adi_port_pair_t port_pair, bool init_state) : ADIPort(port_pair, E_ADI_DIGITAL_IN) {
+ADIDigitalOut::ADIDigitalOut(ext_adi_port_pair_t port_pair, bool init_state) : ADIPort(port_pair, E_ADI_DIGITAL_OUT) {
 	set_value(init_state);
 }
 


### PR DESCRIPTION
#### Summary:
Bruh.

#### Motivation:
Love.

##### References (optional):
#321 

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [x] Run the test case

```cpp
pros::Controller master(pros::E_CONTROLLER_MASTER); 

pros::ADIDigitalOut claw({INTERNAL_ADI_PORT, 'A'}, false);
// jerry::ADIDigitalOut claw('A', false);
// jerry::ADIDigitalOut claw({INTERNAL_ADI_PORT, 'A'}, false);

while (true) {
	if (master.get_digital(pros::E_CONTROLLER_DIGITAL_L1))
		claw.set_value(true);
	else
		claw.set_value(false);

	pros::delay(10);
}
```