### PR TITLE
🐛Fix Link Port Claim Failures

### DIFF
--- a/include/api.h
+++ b/include/api.h
@@ -68,7 +68,6 @@
 #include "pros/distance.hpp"
 #include "pros/gps.hpp"
 #include "pros/imu.hpp"
-#include "pros/link.hpp"
 #include "pros/llemu.hpp"
 #include "pros/misc.hpp"
 #include "pros/motors.hpp"
@@ -77,6 +76,7 @@
 #include "pros/rtos.hpp"
 #include "pros/screen.hpp"
 #include "pros/vision.hpp"
+#include "pros/link.hpp"
 #endif
 
 #endif  // _PROS_API_H_

--- a/include/api.h
+++ b/include/api.h
@@ -68,6 +68,7 @@
 #include "pros/distance.hpp"
 #include "pros/gps.hpp"
 #include "pros/imu.hpp"
+#include "pros/link.hpp"
 #include "pros/llemu.hpp"
 #include "pros/misc.hpp"
 #include "pros/motors.hpp"
@@ -76,7 +77,6 @@
 #include "pros/rtos.hpp"
 #include "pros/screen.hpp"
 #include "pros/vision.hpp"
-#include "pros/link.hpp"
 #endif
 
 #endif  // _PROS_API_H_

--- a/src/devices/vdml_link.c
+++ b/src/devices/vdml_link.c
@@ -28,29 +28,22 @@ static const uint8_t START_BYTE = 0x33;
 
 // necessary because if an override is used on the only radio on the brain, the
 // device is registered still as a radio but has the generic serial icon on the brain 
-// Therefore, just if the controller radio is overriden, it can be either a serial device or radio
-// else, it must be a generic serial device or something has gone wrong.
+// :/
 
-#define claim_port_link(port, err_val)                                                      \
-    if (!VALIDATE_PORT_NO(port)) {                                                          \
-		errno = EINVAL;                                                                     \
-		return err_val;                                                                     \
-	}                                                                                       \
-    v5_device_e_t plugged_device = registry_get_plugged_type(port);                         \
-    v5_smart_device_s_t* device = registry_get_device(port);                                \
-    if(*((bool*)device->pad) == true) {                                                     \
-        if(plugged_device != E_DEVICE_SERIAL && plugged_device != E_DEVICE_RADIO) {         \
-            return err_val;                                                                 \
-        }                                                                                   \
-    }                                                                                       \
-    else if(plugged_device != E_DEVICE_SERIAL) {                                            \
-        return err_val;                                                                     \
-    }                                                                                       \
-                                                                                            \
-	if (!port_mutex_take(port - 1)) {                                                       \
-		errno = EACCES;                                                                     \
-		return err_val;                                                                     \
-	}                                                                                       \
+#define claim_port_link(port, err_val) \
+    if (!VALIDATE_PORT_NO(port)) {                                                  \
+		errno = EINVAL;                                                                 \
+		return err_val;                                                                \
+	}                                                                                   \
+    v5_device_e_t plugged_device = registry_get_plugged_type(port);                 \
+    if(plugged_device != E_DEVICE_SERIAL && plugged_device != E_DEVICE_RADIO) {           \
+        return err_val;                                                                \
+    }                                                                                   \
+	v5_smart_device_s_t* device = registry_get_device(port);                        \
+	if (!port_mutex_take(port - 1)) {                                                   \
+		errno = EACCES;                                                                 \
+		return err_val;                                                                \
+	}                                                                                   \
 
 
 // internal function for clearing the rx buffer 
@@ -78,8 +71,6 @@ static uint32_t _link_init_wrapper(uint8_t port, const char* link_id, link_type_
         return PROS_ERR;
     }
 	v5_smart_device_s_t* device = registry_get_device(port - 1);
-    // set whether this device is an override radio or not
-    *((bool*)device->pad) = ov;
 	if (!port_mutex_take(port - 1)) {
 		errno = EACCES;
 		return PROS_ERR;

--- a/src/devices/vdml_link.c
+++ b/src/devices/vdml_link.c
@@ -28,22 +28,29 @@ static const uint8_t START_BYTE = 0x33;
 
 // necessary because if an override is used on the only radio on the brain, the
 // device is registered still as a radio but has the generic serial icon on the brain 
-// :/
+// Therefore, just if the controller radio is overriden, it can be either a serial device or radio
+// else, it must be a generic serial device or something has gone wrong.
 
-#define claim_port_link(port, err_val) \
-    if (!VALIDATE_PORT_NO(port)) {                                                  \
-		errno = EINVAL;                                                                 \
-		return err_val;                                                                \
-	}                                                                                   \
-    v5_device_e_t plugged_device = registry_get_plugged_type(port);                 \
-    if(plugged_device != E_DEVICE_SERIAL && plugged_device != E_DEVICE_RADIO) {           \
-        return err_val;                                                                \
-    }                                                                                   \
-	v5_smart_device_s_t* device = registry_get_device(port);                        \
-	if (!port_mutex_take(port - 1)) {                                                   \
-		errno = EACCES;                                                                 \
-		return err_val;                                                                \
-	}                                                                                   \
+#define claim_port_link(port, err_val)                                                      \
+    if (!VALIDATE_PORT_NO(port)) {                                                          \
+		errno = EINVAL;                                                                     \
+		return err_val;                                                                     \
+	}                                                                                       \
+    v5_device_e_t plugged_device = registry_get_plugged_type(port);                         \
+    v5_smart_device_s_t* device = registry_get_device(port);                                \
+    if(*((bool*)device->pad) == true) {                                                     \
+        if(plugged_device != E_DEVICE_SERIAL && plugged_device != E_DEVICE_RADIO) {         \
+            return err_val;                                                                 \
+        }                                                                                   \
+    }                                                                                       \
+    else if(plugged_device != E_DEVICE_SERIAL) {                                            \
+        return err_val;                                                                     \
+    }                                                                                       \
+                                                                                            \
+	if (!port_mutex_take(port - 1)) {                                                       \
+		errno = EACCES;                                                                     \
+		return err_val;                                                                     \
+	}                                                                                       \
 
 
 // internal function for clearing the rx buffer 
@@ -70,6 +77,8 @@ static uint32_t _link_init_wrapper(uint8_t port, const char* link_id, link_type_
     if(plugged_device != E_DEVICE_NONE && plugged_device != E_DEVICE_RADIO) {
         return PROS_ERR;
     }
+    // set whether this device is an override radio or not
+    *((bool*)device->pad) = ov;
 	v5_smart_device_s_t* device = registry_get_device(port - 1);
 	if (!port_mutex_take(port - 1)) {
 		errno = EACCES;

--- a/src/devices/vdml_link.c
+++ b/src/devices/vdml_link.c
@@ -77,9 +77,9 @@ static uint32_t _link_init_wrapper(uint8_t port, const char* link_id, link_type_
     if(plugged_device != E_DEVICE_NONE && plugged_device != E_DEVICE_RADIO) {
         return PROS_ERR;
     }
+	v5_smart_device_s_t* device = registry_get_device(port - 1);
     // set whether this device is an override radio or not
     *((bool*)device->pad) = ov;
-	v5_smart_device_s_t* device = registry_get_device(port - 1);
 	if (!port_mutex_take(port - 1)) {
 		errno = EACCES;
 		return PROS_ERR;


### PR DESCRIPTION
#### Summary:
There's a case where the only radio on the brain is the VEXLink radio, and even with an override the icon on the brain shows as a "generic serial device" but the VEXos still believes that it's a radio. This PR fixes it by allowing VEXLink devices to also be radios. 

- [ ] Test case below works:
- [ ] Test more thoroughly with cases other than the code below:

```C++
void initialize() {
    pros::c::delay(50);
    pros::c::link_init_override(20, "TEST", pros::E_LINK_TRANSMITTER);

    while (!pros::c::link_connected(20)) {
      pros::c::delay(20);
    }
}

```
