### PR TITLE
🐛 Fix Issues with Screen Touchbacks and Touch Status

### DIFF
--- a/include/pros/screen.h
+++ b/include/pros/screen.h
@@ -83,7 +83,7 @@ typedef struct screen_touch_status_s {
 #endif
 #endif
 
-typedef void (*touch_event_cb_fn_t)(int16_t, int16_t);
+typedef void (*touch_event_cb_fn_t)();
 
 #ifdef __cplusplus
 namespace c {

--- a/src/devices/screen.c
+++ b/src/devices/screen.c
@@ -382,29 +382,26 @@ uint32_t screen_vprintf_at(text_format_e_t txt_fmt, const int16_t x, const int16
 /**                    information about screen touches                      **/
 /******************************************************************************/
 
+static const screen_touch_status_s_t PROS_SCREEN_ERR = {.touch_status = E_TOUCH_ERROR, .x = -1, .y = -1, .press_count = -1, .release_count = -1};
+
 screen_touch_status_s_t screen_touch_status(void){
-	V5_TouchStatus v5_touch_status;
-	bool mutex_take_failed = 1;
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
-		mutex_take_failed = 0;
+		errno = EACCES;
+		return PROS_SCREEN_ERR;
 	}
-	vexTouchDataGet(&v5_touch_status);
+	V5_TouchStatus v5_touch_status;
 	screen_touch_status_s_t rtv;
+	vexTouchDataGet(&v5_touch_status);
 	rtv.touch_status = (last_touch_e_t)v5_touch_status.lastEvent;
 	rtv.x = v5_touch_status.lastXpos;
 	rtv.y = v5_touch_status.lastYpos;
 	rtv.press_count = v5_touch_status.pressCount;
 	rtv.release_count = v5_touch_status.releaseCount;
-	if (mutex_take_failed == 1 || !mutex_give(_screen_mutex)) {
-		rtv.touch_status = E_TOUCH_ERROR;
-		rtv.x = -1;
-		rtv.y = -1;
-		rtv.press_count = -1;
-		rtv.release_count = -1;
-		return rtv;
-	} else {
-		return rtv;
-	}
+	if (!mutex_give(_screen_mutex)) {
+		errno = EACCES;
+		return PROS_SCREEN_ERR;
+	} 
+	return rtv;
 }
 
 static linked_list_s_t* _touch_event_release_handler_list = NULL;
@@ -447,9 +444,9 @@ static task_stack_t touch_handle_task_stack[TASK_STACK_DEPTH_DEFAULT];
 static static_task_s_t touch_handle_task_buffer;
 static task_t touch_handle_task;
 
-static void _handle_cb(ll_node_s_t* current, void* data) {
-	((touch_event_cb_fn_t)(current->payload.func))(((touch_event_position_data_s_t*)(data))->x,
-	                                               ((touch_event_position_data_s_t*)(data))->y);
+// volatile because some linters think this is going to be optimized out
+static volatile void _handle_cb(ll_node_s_t* current, void* extra_data) {
+	(current->payload.func)();
 }
 
 static inline bool _touch_status_equivalent(V5_TouchStatus x, V5_TouchStatus y) {
@@ -461,23 +458,21 @@ void _touch_handle_task(void* ignore) {
 	while (true) {
 		mutex_take(_screen_mutex, TIMEOUT_MAX);
         vexTouchDataGet(&current);
+		mutex_give(_screen_mutex);
 		if (!_touch_status_equivalent(current, last)) {
-			touch_event_position_data_s_t event_data = { .x = current.lastXpos, .y = current.lastYpos };
 			switch (current.lastEvent) {
 			case E_TOUCH_RELEASED:
-				linked_list_foreach(_touch_event_release_handler_list, _handle_cb, (void*)&event_data);
+				linked_list_foreach(_touch_event_release_handler_list, _handle_cb, NULL);
 				break;
 			case E_TOUCH_PRESSED:
-				linked_list_foreach(_touch_event_press_handler_list, _handle_cb, (void*)&event_data);
+				linked_list_foreach(_touch_event_press_handler_list, _handle_cb, NULL);
 				break;
 			case E_TOUCH_HELD:
-				linked_list_foreach(_touch_event_press_auto_handler_list, _handle_cb,
-				                    (void*)&event_data);
+				linked_list_foreach(_touch_event_press_auto_handler_list, _handle_cb, NULL);
 				break;
 			}
 			last = current;
 		}
-        mutex_give(_screen_mutex);
 		delay(10);
 	}
 }


### PR DESCRIPTION
#### Summary:
Fixed touchbacks causing a prefetch error, as well as fixing the touch status to not hang.

#### Test Procedure:

Both features were tested with the following codes:

```C++
void opcontrol() {
    pros::screen_touch_status_s_t status;
    while(1){
       status = pros::c::screen_touch_status();

       // Will print various information about the last touch
       pros::lcd::print(pros::TEXT_MEDIUM, 1, "Touch Status (Type): %d", status.touch_status);
       pros::lcd::print(pros::TEXT_MEDIUM, 2, "Last X: %d", status.x);
       pros::lcd::print(pros::TEXT_MEDIUM, 3, "Last Y: %d", status.y);
       pros::lcd::print(pros::TEXT_MEDIUM, 4, "Press Count: %d", status.press_count);
       pros::lcd::print(pros::TEXT_MEDIUM, 5, "Release Count: %d", status.release_count);
       pros::delay(20);
    }
}
```

```C++
void changePixel(){
   pros::screen_touch_status_s_t status = pros::screen::touch_status();
   printf("touch callback excuted: %d %d \n", status.x,status.y);
}

void opcontrol() {
   pros::Controller master(pros::E_CONTROLLER_MASTER);
   pros::Motor left_mtr(1);
   pros::Motor right_mtr(2);

   pros::screen::touch_callback(changePixel, TOUCH_PRESSED);
   while(1) {
	// printf("Spinning\n");
	pros::delay(20);
   }
}
```

#### Conclusion

Both codes work after fixes. Inspired by discord tech support and #404 
