### PR TITLE
🐛Add `.cache/` to .gitignore to prevent extra files from being committed

### DIFF
--- a/template-gitignore
+++ b/template-gitignore
@@ -9,6 +9,7 @@
 # PROS
 bin/
 .vscode/
+.cache/
 compile_commands.json
 temp.log
 temp.errors


### PR DESCRIPTION
#### Summary:
Added `.cache/` to .gitignore

#### Motivation:
This stops a bajillion files appearing in git.
