### PR TITLE
🐛Add getentropy to newlib stubs

### DIFF
--- a/src/system/newlib_stubs.c
+++ b/src/system/newlib_stubs.c
@@ -46,6 +46,10 @@ unsigned sleep( unsigned period ) {
 	return 1;
 }
 
+int getentropy(void *_buffer, size_t _length) {
+	return -1;
+}
+
 // HACK: this helps confused libc++ functions call the right instruction. for
 // info see https://github.com/purduesigbots/pros/issues/153#issuecomment-519335375
 void __sync_synchronize(void) {

--- a/src/system/newlib_stubs.c
+++ b/src/system/newlib_stubs.c
@@ -47,6 +47,7 @@ unsigned sleep( unsigned period ) {
 }
 
 int getentropy(void *_buffer, size_t _length) {
+	errno = ENOSYS;
 	return -1;
 }
 


### PR DESCRIPTION
#### Summary:
Add a stub implementation of the `getentropy` function to the newlib stubs included in libpros.

#### Motivation:
Currently, if the arm-none-eabi toolchain's libc is too new, it will emit a reference to getentropy, which results in a linker error

##### References

Closes https://github.com/purduesigbots/pros/issues/362

#### Test Plan:

- [ ] Make sure that a new project with the patched libpros.a builds on Arch Linux
