### PR TITLE
✨Add MutexVar

### DIFF
--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -624,7 +624,7 @@ class MutexVar {
 	MutexVarLock<Var> lock() {
 		while (!mutex.take(TIMEOUT_MAX))
 			;
-		return {{mutex, var}};
+		return {mutex, var};
 	}
 };
 

--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -28,6 +28,7 @@
 #include <cstdlib>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <type_traits>
 
 namespace pros {
@@ -531,6 +532,99 @@ class Mutex {
 	template <typename Duration>
 	bool try_lock_until(const std::chrono::time_point<Clock, Duration>& abs_time) {
 		return take(std::max(static_cast<uint32_t>(0), (abs_time - Clock::now()).count()));
+	}
+};
+
+template <typename Var>
+class MutexVar;
+
+template <typename Var>
+class MutexVarLock {
+	Mutex& mutex;
+	Var& var;
+
+	friend class MutexVar<Var>;
+
+	constexpr MutexVarLock(Mutex& mutex, Var& var) : mutex(mutex), var(var) {}
+
+	public:
+	/**
+	 * Accesses the value of the mutex-protected variable.
+	 */
+	constexpr Var& operator*() const {
+		return var;
+	}
+
+	/**
+	 * Accesses the value of the mutex-protected variable.
+	 */
+	constexpr Var* operator->() const {
+		return &var;
+	}
+
+	~MutexVarLock() {
+		mutex.unlock();
+	}
+};
+
+template <typename Var>
+class MutexVar {
+	Mutex mutex;
+	Var var;
+
+	public:
+	/**
+	 * Creates a mutex-protected variable which is initialized with the given
+	 * constructor arguments.
+	 *
+	 * \param args
+	          The arguments to provide to the Var constructor.
+	 */
+	template <typename... Args>
+	MutexVar(Args&&... args) : mutex(), var(std::forward<Args>(args)...) {}
+
+	/**
+	 * Try to lock the mutex-protected variable.
+	 *
+	 * \param timeout
+	 *        Time to wait before the mutex becomes available, in milliseconds. A
+	 *        timeout of 0 can be used to poll the mutex.
+	 *
+	 * \return A std::optional which contains a MutexVarLock providing access to
+	 * the protected variable if locking is successful.
+	 */
+	std::optional<MutexVarLock<Var>> try_lock(std::uint32_t timeout) {
+		if (mutex.take(timeout)) {
+			return {{mutex, var}};
+		} else {
+			return {};
+		}
+	}
+
+	/**
+	 * Try to lock the mutex-protected variable.
+	 *
+	 * \param timeout
+	 *        Time to wait before the mutex becomes available. A timeout of 0 can
+	 *        be used to poll the mutex.
+	 *
+	 * \return A std::optional which contains a MutexVarLock providing access to
+	 * the protected variable if locking is successful.
+	 */
+	template <typename Rep, typename Period>
+	std::optional<MutexVarLock<Var>> try_lock(const std::chrono::duration<Rep, Period>& rel_time) {
+		try_lock(std::chrono::duration_cast<Clock::duration>(rel_time).count());
+	}
+
+	/**
+	 * Lock the mutex-protected variable, waiting indefinitely.
+	 *
+	 * \return A MutexVarLock providing access to the protected variable.
+	 */
+	MutexVarLock<Var> lock() {
+		while (!mutex.take(TIMEOUT_MAX))
+			;
+		return {{mutex, var}};
 	}
 };
 

--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -60,7 +60,7 @@ class Task {
 	 *
 	 */
 	Task(task_fn_t function, void* parameters = nullptr, std::uint32_t prio = TASK_PRIORITY_DEFAULT,
-	              std::uint16_t stack_depth = TASK_STACK_DEPTH_DEFAULT, const char* name = "");
+	     std::uint16_t stack_depth = TASK_STACK_DEPTH_DEFAULT, const char* name = "");
 
 	/**
 	 * Creates a new task and add it to the list of tasks that are ready to run.
@@ -155,8 +155,8 @@ class Task {
 	 *
 	 */
 	template <class F>
-	explicit Task(F&& function, std::uint32_t prio = TASK_PRIORITY_DEFAULT, std::uint16_t stack_depth = TASK_STACK_DEPTH_DEFAULT,
-	     const char* name = "")
+	explicit Task(F&& function, std::uint32_t prio = TASK_PRIORITY_DEFAULT,
+	              std::uint16_t stack_depth = TASK_STACK_DEPTH_DEFAULT, const char* name = "")
 	    : Task(
 	          [](void* parameters) {
 		          std::unique_ptr<std::function<void()>> ptr{static_cast<std::function<void()>*>(parameters)};
@@ -281,8 +281,8 @@ class Task {
 	std::uint32_t notify();
 
 	/**
- 	 * Utilizes task notifications to wait until specified task is complete and deleted,
- 	 * then continues to execute the program. Analogous to std::thread::join in C++.
+	 * Utilizes task notifications to wait until specified task is complete and deleted,
+	 * then continues to execute the program. Analogous to std::thread::join in C++.
 	 *
 	 * See https://pros.cs.purdue.edu/v5/tutorials/topical/notifications.html for
 	 * details.


### PR DESCRIPTION
#### Summary:
Add a new class template, `MutexVar<Var>`, which wraps a mutex and a variable of type `Var`, allowing access to the protected variable only via a `MutexVarLock`, which is a specialized RAII handle representing exclusive access.

#### Motivation:
This is inspired by and implements the same pattern as [Rust's `Mutex` type](https://doc.rust-lang.org/std/sync/struct.Mutex.html). It provides a means of using the compiler to enforce a contract of exclusive access to a variable via a mutex, rather than relying on the programmer to ensure that they bracket accesses with `take()` and `give()` calls. The RAII pattern also ensures that it is exception-safe.

#### Test Plan:

- [ ] Test the following program:

```cpp
MutexVar<bool> flag{false};

void opcontrol() {
  Task([] {
    for (int i = 0; i < 100; i++) {
      *flag.lock() = true;
      delay(10);
    }
  });

  while (true) {
    if (*flag.lock()) {
      std::cout << "Flag" << std::endl;
    }
    delay(1);
  }
}
```