### PR TITLE
🎨 Remove Redundant Port Validation

### DIFF
--- a/include/vdml/vdml.h
+++ b/include/vdml/vdml.h
@@ -41,10 +41,6 @@
  *        The error code that return if error checking failed
  */
 #define claim_port(port, device_type, error_code)          \
-  if (!VALIDATE_PORT_NO(port)) {                           \
-    errno = ENXIO;                                         \
-    return error_code;                                     \
-  }                                                        \
   if (registry_validate_binding(port, device_type) != 0) { \
     return error_code;                                     \
   }                                                        \


### PR DESCRIPTION
#### Summary:
Removes redundant port number validation in claim_port, the reason being that it's already done in registry_validate_binding. This is to ensure that 

#### Motivation:
Although this is a relatively small change, claim_port is used often throughout our code and constantly called as an easy way to retrieve a registry mutex whenever a user needs to interact with the hardware. I'm not sure how much of an optimization it is, but given the sheer amount of times it gets called we might as well remove this double check which I don't think would be optimized out.

#### Test plan:
Although this change effects every hardware interacting call... testing only one device should be enough since it's just a macro.
- [x] Run code on hardware and make sure that an invalid port has the correct errno value and return value reaction.
- [ ] Run code on hardware and make sure valid ports still mean that the device call still executes correctly.

