### PR TITLE
🐛Temporarily Retarget CLI install to 3.2.3 for CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
       artifactFeeds: 'pros-cli'
       # use official PyPi registry first and fall back to internal feed as needed
       onlyAddExtraIndex: true
-  - bash: pip install pros-cli
+  - bash: pip install pros-cli==3.2.3
     displayName: Install CLI
   - bash: |
       make template


### PR DESCRIPTION
#### Summary:
Since the CI broke on the newest CLI release, we should temporarily retarget the CLI install to 3.2.3 to keep development going.

Of course, this is temporary until issues with the CI are fixed. 
