### PR TITLE
✨Missing Motor Group Methods

### DIFF
--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -1152,7 +1152,7 @@ class Motor_Group {
 	std::vector<double> get_target_positions(void);
 
 
-   /**
+       /**
 	 * Gets the absolute position of the motor in its encoder units.
 	 *
 	 * This function uses the following values of errno when an error state is

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -1152,7 +1152,7 @@ class Motor_Group {
 	std::vector<double> get_target_positions(void);
 
 
-/**
+   /**
 	 * Gets the absolute position of the motor in its encoder units.
 	 *
 	 * This function uses the following values of errno when an error state is

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -1094,6 +1094,19 @@ class Motor_Group {
 	 */
 	std::int32_t set_encoder_units(const motor_encoder_units_e_t units);
 
+	/**
+	 * Sets the "absolute" zero position of the motor group to its current position.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 * EACCESS - The Motor group mutex can't be taken or given
+	 * 
+	 * \return 1 if the operation was successful or PROS_ERR if the operation
+	 * failed, setting errno.
+	 */
+	std::int32_t tare_position(void);
+
   /****************************************************************************/
 	/**                        Motor telemetry functions                       **/
 	/**                                                                        **/
@@ -1138,6 +1151,18 @@ class Motor_Group {
 	 */
 	std::vector<double> get_target_positions(void);
 
+
+/**
+	 * Gets the absolute position of the motor in its encoder units.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 * \return The motor's absolute position in its encoder units or PROS_ERR_F
+	 * if the operation failed, setting errno.
+	 */
+	std::vector<double> get_positions(void);
 /**
 	 * Gets the efficiency of the motors in percent.
 	 *

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -427,6 +427,13 @@ std::int32_t Motor_Group::set_encoder_units(const motor_encoder_units_e_t units)
 	give_mg_mutex(PROS_ERR);
 	return out;
 }
+std::int32_t Motor_Group::tare_position(void) {
+	claim_mg_mutex(PROS_ERR);
+	std::int32_t out = PROS_SUCCESS;
+	mg_foreach(tare_position(), _motors, out);
+	give_mg_mutex(PROS_ERR);
+	return out;
+}
 
 std::vector<double> Motor_Group::get_target_positions(void) {
 	std::vector<double> out;
@@ -438,6 +445,15 @@ std::vector<double> Motor_Group::get_target_positions(void) {
 	return out;
 }
 
+std::vector<double> Motor_Group::get_positions(void) {
+	std::vector<double> out;
+	claim_mg_mutex_vector(PROS_ERR_F);
+	for(Motor motor : _motors) {
+		out.push_back(motor.get_position());
+	}
+	give_mg_mutex_vector(PROS_ERR_F);
+	return out;
+}
 std::vector<double> Motor_Group::get_efficiencies(void) {
 	std::vector<double> out;
 	claim_mg_mutex_vector(PROS_ERR_F);

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -454,6 +454,7 @@ std::vector<double> Motor_Group::get_positions(void) {
 	give_mg_mutex_vector(PROS_ERR_F);
 	return out;
 }
+
 std::vector<double> Motor_Group::get_efficiencies(void) {
 	std::vector<double> out;
 	claim_mg_mutex_vector(PROS_ERR_F);


### PR DESCRIPTION
#### Summary:
Adds missing methods for motor groups.
Adds tare_position and get_position
closes #407 