### PR TITLE
✨Implement Error Handling For Screen

### DIFF
--- a/include/pros/screen.h
+++ b/include/pros/screen.h
@@ -47,7 +47,7 @@ typedef enum {
     E_TOUCH_RELEASED = 0, ///< Last interaction with screen was a quick press
     E_TOUCH_PRESSED, ///< Last interaction with screen was a release
     E_TOUCH_HELD, ///< User is holding screen down
-    MUTEX_ERROR // An error occured while taking/returning the mutex
+    E_TOUCH_ERROR // An error occured while taking/returning the mutex
 } last_touch_e_t;
 
 /**
@@ -105,8 +105,8 @@ namespace c {
  * \param color	The pen color to set (it is recommended to use values
  * 		 from the enum defined in colors.h)
  * 
- * \return Returns 1 if the mutex was successfully returned, or prosERR if there was an error either taking or
- * returning the screen mutex.
+ * \return Returns 1 if the mutex was successfully returned, or PROS_ERR if 
+ *         there was an error either taking or returning the screen mutex.
  */
 uint32_t screen_set_pen(uint32_t color);
 
@@ -120,8 +120,8 @@ uint32_t screen_set_pen(uint32_t color);
  * \param color	The background color to set (it is recommended to use values
  * 					from the enum defined in colors.h)
  * 
- * \return Returns 1 if the mutex was successfully returned, or prosERR if there was an error either taking or 
- * returning the screen mutex.
+ * \return Returns 1 if the mutex was successfully returned, or 
+ * prosERR if there was an error either taking or returning the screen mutex.
  */
 uint32_t screen_set_eraser(uint32_t color);
 
@@ -132,8 +132,9 @@ uint32_t screen_set_eraser(uint32_t color);
  * reached:
  * EACCESS - Another resource is currently trying to access the screen mutex.
  * 
- * \return The current pen color in the form of a value from the enum defined in colors.h, or PROS_ERR if there was an error taking 
- * or returning the screen mutex.
+ * \return The current pen color in the form of a value from the enum defined 
+ *         in colors.h, or PROS_ERR if there was an error taking or returning 
+ *         the screen mutex.
  */
 uint32_t screen_get_pen(void);
 
@@ -144,8 +145,9 @@ uint32_t screen_get_pen(void);
  * reached:
  * EACCESS - Another resource is currently trying to access the screen mutex.
  *
- * \return The current eraser color in the form of a value from the enum defined in colors.h, or PROS_ERR if there was an error 
- * taking or returning the screen mutex.
+ * \return The current eraser color in the form of a value from the enum 
+ *         defined in colors.h, or PROS_ERR if there was an error taking or 
+ *         returning the screen mutex.
  */
 uint32_t screen_get_eraser(void);
 
@@ -156,7 +158,8 @@ uint32_t screen_get_eraser(void);
  * reached:
  * EACCESS - Another resource is currently trying to access the screen mutex.
  * 
- * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+ * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *         taking or returning the screen mutex.
  */
 uint32_t screen_erase(void);
 
@@ -170,7 +173,8 @@ uint32_t screen_erase(void);
  * \param start_line    The line from which scrolling will start
  * \param lines			The number of lines to scroll up
  * 
- * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+ * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *         taking or returning the screen mutex.
  */
 uint32_t screen_scroll(int16_t start_line, int16_t lines);
 
@@ -191,7 +195,8 @@ uint32_t screen_scroll(int16_t start_line, int16_t lines);
  * 						rectangular region
  * \param lines 	The number of lines to scroll upwards
  * 
- * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+ * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *           taking or returning the screen mutex.
  */
 uint32_t screen_scroll_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t lines);
 
@@ -211,7 +216,8 @@ uint32_t screen_scroll_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int1
  * \param stride	Off-screen buffer width in pixels, such that image size
  * 						is stride-padding
  * 
- * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+ * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *         taking or returning the screen mutex.
  */
 uint32_t screen_copy_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint32_t* buf, int32_t stride);
 
@@ -224,7 +230,8 @@ uint32_t screen_copy_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint32
  *
  * \param x, y 	The (x,y) coordinates of the pixel
  * 
- * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+ * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *         taking or returning the screen mutex.
  */
 uint32_t screen_draw_pixel(int16_t x, int16_t y);
 
@@ -237,7 +244,8 @@ uint32_t screen_draw_pixel(int16_t x, int16_t y);
  *
  * \param x, y 	The (x,y) coordinates of the erased
  * 
- * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+ * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *         taking or returning the screen mutex.
  */
 uint32_t screen_erase_pixel(int16_t x, int16_t y);
 
@@ -251,7 +259,8 @@ uint32_t screen_erase_pixel(int16_t x, int16_t y);
  * \param x0, y0	The (x, y) coordinates of the first point of the line
  * \param x1, y1 	The (x, y) coordinates of the second point of the line
  * 
- * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+ * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *         taking or returning the screen mutex.
  */
 uint32_t screen_draw_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
 
@@ -265,7 +274,8 @@ uint32_t screen_draw_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
  * \param x0, y0	The (x, y) coordinates of the first point of the line
  * \param x1, y1 	The (x, y) coordinates of the second point of the line
  * 
- * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+  * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *         taking or returning the screen mutex.
  */
 uint32_t screen_erase_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
 
@@ -279,7 +289,8 @@ uint32_t screen_erase_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
  * \param x0, y0 	The (x,y) coordinates of the first point of the rectangle
  * \param x1, y1 	The (x,y) coordinates of the second point of the rectangle
  * 
- * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+  * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *         taking or returning the screen mutex.
  */
 uint32_t screen_draw_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
 
@@ -293,7 +304,8 @@ uint32_t screen_draw_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
  * \param x0, y0 	The (x,y) coordinates of the first point of the rectangle
  * \param x1, y1 	The (x,y) coordinates of the second point of the rectangle
  * 
- * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+  * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *         taking or returning the screen mutex.
  */
 uint32_t screen_erase_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
 
@@ -308,7 +320,8 @@ uint32_t screen_erase_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
  * \param x0, y0 	The (x,y) coordinates of the first point of the rectangle
  * \param x1, y1 	The (x,y) coordinates of the second point of the rectangle
  * 
- * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+  * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *         taking or returning the screen mutex.
  */
 uint32_t screen_fill_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
 
@@ -322,7 +335,8 @@ uint32_t screen_fill_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
  * \param x, y 	The (x,y) coordinates of the center of the circle
  * \param r 	The radius of the circle
  * 
- * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+  * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *         taking or returning the screen mutex.
  */
 uint32_t screen_draw_circle(int16_t x, int16_t y, int16_t radius);
 
@@ -336,7 +350,8 @@ uint32_t screen_draw_circle(int16_t x, int16_t y, int16_t radius);
  * \param x, y 	The (x,y) coordinates of the center of the circle
  * \param r 	The radius of the circle
  * 
- * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+  * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *         taking or returning the screen mutex.
  */
 uint32_t screen_erase_circle(int16_t x, int16_t y, int16_t radius);
 
@@ -351,7 +366,8 @@ uint32_t screen_erase_circle(int16_t x, int16_t y, int16_t radius);
  * \param x, y 	The (x,y) coordinates of the center of the circle
  * \param r 	The radius of the circle
  * 
- * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+  * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *         taking or returning the screen mutex.
  */
 uint32_t screen_fill_circle(int16_t x, int16_t y, int16_t radius);
 
@@ -371,7 +387,8 @@ uint32_t screen_fill_circle(int16_t x, int16_t y, int16_t radius);
  * \param text  Format string
  * \param ...  Optional list of arguments for the format string
  * 
- *  \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+ *  \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *          taking or returning the screen mutex.
  */
 uint32_t screen_print(text_format_e_t txt_fmt, const int16_t line, const char* text, ...);
 
@@ -388,7 +405,8 @@ uint32_t screen_print(text_format_e_t txt_fmt, const int16_t line, const char* t
  * \param text  Format string
  * \param ...  Optional list of arguments for the format string
  * 
- *  \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+ *  \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *          taking or returning the screen mutex.
  */
 uint32_t screen_print_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y, const char* text, ...);
 
@@ -410,7 +428,8 @@ uint32_t screen_print_at(text_format_e_t txt_fmt, const int16_t x, const int16_t
  * \param text  Format string
  * \param args List of arguments for the format string
  * 
- * \return 1 if there were no errors, or PROS_ERR if an error occured while taking or returning the screen mutex.
+ * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *          while taking or returning the screen mutex.
  */
 uint32_t screen_vprintf(text_format_e_t txt_fmt, const int16_t line, const char* text, va_list args);
 
@@ -434,7 +453,8 @@ uint32_t screen_vprintf(text_format_e_t txt_fmt, const int16_t line, const char*
  * \param text  Format string
  * \param args List of arguments for the format string
  *  
- * \return 1 if there were no errors, or PROS_ERR if an error occured while taking or returning the screen mutex.
+ * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *          while taking or returning the screen mutex.
  */
 uint32_t screen_vprintf_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y, const char* text, va_list args);
 
@@ -450,7 +470,8 @@ uint32_t screen_vprintf_at(text_format_e_t txt_fmt, const int16_t x, const int16
  * 
  * \return The last_touch_e_t enum specifier that indicates the last touch status of the screen (E_TOUCH_EVENT_RELEASE, E_TOUCH_EVENT_PRESS, or E_TOUCH_EVENT_PRESS_AND_HOLD).
  * This will be released by default if no action was taken. 
- * If an error occured, the screen_touch_status_s_t will have its last_touch_e_t enum specifier set to E_TOUCH_ERR, and other values set to -1.
+ * If an error occured, the screen_touch_status_s_t will have its last_touch_e_t
+ *  enum specifier set to E_TOUCH_ERR, and other values set to -1.
  */
 screen_touch_status_s_t screen_touch_status(void);
 
@@ -464,7 +485,8 @@ screen_touch_status_s_t screen_touch_status(void);
  * \param cb Function pointer to callback when event type happens
  * \param event_type Touch event that will trigger the callback.
  * 
- * \return 1 if there were no errors, or PROS_ERR if an error occured while taking or returning the screen mutex.
+ * \return 1 if there were no errors, or PROS_ERR if an error occured 
+ *          while taking or returning the screen mutex.
  */
 uint32_t screen_touch_callback(touch_event_cb_fn_t cb, last_touch_e_t event_type);
 

--- a/include/pros/screen.h
+++ b/include/pros/screen.h
@@ -390,7 +390,7 @@ uint32_t screen_print(text_format_e_t txt_fmt, const int16_t line, const char* t
  * 
  *  \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
-void screen_print_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y, const char* text, ...);
+uint32_t screen_print_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y, const char* text, ...);
 
 /**
  * Print a formatted string to the screen on the specified line

--- a/include/pros/screen.h
+++ b/include/pros/screen.h
@@ -47,7 +47,7 @@ typedef enum {
     E_TOUCH_RELEASED = 0, ///< Last interaction with screen was a quick press
     E_TOUCH_PRESSED, ///< Last interaction with screen was a release
     E_TOUCH_HELD, ///< User is holding screen down
-    E_TOUCH_ERROR // An error occured while taking/returning the mutex
+    E_TOUCH_ERROR ///< An error occured while taking/returning the mutex
 } last_touch_e_t;
 
 /**

--- a/include/pros/screen.h
+++ b/include/pros/screen.h
@@ -46,7 +46,8 @@ typedef enum {
 typedef enum {
     E_TOUCH_RELEASED = 0, ///< Last interaction with screen was a quick press
     E_TOUCH_PRESSED, ///< Last interaction with screen was a release
-    E_TOUCH_HELD ///< User is holding screen down 
+    E_TOUCH_HELD, ///< User is holding screen down
+    MUTEX_ERROR // An error occured while taking/returning the mutex
 } last_touch_e_t;
 
 /**
@@ -104,7 +105,8 @@ namespace c {
  * \param color	The pen color to set (it is recommended to use values
  * 		 from the enum defined in colors.h)
  * 
- * Returns 1 if the operation was successful or 0 if the task scheduler isn't running
+ * \return Returns 1 if the mutex was successfully returned, or prosERR if there was an error either taking or
+ * returning the screen mutex.
  */
 uint32_t screen_set_pen(uint32_t color);
 
@@ -118,7 +120,8 @@ uint32_t screen_set_pen(uint32_t color);
  * \param color	The background color to set (it is recommended to use values
  * 					from the enum defined in colors.h)
  * 
- * Returns 1 if the operation was successful or 0 if the task scheduler isn't running
+ * \return Returns 1 if the mutex was successfully returned, or prosERR if there was an error either taking or 
+ * returning the screen mutex.
  */
 uint32_t screen_set_eraser(uint32_t color);
 
@@ -129,7 +132,8 @@ uint32_t screen_set_eraser(uint32_t color);
  * reached:
  * EACCESS - Another resource is currently trying to access the screen mutex.
  * 
- * \return The current pen color in the form of a value from the enum defined in colors.h.
+ * \return The current pen color in the form of a value from the enum defined in colors.h, or PROS_ERR if there was an error taking 
+ * or returning the screen mutex.
  */
 uint32_t screen_get_pen(void);
 
@@ -140,7 +144,8 @@ uint32_t screen_get_pen(void);
  * reached:
  * EACCESS - Another resource is currently trying to access the screen mutex.
  *
- * \return The current eraser color in the form of a value from the enum defined in colors.h.
+ * \return The current eraser color in the form of a value from the enum defined in colors.h, or PROS_ERR if there was an error 
+ * taking or returning the screen mutex.
  */
 uint32_t screen_get_eraser(void);
 
@@ -150,8 +155,10 @@ uint32_t screen_get_eraser(void);
  * This function uses the following values of errno when an error state is
  * reached:
  * EACCESS - Another resource is currently trying to access the screen mutex.
+ * 
+ * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
-void screen_erase(void);
+uint32_t screen_erase(void);
 
 /**
  * Scroll lines on the display upwards.
@@ -162,8 +169,10 @@ void screen_erase(void);
  *
  * \param start_line    The line from which scrolling will start
  * \param lines			The number of lines to scroll up
+ * 
+ * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
-void screen_scroll(int16_t start_line, int16_t lines);
+uint32_t screen_scroll(int16_t start_line, int16_t lines);
 
 /**
  * Scroll lines within a region on the display
@@ -181,8 +190,10 @@ void screen_scroll(int16_t start_line, int16_t lines);
  * \param x1, y1	The (x,y) coordinates of the second corner of the
  * 						rectangular region
  * \param lines 	The number of lines to scroll upwards
+ * 
+ * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
-void screen_scroll_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t lines);
+uint32_t screen_scroll_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t lines);
 
 /**
  * Copy a screen region (designated by a rectangle) from an off-screen buffer 
@@ -199,8 +210,10 @@ void screen_scroll_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t 
  * \param buf		Off-screen buffer containing screen data
  * \param stride	Off-screen buffer width in pixels, such that image size
  * 						is stride-padding
+ * 
+ * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
-void screen_copy_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint32_t* buf, int32_t stride);
+uint32_t screen_copy_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint32_t* buf, int32_t stride);
 
 /**
  * Draw a single pixel on the screen using the current pen color
@@ -210,8 +223,10 @@ void screen_copy_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint32_t* 
  * EACCESS - Another resource is currently trying to access the screen mutex.
  *
  * \param x, y 	The (x,y) coordinates of the pixel
+ * 
+ * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
-void screen_draw_pixel(int16_t x, int16_t y);
+uint32_t screen_draw_pixel(int16_t x, int16_t y);
 
 /**
  * Erase a pixel from the screen (Sets the location)
@@ -221,8 +236,10 @@ void screen_draw_pixel(int16_t x, int16_t y);
  * EACCESS - Another resource is currently trying to access the screen mutex.
  *
  * \param x, y 	The (x,y) coordinates of the erased
+ * 
+ * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
-void screen_erase_pixel(int16_t x, int16_t y);
+uint32_t screen_erase_pixel(int16_t x, int16_t y);
 
 /**
  * Draw a line on the screen using the current pen color
@@ -233,8 +250,10 @@ void screen_erase_pixel(int16_t x, int16_t y);
  *
  * \param x0, y0	The (x, y) coordinates of the first point of the line
  * \param x1, y1 	The (x, y) coordinates of the second point of the line
+ * 
+ * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
-void screen_draw_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
+uint32_t screen_draw_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
 
 /**
  * Erase a line on the screen using the current eraser color
@@ -245,8 +264,10 @@ void screen_draw_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
  *
  * \param x0, y0	The (x, y) coordinates of the first point of the line
  * \param x1, y1 	The (x, y) coordinates of the second point of the line
+ * 
+ * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
-void screen_erase_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
+uint32_t screen_erase_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
 
 /**
  * Draw a rectangle on the screen using the current pen color
@@ -257,8 +278,10 @@ void screen_erase_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
  *
  * \param x0, y0 	The (x,y) coordinates of the first point of the rectangle
  * \param x1, y1 	The (x,y) coordinates of the second point of the rectangle
+ * 
+ * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
-void screen_draw_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
+uint32_t screen_draw_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
 
 /**
  * Erase a rectangle on the screen using the current eraser color
@@ -269,8 +292,10 @@ void screen_draw_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
  *
  * \param x0, y0 	The (x,y) coordinates of the first point of the rectangle
  * \param x1, y1 	The (x,y) coordinates of the second point of the rectangle
+ * 
+ * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
-void screen_erase_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
+uint32_t screen_erase_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
 
 /**
  * Fill a rectangular region of the screen using the current pen
@@ -282,8 +307,10 @@ void screen_erase_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
  *
  * \param x0, y0 	The (x,y) coordinates of the first point of the rectangle
  * \param x1, y1 	The (x,y) coordinates of the second point of the rectangle
+ * 
+ * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
-void screen_fill_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
+uint32_t screen_fill_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
 
 /**
  * Draw a circle on the screen using the current pen color
@@ -294,8 +321,10 @@ void screen_fill_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
  *
  * \param x, y 	The (x,y) coordinates of the center of the circle
  * \param r 	The radius of the circle
+ * 
+ * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
-void screen_draw_circle(int16_t x, int16_t y, int16_t radius);
+uint32_t screen_draw_circle(int16_t x, int16_t y, int16_t radius);
 
 /**
  * Erase a circle on the screen using the current eraser color
@@ -306,8 +335,10 @@ void screen_draw_circle(int16_t x, int16_t y, int16_t radius);
  *
  * \param x, y 	The (x,y) coordinates of the center of the circle
  * \param r 	The radius of the circle
+ * 
+ * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
-void screen_erase_circle(int16_t x, int16_t y, int16_t radius);
+uint32_t screen_erase_circle(int16_t x, int16_t y, int16_t radius);
 
 /**
  * Fill a circular region of the screen using the current pen
@@ -319,8 +350,10 @@ void screen_erase_circle(int16_t x, int16_t y, int16_t radius);
  *
  * \param x, y 	The (x,y) coordinates of the center of the circle
  * \param r 	The radius of the circle
+ * 
+ * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
-void screen_fill_circle(int16_t x, int16_t y, int16_t radius);
+uint32_t screen_fill_circle(int16_t x, int16_t y, int16_t radius);
 
 /******************************************************************************/
 /**                       Screen Text Display Functions                      **/
@@ -337,8 +370,10 @@ void screen_fill_circle(int16_t x, int16_t y, int16_t radius);
  * \param line The line number on which to print
  * \param text  Format string
  * \param ...  Optional list of arguments for the format string
+ * 
+ *  \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
-void screen_print(text_format_e_t txt_fmt, const int16_t line, const char* text, ...);
+uint32_t screen_print(text_format_e_t txt_fmt, const int16_t line, const char* text, ...);
 
 /**
  * Print a formatted string to the screen at the specified point
@@ -352,6 +387,8 @@ void screen_print(text_format_e_t txt_fmt, const int16_t line, const char* text,
  * \param y The x coordinate of the top left corner of the string
  * \param text  Format string
  * \param ...  Optional list of arguments for the format string
+ * 
+ *  \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
  */
 void screen_print_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y, const char* text, ...);
 
@@ -372,8 +409,10 @@ void screen_print_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y, 
  * \param line The line number on which to print
  * \param text  Format string
  * \param args List of arguments for the format string
+ * 
+ * \return 1 if there were no errors, or PROS_ERR if an error occured while taking or returning the screen mutex.
  */
-void screen_vprintf(text_format_e_t txt_fmt, const int16_t line, const char* text, va_list args);
+uint32_t screen_vprintf(text_format_e_t txt_fmt, const int16_t line, const char* text, va_list args);
 
 /**
  * Print a formatted string to the screen at the specified coordinates
@@ -394,8 +433,10 @@ void screen_vprintf(text_format_e_t txt_fmt, const int16_t line, const char* tex
  * \param x, y The (x,y) coordinates of the top left corner of the string
  * \param text  Format string
  * \param args List of arguments for the format string
+ *  
+ * \return 1 if there were no errors, or PROS_ERR if an error occured while taking or returning the screen mutex.
  */
-void screen_vprintf_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y, const char* text, va_list args);
+uint32_t screen_vprintf_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y, const char* text, va_list args);
 
 /******************************************************************************/
 /**                         Screen Touch Functions                           **/
@@ -406,13 +447,10 @@ void screen_vprintf_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y
 
 /**
  * Gets the touch status of the last touch of the screen.
- *
- * This function uses the following values of errno when an error state is
- * reached:
- * EACCESS - Another resource is currently trying to access the screen mutex.
  * 
  * \return The last_touch_e_t enum specifier that indicates the last touch status of the screen (E_TOUCH_EVENT_RELEASE, E_TOUCH_EVENT_PRESS, or E_TOUCH_EVENT_PRESS_AND_HOLD).
  * This will be released by default if no action was taken. 
+ * If an error occured, the screen_touch_status_s_t will have its last_touch_e_t enum specifier set to E_TOUCH_ERR, and other values set to -1.
  */
 screen_touch_status_s_t screen_touch_status(void);
 
@@ -425,8 +463,10 @@ screen_touch_status_s_t screen_touch_status(void);
  * 
  * \param cb Function pointer to callback when event type happens
  * \param event_type Touch event that will trigger the callback.
+ * 
+ * \return 1 if there were no errors, or PROS_ERR if an error occured while taking or returning the screen mutex.
  */
-void screen_touch_callback(touch_event_cb_fn_t cb, last_touch_e_t event_type);
+uint32_t screen_touch_callback(touch_event_cb_fn_t cb, last_touch_e_t event_type);
 
 #ifdef __cplusplus
 } //namespace c

--- a/include/pros/screen.h
+++ b/include/pros/screen.h
@@ -96,22 +96,38 @@ namespace c {
 
 /**
  * Set the pen color for subsequent graphics operations
+ * 
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
  *
  * \param color	The pen color to set (it is recommended to use values
  * 		 from the enum defined in colors.h)
+ * 
+ * Returns 1 if the operation was successful or 0 if the task scheduler isn't running
  */
-void screen_set_pen(uint32_t color);
+uint32_t screen_set_pen(uint32_t color);
 
 /**
  * Set the eraser color for erasing and the current background.
  *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
+ * 
  * \param color	The background color to set (it is recommended to use values
  * 					from the enum defined in colors.h)
+ * 
+ * Returns 1 if the operation was successful or 0 if the task scheduler isn't running
  */
-void screen_set_eraser(uint32_t color);
+uint32_t screen_set_eraser(uint32_t color);
 
 /**
  *  Get the current pen color.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
  * 
  * \return The current pen color in the form of a value from the enum defined in colors.h.
  */
@@ -120,17 +136,29 @@ uint32_t screen_get_pen(void);
 /**
  * Get the current eraser color.
  *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
+ *
  * \return The current eraser color in the form of a value from the enum defined in colors.h.
  */
 uint32_t screen_get_eraser(void);
 
 /**
  * Clear display with eraser color
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
  */
 void screen_erase(void);
 
 /**
  * Scroll lines on the display upwards.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
  *
  * \param start_line    The line from which scrolling will start
  * \param lines			The number of lines to scroll up
@@ -144,6 +172,10 @@ void screen_scroll(int16_t start_line, int16_t lines);
  * specify a rectangular region within which to scroll lines instead of a start
  * line.
  *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
+ *
  * \param x0, y0	The (x,y) coordinates of the first corner of the
  * 						rectangular region
  * \param x1, y1	The (x,y) coordinates of the second corner of the
@@ -155,6 +187,10 @@ void screen_scroll_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t 
 /**
  * Copy a screen region (designated by a rectangle) from an off-screen buffer 
  * to the screen
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
  *
  * \param x0, y0 	The (x,y) coordinates of the first corner of the
  * 						rectangular region of the screen
@@ -169,6 +205,10 @@ void screen_copy_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint32_t* 
 /**
  * Draw a single pixel on the screen using the current pen color
  *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
+ *
  * \param x, y 	The (x,y) coordinates of the pixel
  */
 void screen_draw_pixel(int16_t x, int16_t y);
@@ -176,12 +216,20 @@ void screen_draw_pixel(int16_t x, int16_t y);
 /**
  * Erase a pixel from the screen (Sets the location)
  *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
+ *
  * \param x, y 	The (x,y) coordinates of the erased
  */
 void screen_erase_pixel(int16_t x, int16_t y);
 
 /**
  * Draw a line on the screen using the current pen color
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
  *
  * \param x0, y0	The (x, y) coordinates of the first point of the line
  * \param x1, y1 	The (x, y) coordinates of the second point of the line
@@ -191,6 +239,10 @@ void screen_draw_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
 /**
  * Erase a line on the screen using the current eraser color
  *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
+ *
  * \param x0, y0	The (x, y) coordinates of the first point of the line
  * \param x1, y1 	The (x, y) coordinates of the second point of the line
  */
@@ -199,6 +251,10 @@ void screen_erase_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
 /**
  * Draw a rectangle on the screen using the current pen color
  *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
+ *
  * \param x0, y0 	The (x,y) coordinates of the first point of the rectangle
  * \param x1, y1 	The (x,y) coordinates of the second point of the rectangle
  */
@@ -206,6 +262,10 @@ void screen_draw_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
 
 /**
  * Erase a rectangle on the screen using the current eraser color
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
  *
  * \param x0, y0 	The (x,y) coordinates of the first point of the rectangle
  * \param x1, y1 	The (x,y) coordinates of the second point of the rectangle
@@ -216,6 +276,10 @@ void screen_erase_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
  * Fill a rectangular region of the screen using the current pen
  * 		  color
  *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
+ *
  * \param x0, y0 	The (x,y) coordinates of the first point of the rectangle
  * \param x1, y1 	The (x,y) coordinates of the second point of the rectangle
  */
@@ -223,6 +287,10 @@ void screen_fill_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
 
 /**
  * Draw a circle on the screen using the current pen color
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
  *
  * \param x, y 	The (x,y) coordinates of the center of the circle
  * \param r 	The radius of the circle
@@ -232,6 +300,10 @@ void screen_draw_circle(int16_t x, int16_t y, int16_t radius);
 /**
  * Erase a circle on the screen using the current eraser color
  *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
+ *
  * \param x, y 	The (x,y) coordinates of the center of the circle
  * \param r 	The radius of the circle
  */
@@ -240,6 +312,10 @@ void screen_erase_circle(int16_t x, int16_t y, int16_t radius);
 /**
  * Fill a circular region of the screen using the current pen
  * 		  color
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
  *
  * \param x, y 	The (x,y) coordinates of the center of the circle
  * \param r 	The radius of the circle
@@ -287,6 +363,10 @@ void screen_print_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y, 
  * 
  * Will default to a medium sized font by default if invalid txt_fmt is given.
  * Exposed mostly for writing libraries and custom functions.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
  * 
  * \param txt_fmt Text format enum that determines if the text is medium, large, medium_center, or large_center. (DOES NOT SUPPORT SMALL)
  * \param line The line number on which to print
@@ -305,6 +385,10 @@ void screen_vprintf(text_format_e_t txt_fmt, const int16_t line, const char* tex
  * 
  * Text formats medium_center and large_center will default to medium and large respectively.
  * Exposed mostly for writing libraries and custom functions.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
  * 
  * \param txt_fmt Text format enum that determines if the text is small, medium, or large.
  * \param x, y The (x,y) coordinates of the top left corner of the string
@@ -322,6 +406,10 @@ void screen_vprintf_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y
 
 /**
  * Gets the touch status of the last touch of the screen.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
  * 
  * \return The last_touch_e_t enum specifier that indicates the last touch status of the screen (E_TOUCH_EVENT_RELEASE, E_TOUCH_EVENT_PRESS, or E_TOUCH_EVENT_PRESS_AND_HOLD).
  * This will be released by default if no action was taken. 
@@ -330,6 +418,10 @@ screen_touch_status_s_t screen_touch_status(void);
 
 /**
  * Assigns a callback function to be called when a certain touch event happens.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * EACCESS - Another resource is currently trying to access the screen mutex.
  * 
  * \param cb Function pointer to callback when event type happens
  * \param event_type Touch event that will trigger the callback.

--- a/include/pros/screen.hpp
+++ b/include/pros/screen.hpp
@@ -45,46 +45,82 @@ const char* convert_args(const std::string& arg) {
 
     /**
      * Set the pen color for subsequent graphics operations
+     * 
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
      *
      * \param color	The pen color to set (it is recommended to use values
      * 		 from the enum defined in colors.h)
+     * 
+     * \return Returns 1 if the mutex was successfully returned, or prosERR if there was an error either taking or
+     * returning the screen mutex.
      */
-    void set_pen(const std::uint32_t color);
+    std::uint32_t set_pen(const std::uint32_t color);
 
     /**
-     * Set the eraser color for clearing and the current background.
+     * Set the eraser color for erasing and the current background.
      *
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     * 
      * \param color	The background color to set (it is recommended to use values
      * 					from the enum defined in colors.h)
+     * 
+     * \return Returns 1 if the mutex was successfully returned, or prosERR if there was an error either taking or 
+     * returning the screen mutex.
      */
-    void set_eraser(const std::uint32_t color);
+    std::uint32_t set_eraser(const std::uint32_t color);
 
     /**
      *  Get the current pen color.
+     *
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
      * 
-     * \return The current pen color of the screen object in the form of a value from the enum defined in colors.h.
+     * \return The current pen color in the form of a value from the enum defined in colors.h, or PROS_ERR if there was an error taking 
+     * or returning the screen mutex.
      */
     std::uint32_t get_pen();
 
     /**
      * Get the current eraser color.
      *
-     * \return The current eraser color of the screen object in the form of a value from the enum defined in colors.h.
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     *
+     * \return The current eraser color in the form of a value from the enum defined in colors.h, or PROS_ERR if there was an error 
+     * taking or returning the screen mutex.
      */
     std::uint32_t get_eraser();
 
     /**
      * Clear display with eraser color
+     *
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     * 
+     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
      */
-    void erase();
+    std::uint32_t erase();
 
     /**
      * Scroll lines on the display upwards.
      *
-     * \param start_line		The line from which scrolling will start
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     *
+     * \param start_line    The line from which scrolling will start
      * \param lines			The number of lines to scroll up
+     * 
+     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
      */
-    void scroll(const std::int16_t start_line, const std::int16_t lines);
+    std::uint32_t scroll(const std::int16_t start_line, const std::int16_t lines);
 
     /**
      * Scroll lines within a region on the display
@@ -93,17 +129,27 @@ const char* convert_args(const std::string& arg) {
      * specify a rectangular region within which to scroll lines instead of a start
      * line.
      *
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     *
      * \param x0, y0	The (x,y) coordinates of the first corner of the
      * 						rectangular region
      * \param x1, y1	The (x,y) coordinates of the second corner of the
      * 						rectangular region
      * \param lines 	The number of lines to scroll upwards
+     * 
+     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
      */
-    void scroll_area(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1, std::int16_t lines);
+    std::uint32_t scroll_area(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1, std::int16_t lines);
 
     /**
      * Copy a screen region (designated by a rectangle) from an off-screen buffer 
      * to the screen
+     *
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
      *
      * \param x0, y0 	The (x,y) coordinates of the first corner of the
      * 						rectangular region of the screen
@@ -112,88 +158,150 @@ const char* convert_args(const std::string& arg) {
      * \param buf		Off-screen buffer containing screen data
      * \param stride	Off-screen buffer width in pixels, such that image size
      * 						is stride-padding
+     * 
+     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
      */
-    void copy_area(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1, uint32_t* buf, const std::int32_t stride);
+    std::uint32_t copy_area(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1, uint32_t* buf, const std::int32_t stride);
 
     /**
      * Draw a single pixel on the screen using the current pen color
      *
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     *
      * \param x, y 	The (x,y) coordinates of the pixel
+     * 
+     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
      */
-    void draw_pixel(const std::int16_t x, const std::int16_t y);
+    std::uint32_t draw_pixel(const std::int16_t x, const std::int16_t y);
 
     /**
      * Erase a pixel from the screen (Sets the location)
      *
-     * \param x, y 	The (x,y) coordinates of the erased pixel
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     *
+     * \param x, y 	The (x,y) coordinates of the erased
+     * 
+     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
      */
-    void erase_pixel(const std::int16_t x, const std::int16_t y);
+    std::uint32_t erase_pixel(const std::int16_t x, const std::int16_t y);
 
     /**
      * Draw a line on the screen using the current pen color
      *
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     *
      * \param x0, y0	The (x, y) coordinates of the first point of the line
      * \param x1, y1 	The (x, y) coordinates of the second point of the line
+     * 
+     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
      */
-    void draw_line(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1);
+    std::uint32_t draw_line(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1);
 
     /**
      * Erase a line on the screen using the current eraser color
      *
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     *
      * \param x0, y0	The (x, y) coordinates of the first point of the line
      * \param x1, y1 	The (x, y) coordinates of the second point of the line
+     * 
+     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
      */
-    void erase_line(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1);
+    std::uint32_t erase_line(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1);
 
     /**
      * Draw a rectangle on the screen using the current pen color
      *
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     *
      * \param x0, y0 	The (x,y) coordinates of the first point of the rectangle
      * \param x1, y1 	The (x,y) coordinates of the second point of the rectangle
+     * 
+     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
      */
-    void draw_rect(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1);
+    std::uint32_t draw_rect(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1);
 
     /**
      * Erase a rectangle on the screen using the current eraser color
      *
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     *
      * \param x0, y0 	The (x,y) coordinates of the first point of the rectangle
      * \param x1, y1 	The (x,y) coordinates of the second point of the rectangle
+     * 
+     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
      */
-    void erase_rect(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1);
+    std::uint32_t erase_rect(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1);
 
     /**
      * Fill a rectangular region of the screen using the current pen
      * 		  color
      *
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     *
      * \param x0, y0 	The (x,y) coordinates of the first point of the rectangle
      * \param x1, y1 	The (x,y) coordinates of the second point of the rectangle
+     * 
+     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
      */
-    void fill_rect(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1);
+    std::uint32_t fill_rect(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1);
 
     /**
      * Draw a circle on the screen using the current pen color
      *
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     *
      * \param x, y 	The (x,y) coordinates of the center of the circle
      * \param r 	The radius of the circle
+     * 
+     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
      */
-    void draw_circle(const std::int16_t x, const std::int16_t y, const std::int16_t radius);
+    std::uint32_t draw_circle(const std::int16_t x, const std::int16_t y, const std::int16_t radius);
 
     /**
      * Erase a circle on the screen using the current eraser color
      *
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     *
      * \param x, y 	The (x,y) coordinates of the center of the circle
      * \param r 	The radius of the circle
+     * 
+     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
      */
-    void erase_circle(const std::int16_t x, const std::int16_t y, const std::int16_t radius);
+    std::uint32_t erase_circle(const std::int16_t x, const std::int16_t y, const std::int16_t radius);
 
     /**
      * Fill a circular region of the screen using the current pen
      * 		  color
      *
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     *
      * \param x, y 	The (x,y) coordinates of the center of the circle
      * \param r 	The radius of the circle
+     * 
+     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
      */
-    void fill_circle(const std::int16_t x, const std::int16_t y, const std::int16_t radius);
+    std::uint32_t fill_circle(const std::int16_t x, const std::int16_t y, const std::int16_t radius);
 
     /******************************************************************************/
     /**                       Screen Text Display Functions                      **/
@@ -230,20 +338,28 @@ const char* convert_args(const std::string& arg) {
     /**                    information about screen touches                      **/
     /******************************************************************************/
     
-    /**
-     * Gets the touch status of the last touch of the screen. 0 by default.
+   /**
+     * Gets the touch status of the last touch of the screen.
      * 
-     * \return The last_touch_e_t enum specifier that indicates the last touch status of the screen (E_TOUCH_EVENT_RELEASE, E_TOUCH_EVENT_PRESS, or E_TOUCH_EVENT_PRESS_AND_HOLD). 
+     * \return The last_touch_e_t enum specifier that indicates the last touch status of the screen (E_TOUCH_EVENT_RELEASE, E_TOUCH_EVENT_PRESS, or E_TOUCH_EVENT_PRESS_AND_HOLD).
+     * This will be released by default if no action was taken. 
+     * If an error occured, the screen_touch_status_s_t will have its last_touch_e_t enum specifier set to E_TOUCH_ERR, and other values set to -1.
      */
     screen_touch_status_s_t touch_status();
     
     /**
      * Assigns a callback function to be called when a certain touch event happens.
+     *
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
      * 
      * \param cb Function pointer to callback when event type happens
      * \param event_type Touch event that will trigger the callback.
+     * 
+     * \return 1 if there were no errors, or PROS_ERR if an error occured while taking or returning the screen mutex.
      */
-    void touch_callback(touch_event_cb_fn_t cb, last_touch_e_t event_type);
+    std::uint32_t touch_callback(touch_event_cb_fn_t cb, last_touch_e_t event_type);
 
 } //namespace screen
 } //namespace pros

--- a/include/pros/screen.hpp
+++ b/include/pros/screen.hpp
@@ -53,8 +53,8 @@ const char* convert_args(const std::string& arg) {
      * \param color	The pen color to set (it is recommended to use values
      * 		 from the enum defined in colors.h)
      * 
-     * \return Returns 1 if the mutex was successfully returned, or prosERR if there was an error either taking or
-     * returning the screen mutex.
+     * \return Returns 1 if the mutex was successfully returned, or prosERR if 
+     * there was an error either taking or returning the screen mutex.
      */
     std::uint32_t set_pen(const std::uint32_t color);
 
@@ -68,8 +68,8 @@ const char* convert_args(const std::string& arg) {
      * \param color	The background color to set (it is recommended to use values
      * 					from the enum defined in colors.h)
      * 
-     * \return Returns 1 if the mutex was successfully returned, or prosERR if there was an error either taking or 
-     * returning the screen mutex.
+     * \return Returns 1 if the mutex was successfully returned, or prosERR
+     *  if there was an error either taking or returning the screen mutex.
      */
     std::uint32_t set_eraser(const std::uint32_t color);
 
@@ -80,8 +80,9 @@ const char* convert_args(const std::string& arg) {
      * reached:
      * EACCESS - Another resource is currently trying to access the screen mutex.
      * 
-     * \return The current pen color in the form of a value from the enum defined in colors.h, or PROS_ERR if there was an error taking 
-     * or returning the screen mutex.
+     * \return The current pen color in the form of a value from the enum 
+     * defined in colors.h, or PROS_ERR if there was an error taking or 
+     * returning the screen mutex.
      */
     std::uint32_t get_pen();
 
@@ -92,8 +93,9 @@ const char* convert_args(const std::string& arg) {
      * reached:
      * EACCESS - Another resource is currently trying to access the screen mutex.
      *
-     * \return The current eraser color in the form of a value from the enum defined in colors.h, or PROS_ERR if there was an error 
-     * taking or returning the screen mutex.
+     * \return The current eraser color in the form of a value from the enum
+     *  defined in colors.h, or PROS_ERR if there was an error taking or 
+     *  returning the screen mutex.
      */
     std::uint32_t get_eraser();
 
@@ -104,7 +106,8 @@ const char* convert_args(const std::string& arg) {
      * reached:
      * EACCESS - Another resource is currently trying to access the screen mutex.
      * 
-     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+     * \return 1 if there were no errors, or PROS_ERR if an error occured 
+     *         taking or returning the screen mutex.
      */
     std::uint32_t erase();
 
@@ -118,7 +121,8 @@ const char* convert_args(const std::string& arg) {
      * \param start_line    The line from which scrolling will start
      * \param lines			The number of lines to scroll up
      * 
-     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+     * \return 1 if there were no errors, or PROS_ERR if an error occured
+     *  taking or returning the screen mutex.
      */
     std::uint32_t scroll(const std::int16_t start_line, const std::int16_t lines);
 
@@ -139,7 +143,8 @@ const char* convert_args(const std::string& arg) {
      * 						rectangular region
      * \param lines 	The number of lines to scroll upwards
      * 
-     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+     * \return 1 if there were no errors, or PROS_ERR if an error occured 
+     * taking or returning the screen mutex.
      */
     std::uint32_t scroll_area(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1, std::int16_t lines);
 
@@ -159,7 +164,8 @@ const char* convert_args(const std::string& arg) {
      * \param stride	Off-screen buffer width in pixels, such that image size
      * 						is stride-padding
      * 
-     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+     * \return 1 if there were no errors, or PROS_ERR if an error occured taking
+     *  or returning the screen mutex.
      */
     std::uint32_t copy_area(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1, uint32_t* buf, const std::int32_t stride);
 
@@ -172,7 +178,8 @@ const char* convert_args(const std::string& arg) {
      *
      * \param x, y 	The (x,y) coordinates of the pixel
      * 
-     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+     * \return 1 if there were no errors, or PROS_ERR if an error occured 
+     * taking or returning the screen mutex.
      */
     std::uint32_t draw_pixel(const std::int16_t x, const std::int16_t y);
 
@@ -185,7 +192,8 @@ const char* convert_args(const std::string& arg) {
      *
      * \param x, y 	The (x,y) coordinates of the erased
      * 
-     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+     * \return 1 if there were no errors, or PROS_ERR if an error occured 
+     * taking or returning the screen mutex.
      */
     std::uint32_t erase_pixel(const std::int16_t x, const std::int16_t y);
 
@@ -199,7 +207,8 @@ const char* convert_args(const std::string& arg) {
      * \param x0, y0	The (x, y) coordinates of the first point of the line
      * \param x1, y1 	The (x, y) coordinates of the second point of the line
      * 
-     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+     * \return 1 if there were no errors, or PROS_ERR if an error occured 
+     * taking or returning the screen mutex.
      */
     std::uint32_t draw_line(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1);
 
@@ -213,7 +222,8 @@ const char* convert_args(const std::string& arg) {
      * \param x0, y0	The (x, y) coordinates of the first point of the line
      * \param x1, y1 	The (x, y) coordinates of the second point of the line
      * 
-     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+     * \return 1 if there were no errors, or PROS_ERR if an error occured 
+     * taking or returning the screen mutex.
      */
     std::uint32_t erase_line(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1);
 
@@ -227,7 +237,8 @@ const char* convert_args(const std::string& arg) {
      * \param x0, y0 	The (x,y) coordinates of the first point of the rectangle
      * \param x1, y1 	The (x,y) coordinates of the second point of the rectangle
      * 
-     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+     * \return 1 if there were no errors, or PROS_ERR if an error occured 
+     * taking or returning the screen mutex.
      */
     std::uint32_t draw_rect(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1);
 
@@ -241,7 +252,8 @@ const char* convert_args(const std::string& arg) {
      * \param x0, y0 	The (x,y) coordinates of the first point of the rectangle
      * \param x1, y1 	The (x,y) coordinates of the second point of the rectangle
      * 
-     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+     * \return 1 if there were no errors, or PROS_ERR if an error occured 
+     * taking or returning the screen mutex.
      */
     std::uint32_t erase_rect(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1);
 
@@ -256,7 +268,8 @@ const char* convert_args(const std::string& arg) {
      * \param x0, y0 	The (x,y) coordinates of the first point of the rectangle
      * \param x1, y1 	The (x,y) coordinates of the second point of the rectangle
      * 
-     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+     * \return 1 if there were no errors, or PROS_ERR if an error occured 
+     * taking or returning the screen mutex.
      */
     std::uint32_t fill_rect(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1);
 
@@ -270,7 +283,8 @@ const char* convert_args(const std::string& arg) {
      * \param x, y 	The (x,y) coordinates of the center of the circle
      * \param r 	The radius of the circle
      * 
-     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+     * \return 1 if there were no errors, or PROS_ERR if an error occured 
+     * taking or returning the screen mutex.
      */
     std::uint32_t draw_circle(const std::int16_t x, const std::int16_t y, const std::int16_t radius);
 
@@ -284,7 +298,8 @@ const char* convert_args(const std::string& arg) {
      * \param x, y 	The (x,y) coordinates of the center of the circle
      * \param r 	The radius of the circle
      * 
-     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+     * \return 1 if there were no errors, or PROS_ERR if an error occured 
+     * taking or returning the screen mutex.
      */
     std::uint32_t erase_circle(const std::int16_t x, const std::int16_t y, const std::int16_t radius);
 
@@ -299,7 +314,8 @@ const char* convert_args(const std::string& arg) {
      * \param x, y 	The (x,y) coordinates of the center of the circle
      * \param r 	The radius of the circle
      * 
-     * \return 1 if there were no errors, or PROS_ERR if an error occured taking or returning the screen mutex.
+     * \return 1 if there were no errors, or PROS_ERR if an error occured 
+     * taking or returning the screen mutex.
      */
     std::uint32_t fill_circle(const std::int16_t x, const std::int16_t y, const std::int16_t radius);
 
@@ -343,7 +359,8 @@ const char* convert_args(const std::string& arg) {
      * 
      * \return The last_touch_e_t enum specifier that indicates the last touch status of the screen (E_TOUCH_EVENT_RELEASE, E_TOUCH_EVENT_PRESS, or E_TOUCH_EVENT_PRESS_AND_HOLD).
      * This will be released by default if no action was taken. 
-     * If an error occured, the screen_touch_status_s_t will have its last_touch_e_t enum specifier set to E_TOUCH_ERR, and other values set to -1.
+     * If an error occured, the screen_touch_status_s_t will have its 
+     * last_touch_e_t enum specifier set to E_TOUCH_ERR, and other values set to -1.
      */
     screen_touch_status_s_t touch_status();
     
@@ -357,7 +374,8 @@ const char* convert_args(const std::string& arg) {
      * \param cb Function pointer to callback when event type happens
      * \param event_type Touch event that will trigger the callback.
      * 
-     * \return 1 if there were no errors, or PROS_ERR if an error occured while taking or returning the screen mutex.
+     * \return 1 if there were no errors, or PROS_ERR if an error occured 
+     * while taking or returning the screen mutex.
      */
     std::uint32_t touch_callback(touch_event_cb_fn_t cb, last_touch_e_t event_type);
 

--- a/src/devices/screen.c
+++ b/src/devices/screen.c
@@ -36,112 +36,166 @@ typedef struct touch_event_position_data_s {
 	int16_t y;
 } touch_event_position_data_s_t;
 
-void screen_set_pen(uint32_t color){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+uint32_t screen_set_pen(uint32_t color){
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexDisplayForegroundColor(color);
-	mutex_give(_screen_mutex);
+	return xTaskGetSchedulerState() != taskSCHEDULER_RUNNING || mutex_give(_screen_mutex); // 0 if task scheduler isn't running
 }
 
-void screen_set_eraser(uint32_t color){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+uint32_t screen_set_eraser(uint32_t color){
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexDisplayBackgroundColor(color);
-	mutex_give(_screen_mutex);
+	return xTaskGetSchedulerState() != taskSCHEDULER_RUNNING || mutex_give(_screen_mutex);
 }
 
 uint32_t screen_get_pen(void){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
-	uint32_t color = vexDisplayForegroundColorGet();
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
+	uint32_t color = vexDisplayForegroundColorGet(); // What to return when an int's already being returned?
 	mutex_give(_screen_mutex);
 	return color;
 }
 
 uint32_t screen_get_eraser(void){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	uint32_t color = vexDisplayBackgroundColorGet();
 	mutex_give(_screen_mutex);
 	return color;
 }
 
 void screen_erase(void){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexDisplayErase();
 	mutex_give(_screen_mutex);
 }
 
 void screen_scroll(int16_t start_line, int16_t lines){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexDisplayScroll(start_line, lines);
 	mutex_give(_screen_mutex);
 }
 
 void screen_scroll_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t lines){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexDisplayScrollRect(x0, y0, x1, y1, lines);
 	mutex_give(_screen_mutex);
 }
 
 void screen_copy_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint32_t* buf, int32_t stride){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexDisplayCopyRect(x0, y0, x1, y1, buf, stride);
 	mutex_give(_screen_mutex);
 }
 
 void screen_draw_pixel(int16_t x, int16_t y){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexDisplayPixelSet(x, y);
 	mutex_give(_screen_mutex);
 }
 
 void screen_erase_pixel(int16_t x, int16_t y){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexDisplayPixelClear(x, y);
 	mutex_give(_screen_mutex);
 }
 
 void screen_draw_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexDisplayLineDraw(x0, y0, x1, y1);
 	mutex_give(_screen_mutex);
 }
 
 void screen_erase_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexDisplayLineClear(x0, y0, x1, y1);
 	mutex_give(_screen_mutex);
 }
 
 void screen_draw_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexDisplayRectDraw(x0, y0, x1, y1);
 	mutex_give(_screen_mutex);
 }
 
 void screen_erase_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexDisplayRectClear(x0, y0, x1, y1);
 	mutex_give(_screen_mutex);
 }
 
 void screen_fill_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexDisplayRectFill(x0, y0, x1, y1);
 	mutex_give(_screen_mutex);
 }
 
 void screen_draw_circle(int16_t x, int16_t y, int16_t radius){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexDisplayCircleDraw(x, y, radius);
 	mutex_give(_screen_mutex);
 }
 
 void screen_erase_circle(int16_t x, int16_t y, int16_t radius){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexDisplayCircleClear(x, y, radius);
 	mutex_give(_screen_mutex);
 }
 
 void screen_fill_circle(int16_t x, int16_t y, int16_t radius){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexDisplayCircleFill(x, y, radius);
 	mutex_give(_screen_mutex);
 }
@@ -167,7 +221,10 @@ void screen_print_at(text_format_e_t txt_fmt, int16_t x, int16_t y, const char* 
 }
 
 void screen_vprintf(text_format_e_t txt_fmt, const int16_t line, const char* text, va_list args){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	char* out;
 	vasprintf(&out, text, args);
 	va_list empty;
@@ -203,7 +260,10 @@ void screen_vprintf(text_format_e_t txt_fmt, const int16_t line, const char* tex
 }
 
 void screen_vprintf_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y, const char* text, va_list args){
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	char* out;
 	vasprintf(&out, text, args);
 	va_list empty;
@@ -242,7 +302,10 @@ void screen_vprintf_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y
 
 screen_touch_status_s_t screen_touch_status(void){
 	V5_TouchStatus v5_touch_status;
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	vexTouchDataGet(&v5_touch_status);
 	screen_touch_status_s_t rtv;
 	rtv.touch_status = (last_touch_e_t)v5_touch_status.lastEvent;
@@ -265,7 +328,10 @@ static void _set_up_touch_callback_storage() {
 }
 
 void screen_touch_callback(touch_event_cb_fn_t cb, last_touch_e_t event_type) {
-	mutex_take(_screen_mutex, TIMEOUT_MAX);
+	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+		errno = EACCES;
+		return PROS_ERR;
+	}
 	switch (event_type) {
 	case E_TOUCH_RELEASED:
 		linked_list_prepend_func(_touch_event_release_handler_list, (generic_fn_t)cb);
@@ -296,7 +362,10 @@ static inline bool _touch_status_equivalent(V5_TouchStatus x, V5_TouchStatus y) 
 void _touch_handle_task(void* ignore) {
 	V5_TouchStatus last, current;
 	while (true) {
-		mutex_take(_screen_mutex, TIMEOUT_MAX);
+		if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
+			errno = EACCES;
+			return PROS_ERR;
+		}
         vexTouchDataGet(&current);
 		if (!_touch_status_equivalent(current, last)) {
 			touch_event_position_data_s_t event_data = { .x = current.lastXpos, .y = current.lastYpos };

--- a/src/devices/screen.c
+++ b/src/devices/screen.c
@@ -459,7 +459,7 @@ static inline bool _touch_status_equivalent(V5_TouchStatus x, V5_TouchStatus y) 
 void _touch_handle_task(void* ignore) {
 	V5_TouchStatus last, current;
 	while (true) {
-		mutex_take(_screen_mutex, TIMEOUT_MAX)
+		mutex_take(_screen_mutex, TIMEOUT_MAX);
         vexTouchDataGet(&current);
 		if (!_touch_status_equivalent(current, last)) {
 			touch_event_position_data_s_t event_data = { .x = current.lastXpos, .y = current.lastYpos };
@@ -477,7 +477,7 @@ void _touch_handle_task(void* ignore) {
 			}
 			last = current;
 		}
-        mutex_give(_screen_mutex)
+        mutex_give(_screen_mutex);
 		delay(10);
 	}
 }

--- a/src/devices/screen.c
+++ b/src/devices/screen.c
@@ -42,7 +42,11 @@ uint32_t screen_set_pen(uint32_t color){
 		return PROS_ERR;
 	}
 	vexDisplayForegroundColor(color);
-	return xTaskGetSchedulerState() != taskSCHEDULER_RUNNING || mutex_give(_screen_mutex); // 0 if task scheduler isn't running
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
 uint32_t screen_set_eraser(uint32_t color){
@@ -51,7 +55,11 @@ uint32_t screen_set_eraser(uint32_t color){
 		return PROS_ERR;
 	}
 	vexDisplayBackgroundColor(color);
-	return xTaskGetSchedulerState() != taskSCHEDULER_RUNNING || mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
 uint32_t screen_get_pen(void){
@@ -59,8 +67,10 @@ uint32_t screen_get_pen(void){
 		errno = EACCES;
 		return PROS_ERR;
 	}
-	uint32_t color = vexDisplayForegroundColorGet(); // What to return when an int's already being returned?
-	mutex_give(_screen_mutex);
+	uint32_t color = vexDisplayForegroundColorGet();
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	}
 	return color;
 }
 
@@ -70,134 +80,192 @@ uint32_t screen_get_eraser(void){
 		return PROS_ERR;
 	}
 	uint32_t color = vexDisplayBackgroundColorGet();
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	}
 	return color;
 }
 
-void screen_erase(void){
+uint32_t screen_erase(void){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
 	}
 	vexDisplayErase();
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
-void screen_scroll(int16_t start_line, int16_t lines){
+uint32_t screen_scroll(int16_t start_line, int16_t lines){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
 	}
 	vexDisplayScroll(start_line, lines);
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
-void screen_scroll_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t lines){
+uint32_t screen_scroll_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t lines){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
 	}
 	vexDisplayScrollRect(x0, y0, x1, y1, lines);
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
-void screen_copy_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint32_t* buf, int32_t stride){
+uint32_t screen_copy_area(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint32_t* buf, int32_t stride){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
 	}
 	vexDisplayCopyRect(x0, y0, x1, y1, buf, stride);
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
-void screen_draw_pixel(int16_t x, int16_t y){
+uint32_t screen_draw_pixel(int16_t x, int16_t y){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
 	}
 	vexDisplayPixelSet(x, y);
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
-void screen_erase_pixel(int16_t x, int16_t y){
+uint32_t screen_erase_pixel(int16_t x, int16_t y){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
 	}
 	vexDisplayPixelClear(x, y);
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
-void screen_draw_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1){
+uint32_t screen_draw_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
 	}
 	vexDisplayLineDraw(x0, y0, x1, y1);
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
-void screen_erase_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1){
+uint32_t screen_erase_line(int16_t x0, int16_t y0, int16_t x1, int16_t y1){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
 	}
 	vexDisplayLineClear(x0, y0, x1, y1);
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
-void screen_draw_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1){
+uint32_t screen_draw_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
 	}
 	vexDisplayRectDraw(x0, y0, x1, y1);
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
-void screen_erase_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1){
+uint32_t screen_erase_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
 	}
 	vexDisplayRectClear(x0, y0, x1, y1);
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
-void screen_fill_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1){
+uint32_t screen_fill_rect(int16_t x0, int16_t y0, int16_t x1, int16_t y1){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
 	}
 	vexDisplayRectFill(x0, y0, x1, y1);
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
-void screen_draw_circle(int16_t x, int16_t y, int16_t radius){
+uint32_t screen_draw_circle(int16_t x, int16_t y, int16_t radius){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
 	}
 	vexDisplayCircleDraw(x, y, radius);
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
-void screen_erase_circle(int16_t x, int16_t y, int16_t radius){
+uint32_t screen_erase_circle(int16_t x, int16_t y, int16_t radius){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
 	}
 	vexDisplayCircleClear(x, y, radius);
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
-void screen_fill_circle(int16_t x, int16_t y, int16_t radius){
+uint32_t screen_fill_circle(int16_t x, int16_t y, int16_t radius){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
 	}
 	vexDisplayCircleFill(x, y, radius);
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
 /******************************************************************************/
@@ -206,21 +274,27 @@ void screen_fill_circle(int16_t x, int16_t y, int16_t radius){
 /**     These functions allow programmers to display text on the v5 screen   **/
 /******************************************************************************/
 
-void screen_print(text_format_e_t txt_fmt, const int16_t line, const char* text, ...){
+uint32_t screen_print(text_format_e_t txt_fmt, const int16_t line, const char* text, ...){
     va_list args;
     va_start(args, text);
-    screen_vprintf((uint8_t)txt_fmt, line, text, args);
+    if (screen_vprintf((uint8_t)txt_fmt, line, text, args) == PROS_ERR) {
+		return PROS_ERR;
+	}
     va_end(args);
+	return 1;
 }
 
-void screen_print_at(text_format_e_t txt_fmt, int16_t x, int16_t y, const char* text, ...){
+uint32_t screen_print_at(text_format_e_t txt_fmt, int16_t x, int16_t y, const char* text, ...){
     va_list args;
     va_start(args, text);
-    screen_vprintf_at((uint8_t)txt_fmt, x, y, text, args);
+    if (screen_vprintf_at((uint8_t)txt_fmt, x, y, text, args) == PROS_ERR) {
+		return PROS_ERR;
+	}
     va_end(args);
+	return 1;
 }
 
-void screen_vprintf(text_format_e_t txt_fmt, const int16_t line, const char* text, va_list args){
+uint32_t screen_vprintf(text_format_e_t txt_fmt, const int16_t line, const char* text, va_list args){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
@@ -256,10 +330,14 @@ void screen_vprintf(text_format_e_t txt_fmt, const int16_t line, const char* tex
             break;
         }
     }
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
-void screen_vprintf_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y, const char* text, va_list args){
+uint32_t screen_vprintf_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y, const char* text, va_list args){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
@@ -291,7 +369,11 @@ void screen_vprintf_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y
             break;
         }
     }
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 /******************************************************************************/
 /**                         Screen Touch Functions                           **/
@@ -303,8 +385,13 @@ void screen_vprintf_at(text_format_e_t txt_fmt, const int16_t x, const int16_t y
 screen_touch_status_s_t screen_touch_status(void){
 	V5_TouchStatus v5_touch_status;
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
-		errno = EACCES;
-		return PROS_ERR;
+		screen_touch_Status_s_t err;
+		err.touch_status = MUTEX_ERROR;
+		err.x = -1;
+		err.y = -1;
+		err.press_count = -1;
+		err.release_count = -1;
+		return err;
 	}
 	vexTouchDataGet(&v5_touch_status);
 	screen_touch_status_s_t rtv;
@@ -313,8 +400,16 @@ screen_touch_status_s_t screen_touch_status(void){
 	rtv.y = v5_touch_status.lastYpos;
 	rtv.press_count = v5_touch_status.pressCount;
 	rtv.release_count = v5_touch_status.releaseCount;
-	mutex_give(_screen_mutex);
-	return rtv;
+	if (!mutex_give(_screen_mutex)) {
+		rtv.touch_status = MUTEX_ERROR;
+		rtv.x = -1;
+		rtv.y = -1;
+		rtv.press_count = -1;
+		rtv.release_count = -1;
+		return rtv;
+	} else {
+		return rtv;
+	}
 }
 
 static linked_list_s_t* _touch_event_release_handler_list = NULL;
@@ -327,7 +422,7 @@ static void _set_up_touch_callback_storage() {
 	_touch_event_press_auto_handler_list = linked_list_init();
 }
 
-void screen_touch_callback(touch_event_cb_fn_t cb, last_touch_e_t event_type) {
+uint32_t screen_touch_callback(touch_event_cb_fn_t cb, last_touch_e_t event_type) {
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
@@ -343,7 +438,11 @@ void screen_touch_callback(touch_event_cb_fn_t cb, last_touch_e_t event_type) {
 		linked_list_prepend_func(_touch_event_press_auto_handler_list, (generic_fn_t)cb);
 		break;
 	}
-	mutex_give(_screen_mutex);
+	if (!mutex_give(_screen_mutex)) {
+		return PROS_ERR;
+	} else {
+		return 1;
+	}
 }
 
 static task_stack_t touch_handle_task_stack[TASK_STACK_DEPTH_DEFAULT];

--- a/src/devices/screen.cpp
+++ b/src/devices/screen.cpp
@@ -17,12 +17,12 @@
 namespace pros {
 namespace screen {
 
-    void set_pen(const std::uint32_t color){
-        pros::c::screen_set_pen(color);
+    std::uint32_t set_pen(const std::uint32_t color){
+        return pros::c::screen_set_pen(color);
     }
     
-    void set_eraser(const std::uint32_t color){
-        pros::c::screen_set_eraser(color);
+    std::uint32_t set_eraser(const std::uint32_t color){
+        return pros::c::screen_set_eraser(color);
     }
 
     std::uint32_t get_pen(){
@@ -33,68 +33,68 @@ namespace screen {
         return pros::c::screen_get_eraser();
     }
 
-    void erase(){
-        pros::c::screen_erase();
+    std::uint32_t erase(){
+        return pros::c::screen_erase();
     }
 
-    void scroll(const std::int16_t start_line, const std::int16_t lines){
-        pros::c::screen_scroll(start_line, lines);
+    std::uint32_t scroll(const std::int16_t start_line, const std::int16_t lines){
+        return pros::c::screen_scroll(start_line, lines);
     }
 
-    void scroll_area(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1, std::int16_t lines){
-        pros::c::screen_scroll_area(x0, y0, x1, y1, lines);
+    std::uint32_t scroll_area(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1, std::int16_t lines){
+        return pros::c::screen_scroll_area(x0, y0, x1, y1, lines);
     }
 
-    void copy_area(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1, uint32_t* buf, const std::int32_t stride){
-        pros::c::screen_copy_area( x0, y0, x1, y1, buf, stride);
+    std::uint32_t copy_area(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1, uint32_t* buf, const std::int32_t stride){
+        return pros::c::screen_copy_area( x0, y0, x1, y1, buf, stride);
     }
 
-    void draw_pixel(const std::int16_t x, const std::int16_t y){
-        pros::c::screen_draw_pixel(x, y);
+    std::uint32_t draw_pixel(const std::int16_t x, const std::int16_t y){
+        return pros::c::screen_draw_pixel(x, y);
     }
 
-    void erase_pixel(const std::int16_t x, const std::int16_t y){
-        pros::c::screen_erase_pixel(x, y);
+    std::uint32_t erase_pixel(const std::int16_t x, const std::int16_t y){
+        return pros::c::screen_erase_pixel(x, y);
     }
 
-    void draw_line(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1){
-        pros::c::screen_draw_line(x0, y0, x1, y1);
+    std::uint32_t draw_line(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1){
+        return pros::c::screen_draw_line(x0, y0, x1, y1);
     }
 
-    void erase_line(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1){
-        pros::c::screen_erase_line(x0, y0, x1, y1);
+    std::uint32_t erase_line(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1){
+        return pros::c::screen_erase_line(x0, y0, x1, y1);
     }
 
-    void draw_rect(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1){
-        pros::c::screen_draw_rect(x0, y0, x1, y1);
+    std::uint32_t draw_rect(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1){
+        return pros::c::screen_draw_rect(x0, y0, x1, y1);
     }
 
-    void erase_rect(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1){
-        pros::c::screen_erase_rect(x0, y0, x1, y1);
+    std::uint32_t erase_rect(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1){
+        return pros::c::screen_erase_rect(x0, y0, x1, y1);
     }
 
-    void fill_rect(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1){
-        pros::c::screen_fill_rect(x0, y0, x1, y1);
+    std::uint32_t fill_rect(const std::int16_t x0, const std::int16_t y0, const std::int16_t x1, const std::int16_t y1){
+        return pros::c::screen_fill_rect(x0, y0, x1, y1);
     }
 
-    void draw_circle(const std::int16_t x, const std::int16_t y, const std::int16_t radius){
-        pros::c::screen_draw_circle(x, y, radius);
+    std::uint32_t draw_circle(const std::int16_t x, const std::int16_t y, const std::int16_t radius){
+        return pros::c::screen_draw_circle(x, y, radius);
     }
 
-    void erase_circle(const std::int16_t x, const std::int16_t y, const std::int16_t radius){
-        pros::c::screen_erase_circle(x, y, radius);
+    std::uint32_t erase_circle(const std::int16_t x, const std::int16_t y, const std::int16_t radius){
+        return pros::c::screen_erase_circle(x, y, radius);
     }
 
-    void fill_circle(const std::int16_t x, const std::int16_t y, const std::int16_t radius){
-        pros::c::screen_fill_circle(x, y, radius);
+    std::uint32_t fill_circle(const std::int16_t x, const std::int16_t y, const std::int16_t radius){
+        return pros::c::screen_fill_circle(x, y, radius);
     }
 
     screen_touch_status_s_t touch_status() {
         return pros::c::screen_touch_status();
     }
 
-    void touch_callback(touch_event_cb_fn_t cb, last_touch_e_t event_type){
-        pros::c::screen_touch_callback(cb, event_type);
+    std::uint32_t touch_callback(touch_event_cb_fn_t cb, last_touch_e_t event_type){
+        return pros::c::screen_touch_callback(cb, event_type);
     }
 
 }  // namespace screen


### PR DESCRIPTION
#### Summary:
Implemented error catching and handling for the screen class, where if an error is detected (e.g. a mutex isn't able to be taken), the method in question will catch the error, set errno to the proper error, and return PROS_ERR. 

#### Motivation:
The screen class didn't have any error catching or handling, as such this addition will help users when debugging their code.

##### References (optional):
closes #328 

#### Test Plan:
While a mutex is taken, run methods from the screen class; if they set errno correctly and return PROS_ERR, then the error handling works fine.

- [ ] test item
