### PR TITLE
🚸Removed internal ext_adi_gyro wrapper

### DIFF
--- a/src/devices/vdml_ext_adi.c
+++ b/src/devices/vdml_ext_adi.c
@@ -366,7 +366,7 @@ double ext_adi_gyro_get(ext_adi_gyro_t gyro) {
 	get_ports(gyro, smart_port, adi_port);
 	transform_adi_port(adi_port);
 	claim_port_f(smart_port, E_DEVICE_ADI);
-	claim_port(port, device_type, PROS_ERR_F)
+	validate_type(device, adi_port, E_ADI_LEGACY_GYRO);
 
 	double rtv = (double)vexDeviceAdiValueGet(device->device_info, adi_port);
 	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[adi_port];

--- a/src/devices/vdml_ext_adi.c
+++ b/src/devices/vdml_ext_adi.c
@@ -361,29 +361,18 @@ ext_adi_gyro_t ext_adi_gyro_init(uint8_t smart_port, uint8_t adi_port, double mu
 	return_port(smart_port - 1, merge_adi_ports(smart_port - 1, adi_port + 1));
 }
 
-// Internal wrapper for adi_gyro_get to get around transform_adi_port, claim_port_i, validate_type and return_port
-// possibly returning PROS_ERR, not PROS_ERR_F
-int32_t _ext_adi_gyro_get(ext_adi_gyro_t gyro, double* out) {
+double ext_adi_gyro_get(ext_adi_gyro_t gyro) {
 	uint8_t smart_port, adi_port;
 	get_ports(gyro, smart_port, adi_port);
 	transform_adi_port(adi_port);
-	claim_port_i(smart_port, E_DEVICE_ADI);
-	validate_type(device, adi_port, E_ADI_LEGACY_GYRO);
+	claim_port_f(smart_port, E_DEVICE_ADI);
+	claim_port(port, device_type, PROS_ERR_F)
 
-	double rtn = (double)vexDeviceAdiValueGet(device->device_info, adi_port);
+	double rtv = (double)vexDeviceAdiValueGet(device->device_info, adi_port);
 	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[adi_port];
-	rtn -= adi_data->gyro_data.tare_value;
-	rtn *= adi_data->gyro_data.multiplier;
-	*out = rtn;
-	return_port(smart_port, 1);
-}
-
-double ext_adi_gyro_get(ext_adi_gyro_t gyro) {
-	double rtn;
-	if (_ext_adi_gyro_get(gyro, &rtn) == PROS_ERR)
-		return PROS_ERR_F;
-	else
-		return rtn;
+	rtv -= adi_data->gyro_data.tare_value;
+	rtv *= adi_data->gyro_data.multiplier;
+	return_port(smart_port, rtv);
 }
 
 int32_t ext_adi_gyro_reset(ext_adi_gyro_t gyro) {

--- a/src/devices/vdml_ext_adi.c
+++ b/src/devices/vdml_ext_adi.c
@@ -66,6 +66,13 @@ typedef union adi_data {
 		return PROS_ERR;                                                                                      \
 	}
 
+#define validate_type_f(device, port, type)                                                                 \
+	adi_port_config_e_t config = (adi_port_config_e_t)vexDeviceAdiPortConfigGet(device->device_info, port); \
+	if (config != type) {                                                                                   \
+		errno = EADDRINUSE;                                                                                   \
+		return PROS_ERR_F;                                                                                      \
+	}
+
 #define validate_motor(device, port)                                                                      \
 	adi_port_config_e_t config = (adi_port_config_e_t)vexDeviceAdiPortConfigGet(device->device_info, port); \
 	if (config != E_ADI_LEGACY_PWM && config != E_ADI_LEGACY_SERVO) {                                       \
@@ -366,7 +373,7 @@ double ext_adi_gyro_get(ext_adi_gyro_t gyro) {
 	get_ports(gyro, smart_port, adi_port);
 	transform_adi_port(adi_port);
 	claim_port_f(smart_port, E_DEVICE_ADI);
-	validate_type(device, adi_port, E_ADI_LEGACY_GYRO);
+	validate_type_f(device, adi_port, E_ADI_LEGACY_GYRO);
 
 	double rtv = (double)vexDeviceAdiValueGet(device->device_info, adi_port);
 	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[adi_port];


### PR DESCRIPTION
#### Summary:
This PR removes the internal ext_adi_gyro wrapper, and uses claim_port_f properly instead of claim_port_i.
Also adds a validate_type_f for float returns.

Motivation: Unnecessary stack frame removed