### PR TITLE
🐛 Fix rotation sensor race condition

### DIFF
--- a/include/pros/rotation.h
+++ b/include/pros/rotation.h
@@ -180,7 +180,7 @@ int32_t rotation_set_reversed(uint8_t port, bool value);
  */
 int32_t rotation_reverse(uint8_t port);
 
-int32_t rotation_set_reversed_blocking(uint8_t port, bool value);
+int32_t rotation_init_with_reverse_flag(uint8_t port, bool reverse_flag);
 
 /**
  * Get the Rotation Sensor's reversed flag

--- a/include/pros/rotation.h
+++ b/include/pros/rotation.h
@@ -190,8 +190,8 @@ int32_t rotation_reverse(uint8_t port);
  *
  * \param  port
  * 				 The V5 Rotation Sensor port number from 1-21
- * \param reverse_flag
- *               Determines if the Rotation Sensor is reversed or not.
+ * \param  reverse_flag
+ * 				 Determines if the Rotation Sensor is reversed or not.
  * 
  * \return 1 if the operation was successful or PROS_ERR if the operation
  * failed, setting errno.

--- a/include/pros/rotation.h
+++ b/include/pros/rotation.h
@@ -180,6 +180,8 @@ int32_t rotation_set_reversed(uint8_t port, bool value);
  */
 int32_t rotation_reverse(uint8_t port);
 
+int32_t rotation_set_reversed_blocking(uint8_t port, bool value);
+
 /**
  * Get the Rotation Sensor's reversed flag
  * 

--- a/include/pros/rotation.h
+++ b/include/pros/rotation.h
@@ -180,7 +180,23 @@ int32_t rotation_set_reversed(uint8_t port, bool value);
  */
 int32_t rotation_reverse(uint8_t port);
 
-int32_t rotation_init_with_reverse_flag(uint8_t port, bool reverse_flag);
+/**
+ * Initialize the Rotation Sensor with a reverse flag
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * ENXIO - The given value is not within the range of V5 ports (1-21).
+ * ENODEV - The port cannot be configured as an Rotation Sensor
+ *
+ * \param  port
+ * 				 The V5 Rotation Sensor port number from 1-21
+ * \param reverse_flag
+ *               Determines if the Rotation Sensor is reversed or not.
+ * 
+ * \return 1 if the operation was successful or PROS_ERR if the operation
+ * failed, setting errno.
+ */
+int32_t rotation_init_reverse(uint8_t port, bool reverse_flag);
 
 /**
  * Get the Rotation Sensor's reversed flag

--- a/include/pros/rotation.hpp
+++ b/include/pros/rotation.hpp
@@ -29,6 +29,8 @@ class Rotation {
 	public:
 	Rotation(const std::uint8_t port) : _port(port){};
 
+	Rotation(const std::uint8_t port, const bool reverse_flag) : _port(port){};
+
 	/**
 	 * Reset the Rotation Sensor
 	 *

--- a/include/pros/rotation.hpp
+++ b/include/pros/rotation.hpp
@@ -29,7 +29,7 @@ class Rotation {
 	public:
 	Rotation(const std::uint8_t port) : _port(port){};
 
-	Rotation(const std::uint8_t port, const bool reverse_flag) : _port(port){};
+	Rotation(const std::uint8_t port, const bool reverse_flag);
 
 	/**
 	 * Reset the Rotation Sensor

--- a/src/devices/vdml_rotation.c
+++ b/src/devices/vdml_rotation.c
@@ -75,7 +75,7 @@ int32_t rotation_set_reversed(uint8_t port, bool value) {
 	return_port(port - 1, 1);
 }
 
-int32_t rotation_init_with_reverse_flag(uint8_t port, bool reverse) {
+int32_t rotation_init_with_reverse_flag(uint8_t port, bool reverse_flag) {
 	claim_port_i(port - 1, E_DEVICE_ROTATION);
     uint16_t timeoutCount = 0;
     // releasing mutex so vexBackgrounProcessing can run without being blocked.
@@ -91,7 +91,7 @@ int32_t rotation_init_with_reverse_flag(uint8_t port, bool reverse) {
         }
         device = device; // suppressing compiler warning
     } while(vexDeviceAbsEncStatusGet(device->device_info) == 0);
-    vexAbsEncReverseFlagSet(port - 1, reverse);
+    vexAbsEncReverseFlagSet(port - 1, reverse_flag);
     return_port(port - 1, 1)
 }
 

--- a/src/devices/vdml_rotation.c
+++ b/src/devices/vdml_rotation.c
@@ -84,7 +84,7 @@ int32_t rotation_init_with_reverse_flag(uint8_t port, bool reverse_flag) {
         task_delay(5);
         timeoutCount += 5;
         claim_port_i(port - 1, E_DEVICE_ROTATION);
-        if (timeoutCount >= ROTATION_INIT_TIMEOUT) {
+        if (timeoutCount >= ROTATION_RESET_TIMEOUT) {
             port_mutex_give(port - 1);
             errno = EAGAIN;
             return PROS_ERR;

--- a/src/devices/vdml_rotation.c
+++ b/src/devices/vdml_rotation.c
@@ -17,6 +17,8 @@
 #include "vdml/registry.h"
 #include "vdml/vdml.h"
 
+#define ROTATION_RESET_TIMEOUT 1000
+
 int32_t rotation_reset(uint8_t port) {
 	claim_port_i(port - 1, E_DEVICE_ROTATION);
 	vexDeviceAbsEncReset(device->device_info);
@@ -71,6 +73,26 @@ int32_t rotation_set_reversed(uint8_t port, bool value) {
 	claim_port_i(port - 1, E_DEVICE_ROTATION);
 	vexDeviceAbsEncReverseFlagSet(device->device_info, value);
 	return_port(port - 1, 1);
+}
+
+int32_t rotation_init_with_reverse_flag(uint8_t port, bool reverse) {
+	claim_port_i(port - 1, E_DEVICE_ROTATION);
+    uint16_t timeoutCount = 0;
+    // releasing mutex so vexBackgrounProcessing can run without being blocked.
+    do {
+        port_mutex_give(port - 1);
+        task_delay(5);
+        timeoutCount += 5;
+        claim_port_i(port - 1, E_DEVICE_ROTATION);
+        if (timeoutCount >= ROTATION_INIT_TIMEOUT) {
+            port_mutex_give(port - 1);
+            errno = EAGAIN;
+            return PROS_ERR;
+        }
+        device = device; // suppressing compiler warning
+    } while(vexDeviceAbsEncStatusGet(device->device_info) == 0);
+    vexAbsEncReverseFlagSet(port - 1, reverse);
+    return_port(port - 1, 1)
 }
 
 int32_t rotation_reverse(uint8_t port){

--- a/src/devices/vdml_rotation.c
+++ b/src/devices/vdml_rotation.c
@@ -75,7 +75,7 @@ int32_t rotation_set_reversed(uint8_t port, bool value) {
 	return_port(port - 1, 1);
 }
 
-int32_t rotation_init_with_reverse_flag(uint8_t port, bool reverse_flag) {
+int32_t rotation_init_reverse(uint8_t port, bool reverse_flag) {
 	claim_port_i(port - 1, E_DEVICE_ROTATION);
     uint16_t timeoutCount = 0;
     // releasing mutex so vexBackgrounProcessing can run without being blocked.

--- a/src/devices/vdml_rotation.cpp
+++ b/src/devices/vdml_rotation.cpp
@@ -15,7 +15,7 @@
 namespace pros {
     
 Rotation::Rotation(const std::uint8_t port, const bool reverse_flag) : _port(port) {
-    pros::c::rotation_init_with_reverse_flag(port, reverse_flag);
+    pros::c::rotation_init_reverse(port, reverse_flag);
 }
 
 std::int32_t Rotation::reset() {

--- a/src/devices/vdml_rotation.cpp
+++ b/src/devices/vdml_rotation.cpp
@@ -13,6 +13,11 @@
 #include "pros/rotation.hpp"
 
 namespace pros {
+    
+Rotation::Rotation(const std::uint8_t port, const bool reverse_flag) : _port(port) {
+    pros::c::rotation_init_with_reverse_flag(port, reverse_flag);
+}
+
 std::int32_t Rotation::reset() {
 	return pros::c::rotation_reset(_port);
 }

--- a/src/devices/vdml_rotation.cpp
+++ b/src/devices/vdml_rotation.cpp
@@ -15,7 +15,7 @@
 namespace pros {
     
 Rotation::Rotation(const std::uint8_t port, const bool reverse_flag) : _port(port) {
-    pros::c::rotation_init_reverse(port, reverse_flag);
+	pros::c::rotation_init_reverse(port, reverse_flag);
 }
 
 std::int32_t Rotation::reset() {


### PR DESCRIPTION
#### Summary:
Created a constructor with a block to prevent race conditions. Waits for the sensor initialization to complete to set the reverse flag.

#### Motivation:
https://www.vexforum.com/t/rotation-sensor-bug-workaround-on-vexos-1-1-0/96577

#### Test Plan:
It builds.

