### PR TITLE
🐛 fix linker script improper use of keyword as region name

### DIFF
--- a/firmware/v5-common.ld
+++ b/firmware/v5-common.ld
@@ -27,15 +27,15 @@ SECTIONS
    *(.vfp11_veneer)
    *(.ARM.extab)
    *(.gnu.linkonce.armextab.*)
-} > MEMORY
-
+} > RAM
+ 
 .init : {
    KEEP (*(.init))
-} > MEMORY
+} > RAM
 
 .fini : {
    KEEP (*(.fini))
-} > MEMORY
+} > RAM
 
 .rodata : {
    __rodata_start = .;
@@ -43,14 +43,14 @@ SECTIONS
    *(.rodata.*)
    *(.gnu.linkonce.r.*)
    __rodata_end = .;
-} > MEMORY
+} > RAM
 
 .rodata1 : {
    __rodata1_start = .;
    *(.rodata1)
    *(.rodata1.*)
    __rodata1_end = .;
-} > MEMORY
+} > RAM
 
 .sdata2 : {
    __sdata2_start = .;
@@ -58,7 +58,7 @@ SECTIONS
    *(.sdata2.*)
    *(.gnu.linkonce.s2.*)
    __sdata2_end = .;
-} > MEMORY
+} > RAM
 
 .sbss2 : {
    __sbss2_start = .;
@@ -66,7 +66,7 @@ SECTIONS
    *(.sbss2.*)
    *(.gnu.linkonce.sb2.*)
    __sbss2_end = .;
-} > MEMORY
+} > RAM
 
 .data : {
    __data_start = .;
@@ -77,18 +77,18 @@ SECTIONS
    *(.got)
    *(.got.plt)
    __data_end = .;
-} > MEMORY
+} > RAM
 
 .data1 : {
    __data1_start = .;
    *(.data1)
    *(.data1.*)
    __data1_end = .;
-} > MEMORY
+} > RAM
 
 .got : {
    *(.got)
-} > MEMORY
+} > RAM
 
 .ctors : {
    __CTOR_LIST__ = .;
@@ -99,7 +99,7 @@ SECTIONS
    KEEP (*(.ctors))
    __CTOR_END__ = .;
    ___CTORS_END___ = .;
-} > MEMORY
+} > RAM
 
 .dtors : {
    __DTOR_LIST__ = .;
@@ -110,67 +110,67 @@ SECTIONS
    KEEP (*(.dtors))
    __DTOR_END__ = .;
    ___DTORS_END___ = .;
-} > MEMORY
+} > RAM
 
 .fixup : {
    __fixup_start = .;
    *(.fixup)
    __fixup_end = .;
-} > MEMORY
+} > RAM
 
 .eh_frame : {
    *(.eh_frame)
-} > MEMORY
+} > RAM
 
 .eh_framehdr : {
    __eh_framehdr_start = .;
    *(.eh_framehdr)
    __eh_framehdr_end = .;
-} > MEMORY
+} > RAM
 
 .gcc_except_table : {
    *(.gcc_except_table)
-} > MEMORY
+} > RAM
 
 .mmu_tbl (ALIGN(16384)) : {
    __mmu_tbl_start = .;
    *(.mmu_tbl)
    __mmu_tbl_end = .;
-} > MEMORY
+} > RAM
 
 .ARM.exidx : {
    __exidx_start = .;
    *(.ARM.exidx*)
    *(.gnu.linkonce.armexidix.*.*)
    __exidx_end = .;
-} > MEMORY
+} > RAM
 
 .preinit_array : {
    __preinit_array_start = .;
    KEEP (*(SORT(.preinit_array.*)))
    KEEP (*(.preinit_array))
    __preinit_array_end = .;
-} > MEMORY
+} > RAM
 
 .init_array : {
    __init_array_start = .;
    KEEP (*(SORT(.init_array.*)))
    KEEP (*(.init_array))
    __init_array_end = .;
-} > MEMORY
+} > RAM
 
 .fini_array : {
    __fini_array_start = .;
    KEEP (*(SORT(.fini_array.*)))
    KEEP (*(.fini_array))
    __fini_array_end = .;
-} > MEMORY
+} > RAM
 
 .ARM.attributes : {
    __ARM.attributes_start = .;
    *(.ARM.attributes)
    __ARM.attributes_end = .;
-} > MEMORY
+} > RAM
 
 .sdata : {
    __sdata_start = .;
@@ -178,7 +178,7 @@ SECTIONS
    *(.sdata.*)
    *(.gnu.linkonce.s.*)
    __sdata_end = .;
-} > MEMORY
+} > RAM
 
 .sbss (NOLOAD) : {
    __sbss_start = .;
@@ -186,7 +186,7 @@ SECTIONS
    *(.sbss.*)
    *(.gnu.linkonce.sb.*)
    __sbss_end = .;
-} > MEMORY
+} > RAM
 
 .tdata : {
    __tdata_start = .;
@@ -194,7 +194,7 @@ SECTIONS
    *(.tdata.*)
    *(.gnu.linkonce.td.*)
    __tdata_end = .;
-} > MEMORY
+} > RAM
 
 .tbss : {
    __tbss_start = .;
@@ -202,7 +202,7 @@ SECTIONS
    *(.tbss.*)
    *(.gnu.linkonce.tb.*)
    __tbss_end = .;
-} > MEMORY
+} > RAM
 
 .bss (NOLOAD) : {
    __bss_start = .;
@@ -211,7 +211,7 @@ SECTIONS
    *(.gnu.linkonce.b.*)
    *(COMMON)
    __bss_end = .;
-} > MEMORY
+} > RAM
 
 _SDA_BASE_ = __sdata_start + ((__sbss_end - __sdata_start) / 2 );
 

--- a/firmware/v5-common.ld
+++ b/firmware/v5-common.ld
@@ -28,7 +28,7 @@ SECTIONS
    *(.ARM.extab)
    *(.gnu.linkonce.armextab.*)
 } > RAM
- 
+
 .init : {
    KEEP (*(.init))
 } > RAM

--- a/firmware/v5-hot.ld
+++ b/firmware/v5-hot.ld
@@ -28,6 +28,6 @@ MEMORY
    HOT_MEMORY : ORIGIN = start_of_hot_mem, LENGTH = _HOT_MEM_SIZE  /* Just over 8 MB */
 }
 
-REGION_ALIAS("MEMORY", HOT_MEMORY);
+REGION_ALIAS("RAM", HOT_MEMORY);
 
 ENTRY(install_hot_table)

--- a/firmware/v5.ld
+++ b/firmware/v5.ld
@@ -28,6 +28,6 @@ MEMORY
    HOT_MEMORY : ORIGIN = start_of_hot_mem, LENGTH = _HOT_MEM_SIZE  /* Just over 8 MB */
 }
 
-REGION_ALIAS("MEMORY", COLD_MEMORY);
+REGION_ALIAS("RAM", COLD_MEMORY);
 
 ENTRY(vexStartup)


### PR DESCRIPTION
Gnu ld 2.38 now uses MEMORY as a keyword, while the pros linker scripts uses it as the name of a region, causing an error during linking that prevents any project from building. This PR contains a simple fix for that by renaming all instances of MEMORY to RAM. 

closes #364 