### PR TITLE
🐛 gcc exception table section name typo

### DIFF
--- a/firmware/v5-common.ld
+++ b/firmware/v5-common.ld
@@ -21,7 +21,7 @@ SECTIONS
    *(.gnu.linkonce.t.*)
    *(.plt)
    *(.gnu_warning)
-   *(.gcc_execpt_table)
+   *(.gcc_except_table)
    *(.glue_7)
    *(.glue_7t)
    *(.vfp11_veneer)


### PR DESCRIPTION
#### Summary:
`gcc_except_table` was misspelled as `gcc_execpt_table`.

#### Motivation:
The linking is improper if the exception table is not included properly.

#### Test Plan:

- [ ] Verify that the exception table is now in the binary
