### PR TITLE
✨Add Blocking Reset Option for IMU

### DIFF
--- a/include/pros/imu.h
+++ b/include/pros/imu.h
@@ -88,6 +88,27 @@ typedef struct __attribute__((__packed__)) euler_s {
  */
 int32_t imu_reset(uint8_t port);
 
+/**
+ * Calibrate IMU and Blocks while Calibrating
+ *
+ * Calibration takes approximately 2 seconds and blocks during this period, 
+ * with a timeout for this operation being set a 3 seconds as a safety margin.
+ * Like the other reset function, this function also blocks until the IMU 
+ * status flag is set properly to E_IMU_STATUS_CALIBRATING, with a minimum 
+ * blocking time of 5ms and a timeout of 1 second if it's never set.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * ENXIO - The given value is not within the range of V5 ports (1-21).
+ * ENODEV - The port cannot be configured as an Inertial Sensor
+ * EAGAIN - The sensor is already calibrating, or time out setting the status flag.
+ *
+ * \param port
+ *        The V5 Inertial Sensor port number from 1-21
+ * \return 1 if the operation was successful or PROS_ERR if the operation
+ * failed (timing out or port claim failure), setting errno.
+ */
+int32_t imu_reset_blocking(uint8_t port);
 
 /**
  * Set the Inertial Sensor's refresh interval in milliseconds.

--- a/include/pros/imu.hpp
+++ b/include/pros/imu.hpp
@@ -31,9 +31,11 @@ class Imu {
 	/**
 	 * Calibrate IMU
 	 *
-	 * Calibration takes approximately 2 seconds, but this function only blocks
- 	 * until the IMU status flag is set properly to E_IMU_STATUS_CALIBRATING,
-	 * with a minimum blocking time of 5ms.
+	 * Calibration takes approximately 2 seconds and blocks during this period if 
+	 * the blocking param is true, with a timeout for this operation being set a 3 
+	 * seconds as a safety margin. This function also blocks until the IMU 
+	 * status flag is set properly to E_IMU_STATUS_CALIBRATING, with a minimum 
+	 * blocking time of 5ms and a timeout of 1 second if it's never set.
 	 * 
 	 * This function uses the following values of errno when an error state is
 	 * reached:
@@ -41,10 +43,12 @@ class Imu {
 	 * ENODEV - The port cannot be configured as an Inertial Sensor
 	 * EAGAIN - The sensor is already calibrating, or time out setting the status flag.
 	 *
+	 * \param blocking 
+	 *			Whether this function blocks during calibration.
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 */
-	virtual std::int32_t reset() const;
+	virtual std::int32_t reset(bool blocking = false) const;
 	/**
 	* Set the Inertial Sensor's refresh interval in milliseconds.
 	*
@@ -63,7 +67,8 @@ class Imu {
 	* ENODEV - The port cannot be configured as an Inertial Sensor
 	* EAGAIN - The sensor is still calibrating
 	*
-	* \param rate The data refresh interval in milliseconds
+	* \param rate 
+	*			The data refresh interval in milliseconds
 	* \return 1 if the operation was successful or PROS_ERR if the operation
 	* failed, setting errno.
 	*/

--- a/src/devices/vdml_imu.c
+++ b/src/devices/vdml_imu.c
@@ -27,7 +27,8 @@
 		return_port(port - 1, err_return);                                         \
 	}
 
-#define IMU_RESET_TIMEOUT 1000
+#define IMU_RESET_FLAG_SET_TIMEOUT 1000
+#define IMU_RESET_TIMEOUT 3000 // Canonically this should be 2s, but 3s for good margin
 
 typedef struct __attribute__ ((packed)) imu_reset_data { 
 	double heading_offset;
@@ -50,13 +51,51 @@ int32_t imu_reset(uint8_t port) {
 		task_delay(5);
 		timeoutCount += 5;
 		claim_port_i(port - 1, E_DEVICE_IMU);
-		if (timeoutCount >= IMU_RESET_TIMEOUT) {
+		if (timeoutCount >= IMU_RESET_FLAG_SET_TIMEOUT) {
 			port_mutex_give(port - 1);
 			errno = EAGAIN;
 			return PROS_ERR;
 		}
 		device = device; // suppressing compiler warning
 	} while(!(vexDeviceImuStatusGet(device->device_info) & E_IMU_STATUS_CALIBRATING));
+	port_mutex_give(port - 1);
+	return 1;
+}
+
+int32_t imu_reset_blocking(uint8_t port) {
+	claim_port_i(port - 1, E_DEVICE_IMU);
+	ERROR_IMU_STILL_CALIBRATING(port, device, PROS_ERR);
+	vexDeviceImuReset(device->device_info);
+	// delay for vexos to set calibration flag, background processing must be called for flag
+	// to be set.
+	uint16_t timeoutCount = 0;
+	// releasing mutex so vexBackgroundProcessing can run without being blocked.
+	do {
+		port_mutex_give(port - 1);
+		task_delay(5);
+		timeoutCount += 5;
+		claim_port_i(port - 1, E_DEVICE_IMU);
+		if (timeoutCount >= IMU_RESET_FLAG_SET_TIMEOUT) {
+			port_mutex_give(port - 1);
+			errno = EAGAIN;
+			return PROS_ERR;
+		}
+		device = device; // suppressing compiler warning
+	} while(!(vexDeviceImuStatusGet(device->device_info) & E_IMU_STATUS_CALIBRATING));
+	// same concept here, we add a blocking delay for the blocking version to wait
+	// until the IMU calibrating flag is cleared
+	do {
+		port_mutex_give(port - 1);
+		task_delay(5);
+		timeoutCount += 5;
+		claim_port_i(port - 1, E_DEVICE_IMU);
+		if (timeoutCount >= IMU_RESET_TIMEOUT) {
+			port_mutex_give(port - 1);
+			errno = EAGAIN;
+			return PROS_ERR;
+		}
+		device = device; // suppressing compiler warning
+	} while(vexDeviceImuStatusGet(device->device_info) & E_IMU_STATUS_CALIBRATING);
 	port_mutex_give(port - 1);
 	return 1;
 }

--- a/src/devices/vdml_imu.cpp
+++ b/src/devices/vdml_imu.cpp
@@ -13,7 +13,7 @@
 #include "pros/imu.hpp"
 
 namespace pros {
-std::int32_t Imu::reset(bool blocking = false) const {
+std::int32_t Imu::reset(bool blocking /*= false*/) const {
 	return blocking ? pros::c::imu_reset_blocking(_port) : pros::c::imu_reset(_port);
 }
 

--- a/src/devices/vdml_imu.cpp
+++ b/src/devices/vdml_imu.cpp
@@ -13,8 +13,8 @@
 #include "pros/imu.hpp"
 
 namespace pros {
-std::int32_t Imu::reset() const {
-	return pros::c::imu_reset(_port);
+std::int32_t Imu::reset(bool blocking = false) const {
+	return blocking ? pros::c::imu_reset_blocking(_port) : pros::c::imu_reset(_port);
 }
 
 std::int32_t Imu::set_data_rate(std::uint32_t rate) const {


### PR DESCRIPTION
### Summary:
Added an option in the C and C++ API for a calibration function to block while resetting instead of forcing the user to do it every time.
#### API Addition Summary:
#### C:
- `pros::c::reset_blocking();`

#### C++:
Added a default parameter to Imu::reset that doesn't block by default, but will block if `.reset(true);` is called.
- `pros::Imu::reset(bool blocking = false);`


### Motivation:
Improve the PROS API and its usability

### References:
#398 

### Test Plan:
This should be a short hardware test:
- [x] Test on hardware, make sure both forms of reset/calibration work as intended.
