### PR TITLE
Resolve compiler warnings for doxygen comment blocks in imu.h

### DIFF
--- a/include/pros/imu.h
+++ b/include/pros/imu.h
@@ -45,10 +45,10 @@ namespace c {
  * @brief Indicates IMU status.
  */
 typedef enum imu_status_e {
-	/// The IMU is calibrating
+	/** The IMU is calibrating */
 	E_IMU_STATUS_CALIBRATING = 0x01,
-	/// Used to indicate that an error state was reached in the imu_get_status function,\
-	not that the IMU is necessarily in an error state
+	/** Used to indicate that an error state was reached in the imu_get_status function,\
+	not that the IMU is necessarily in an error state */
 	E_IMU_STATUS_ERROR = 0xFF,
 } imu_status_e_t;
 
@@ -471,8 +471,10 @@ imu_status_e_t imu_get_status(uint8_t port);
 // void imu_set_mode(uint8_t port, uint32_t mode);
 // uint32_t imu_get_mode(uint8_t port);
 
-/// \name Value Reset Functions
-///@{
+/**
+ * \name Value Reset Functions 
+ * @{
+*/
 
 /**
  * Resets the current reading of the Inertial Sensor's heading to zero
@@ -682,10 +684,12 @@ int32_t imu_tare_euler(uint8_t port);
  */
 int32_t imu_tare(uint8_t port);
 
-///@}
+/** @} */
 
-/// \name Value Set Functions
-///@{
+/**
+ * \name Value Set Functions
+ * @{
+*/
 
 /**
  * Sets the current reading of the Inertial Sensor's euler values to
@@ -883,9 +887,9 @@ int32_t imu_set_roll(uint8_t port, double target);
  */
 int32_t imu_set_yaw(uint8_t port, double target);
 
-///@}
+/** @} */
 
-///@}
+/** @} */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
#### Summary:
During compilation of the develop-pros-4 branch there are multiple warnings about the doxygen style comment blocks in the `include/imu.h` file such as:
```
In file included from ./include/api.h:55,
                 from ./include/kapi.h:21,
                 from src/system/startup.c:18:
./include/pros/imu.h:50:2: warning: multi-line comment [-Wcomment]
   50 |  /// Used to indicate that an error state was reached in the imu_get_status function,\
      |  ^
```

Doxygen allows for multiple styles of comment blocks so it is better to go with something that does not generate such warnings.

#### Motivation:
Removing these warnings will allow for more efficient development of pros 4 and replacing the comment block style is a better alternative than suppressing the warnings.

##### References (optional):
From the [Doxygen Manual](https://www.doxygen.nl/manual/docblocks.html) we have multiple options for creating comment blocks that doxygen will recognize and include in the generated documentation in this case I implemented the Javadoc style comment blocks. 

#### Test Plan:
- [x] Compile the develop-pros-4 branch with the old comment style -- results in comment block style warnings
- [x] Compile the develop-pros-4 branch with the javadoc style comment -- results in no warnings for comment blocks
