### PR TITLE
🐛 Prevent LLEMU Clearing Segfault

### DIFF
--- a/src/display/llemu.c
+++ b/src/display/llemu.c
@@ -177,7 +177,7 @@ bool _lcd_set_text(lv_obj_t* lcd_dummy, int16_t line, const char* text) {
 }
 
 void _lcd_clear(lv_obj_t* lcd_dummy) {
-	for (std::size_t i = 0; i < LLEMU_LINES; i++)
+	for (size_t i = 0; i < LLEMU_LINES; i++)
     	_lcd_clear_line(lcd_dummy, i);
 }
 

--- a/src/display/llemu.c
+++ b/src/display/llemu.c
@@ -176,11 +176,6 @@ bool _lcd_set_text(lv_obj_t* lcd_dummy, int16_t line, const char* text) {
 	return _lcd_print(lcd_dummy, line, "%s", text);
 }
 
-void _lcd_clear(lv_obj_t* lcd_dummy) {
-	for (size_t i = 0; i < LLEMU_LINES; i++)
-    	_lcd_clear_line(lcd_dummy, i);
-}
-
 bool _lcd_clear_line(lv_obj_t* lcd_dummy, int16_t line) {
 	if (line < 0 || line > 7) {
 		errno = EINVAL;
@@ -189,6 +184,11 @@ bool _lcd_clear_line(lv_obj_t* lcd_dummy, int16_t line) {
 	lcd_s_t* lcd = lv_obj_get_ext_attr(lcd_dummy);
 	lv_label_set_text(lcd->lcd_text[line], "");
 	return true;
+}
+
+void _lcd_clear(lv_obj_t* lcd_dummy) {
+	for (size_t i = 0; i < LLEMU_LINES; i++)
+    	_lcd_clear_line(lcd_dummy, i);
 }
 
 void _lcd_set_left_callback(lv_obj_t* lcd_dummy, lcd_btn_cb_fn_t cb) {

--- a/src/display/llemu.c
+++ b/src/display/llemu.c
@@ -23,6 +23,10 @@
 #include "kapi.h"
 #include "pros/llemu.h"
 
+#define LCD_W 		480 
+#define LCD_H 		240
+#define LLEMU_LINES 8
+
 static lv_style_t frame_style;
 static lv_style_t screen_style;
 static lv_style_t button_style;
@@ -81,10 +85,10 @@ static lv_obj_t* _create_lcd(void) {
 	button_pressed_style.body.grad_color = LV_COLOR_MAKE(0x80, 0x80, 0x80);
 
 	lv_obj_t* lcd_dummy = lv_obj_create(lv_scr_act(), NULL);
-	lv_obj_set_size(lcd_dummy, 480, 240);
+	lv_obj_set_size(lcd_dummy, LCD_W, LCD_H);
 
 	lv_obj_t* frame = lv_cont_create(lcd_dummy, NULL);
-	lv_obj_set_size(frame, 480, 240);
+	lv_obj_set_size(frame, LCD_W, LCD_H);
 	lv_obj_set_style(frame, &frame_style);
 
 	lv_obj_t* screen = lv_cont_create(frame, NULL);
@@ -133,7 +137,7 @@ static lv_obj_t* _create_lcd(void) {
 	lcd->callbacks[1] = NULL;
 	lcd->callbacks[2] = NULL;
 
-	for (size_t i = 0; i < 8; i++) {
+	for (size_t i = 0; i < LLEMU_LINES; i++) {
 		lcd->lcd_text[i] = lv_label_create(lcd->screen, NULL);
 		lv_obj_set_width(lcd->lcd_text[i], 426);
 		lv_obj_align(lcd->lcd_text[i], NULL, LV_ALIGN_IN_TOP_LEFT, 5, 20 * i);
@@ -173,10 +177,8 @@ bool _lcd_set_text(lv_obj_t* lcd_dummy, int16_t line, const char* text) {
 }
 
 void _lcd_clear(lv_obj_t* lcd_dummy) {
-	lcd_s_t* lcd = lv_obj_get_ext_attr(lcd_dummy);
-	// delete children of screen (this is fine because when we print, we just
-	// overwrite the pointer anyway)
-	lv_obj_clean(lcd->screen);
+	for (std::size_t i = 0; i < LLEMU_LINES; i++)
+    	_lcd_clear_line(lcd_dummy, i);
 }
 
 bool _lcd_clear_line(lv_obj_t* lcd_dummy, int16_t line) {

--- a/src/display/llemu.c
+++ b/src/display/llemu.c
@@ -151,7 +151,7 @@ static lv_obj_t* _create_lcd(void) {
 }
 
 bool _lcd_vprint(lv_obj_t* lcd_dummy, int16_t line, const char* fmt, va_list args) {
-	if (line < 0 || line > 7) {
+	if (line < 0 || line > (LLEMU_LINES - 1)) {
 		errno = EINVAL;
 		return false;
 	}

--- a/src/display/llemu.c
+++ b/src/display/llemu.c
@@ -188,7 +188,7 @@ bool _lcd_clear_line(lv_obj_t* lcd_dummy, int16_t line) {
 
 void _lcd_clear(lv_obj_t* lcd_dummy) {
 	for (size_t i = 0; i < LLEMU_LINES; i++) {
-    	_lcd_clear_line(lcd_dummy, i);
+		_lcd_clear_line(lcd_dummy, i);
 	}
 }
 

--- a/src/display/llemu.c
+++ b/src/display/llemu.c
@@ -23,8 +23,8 @@
 #include "kapi.h"
 #include "pros/llemu.h"
 
-#define LCD_W 		480 
-#define LCD_H 		240
+#define LCD_WIDTH	480 
+#define LCD_HEIGHT 	240
 #define LLEMU_LINES 8
 
 static lv_style_t frame_style;
@@ -85,10 +85,10 @@ static lv_obj_t* _create_lcd(void) {
 	button_pressed_style.body.grad_color = LV_COLOR_MAKE(0x80, 0x80, 0x80);
 
 	lv_obj_t* lcd_dummy = lv_obj_create(lv_scr_act(), NULL);
-	lv_obj_set_size(lcd_dummy, LCD_W, LCD_H);
+	lv_obj_set_size(lcd_dummy, LCD_WIDTH, LCD_HEIGHT);
 
 	lv_obj_t* frame = lv_cont_create(lcd_dummy, NULL);
-	lv_obj_set_size(frame, LCD_W, LCD_H);
+	lv_obj_set_size(frame, LCD_WIDTH, LCD_HEIGHT);
 	lv_obj_set_style(frame, &frame_style);
 
 	lv_obj_t* screen = lv_cont_create(frame, NULL);
@@ -177,7 +177,7 @@ bool _lcd_set_text(lv_obj_t* lcd_dummy, int16_t line, const char* text) {
 }
 
 bool _lcd_clear_line(lv_obj_t* lcd_dummy, int16_t line) {
-	if (line < 0 || line > 7) {
+	if (line < 0 || line > (LLEMU_LINES - 1)) {
 		errno = EINVAL;
 		return false;
 	}
@@ -187,8 +187,9 @@ bool _lcd_clear_line(lv_obj_t* lcd_dummy, int16_t line) {
 }
 
 void _lcd_clear(lv_obj_t* lcd_dummy) {
-	for (size_t i = 0; i < LLEMU_LINES; i++)
+	for (size_t i = 0; i < LLEMU_LINES; i++) {
     	_lcd_clear_line(lcd_dummy, i);
+	}
 }
 
 void _lcd_set_left_callback(lv_obj_t* lcd_dummy, lcd_btn_cb_fn_t cb) {


### PR DESCRIPTION
#### Summary:
This prevents a segfault that occurs when the LCD on LLEMU is cleared.

##### References (optional):
closes #338 

#### Test Plan:
- [x] Attempt to clear the LCD and see if a segfault occurs w/ the new code. 
