### PR TITLE
Remove "explicit" from Task constructor

### DIFF
--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -58,7 +58,7 @@ class Task {
 	 *        debugging. The name may be up to 32 characters long.
 	 *
 	 */
-	explicit Task(task_fn_t function, void* parameters = nullptr, std::uint32_t prio = TASK_PRIORITY_DEFAULT,
+	Task(task_fn_t function, void* parameters = nullptr, std::uint32_t prio = TASK_PRIORITY_DEFAULT,
 	              std::uint16_t stack_depth = TASK_STACK_DEPTH_DEFAULT, const char* name = "");
 
 	/**


### PR DESCRIPTION
#### Summary:
Removes ``explicit`` from the Task constructor in rtos.hpp. That's all.