### PR TITLE
fix ext_adi_led_set and ext_adi_led_set_pixel

### DIFF
--- a/src/devices/vdml_ext_adi.c
+++ b/src/devices/vdml_ext_adi.c
@@ -462,10 +462,10 @@ ext_adi_led_t ext_adi_led_init(uint8_t smart_port, uint8_t adi_port) {
 
 int32_t ext_adi_led_set(ext_adi_led_t led, uint32_t* buffer, uint32_t buffer_length) {
 	uint8_t smart_port, adi_port;
-	get_ports(led, smart_port, adi_port);
+	get_ports(led, smart_port - 1, adi_port);
 	claim_port_i(smart_port, E_DEVICE_ADI);
 	transform_adi_port(adi_port);
-	validate_type(device, adi_port, smart_port - 1, E_ADI_DIGITAL_OUT);
+	validate_type(device, adi_port, smart_port - 1, E_ADI_DIGITAL_OUT);//subtracted 1 from smart_port
 	if (buffer_length > MAX_LED) {
 		buffer_length = MAX_LED;
 	}
@@ -477,13 +477,13 @@ int32_t ext_adi_led_set(ext_adi_led_t led, uint32_t* buffer, uint32_t buffer_len
 	}
 	uint32_t rtv = (uint32_t)vexDeviceAdiAddrLedSet(device->device_info, adi_port, buffer, 0, buffer_length, 0);
 	printf("rtv: %d", rtv);
-	return_port(smart_port, rtv);
+	return_port(smart_port - 1, rtv); //subtracted 1 from smart_port
 }
 
 int32_t ext_adi_led_set_pixel(ext_adi_led_t led, uint32_t* buffer, uint32_t buffer_length, uint32_t color, uint32_t pixel_position) {
 	uint8_t smart_port, adi_port;
 	get_ports(led, smart_port, adi_port);
-	claim_port_i(smart_port, E_DEVICE_ADI);
+	claim_port_i(smart_port - 1, E_DEVICE_ADI); //subtracted 1 from smart_port
 	transform_adi_port(adi_port);
 	validate_type(device, adi_port, smart_port - 1, E_ADI_DIGITAL_OUT);
 	if(buffer == NULL || pixel_position < 0 || buffer_length >= MAX_LED || buffer_length < 1 || pixel_position > buffer_length - 1) {
@@ -492,7 +492,7 @@ int32_t ext_adi_led_set_pixel(ext_adi_led_t led, uint32_t* buffer, uint32_t buff
 	}
 	buffer[pixel_position] = color;
 	uint32_t rtv = (uint32_t)vexDeviceAdiAddrLedSet(device->device_info, adi_port, buffer, 0, buffer_length, 0);
-	return_port(smart_port, rtv);
+	return_port(smart_port - 1, rtv); //subtracted 1 from smart_port
 }
 
 int32_t ext_adi_led_set_all(ext_adi_led_t led, uint32_t* buffer, uint32_t buffer_length, uint32_t color) {


### PR DESCRIPTION
subtracted 1 from smart_port because it needs to be zero-indexed 🙃

#### Summary:
I did a lot of testing and I am fairly confident that this is where the issue is. It's a problem with different indexing systems for smart ports. I started by testing addrled functions in VEXcode by using the SDK directly. The working code there looked like this. 

```cpp
#include "vex.h"

vex::brain       Brain;

// Declaration for SDK function for setting addrled. written by james, i just copied it
extern "C"  int32_t  vexAdiAddrLedSet( uint32_t index, uint32_t port, uint32_t *pData, uint32_t nOffset, uint32_t nLength, uint32_t options );

int main() {  

    // Create a buffer 8 long, all one color
    uint32_t maxled = 8;
    uint32_t ledbuffer[64];
      for(int i = 0;i<maxled;i++){
          ledbuffer[i] = 0xB00B69;
      }
    

    // Use sdk calls to configure ports to digitalout
    //both port id and port index are zero-indexed. i was using (22,3), (1,1), and (1,3)
    //these are declared in v5_api.h and v5_apitypes.h
    vexDeviceAdiPortConfigSet(vexDeviceGetByIndex(0), 0, kAdiPortTypeDigitalOut);
    vexDeviceAdiPortConfigSet(vexDeviceGetByIndex(0), 2, kAdiPortTypeDigitalOut);
    vexDeviceAdiPortConfigSet(vexDeviceGetByIndex(21), 2, kAdiPortTypeDigitalOut);


    vex::this_thread::sleep_for(200); // Delay to give ports time to configure. THIS IS NEEDED!!!!!! don't know how long though
    // Set each of the three strips to turn on. 20ms delay between calls, only 10 is needed i though i think


    vexAdiAddrLedSet( 0, 0, ledbuffer, 0, 8, 0 );
    vex::this_thread::sleep_for(20);
    vexAdiAddrLedSet( 0, 2, ledbuffer, 0, 8, 0 );
    vex::this_thread::sleep_for(20);
    vexAdiAddrLedSet( 21, 2, ledbuffer, 0, 8, 0 );
}
```

I then ported this to PROS, where I was able to do the exact same thing, using this code. 
```cpp
void initialize() {
	pros::lcd::initialize();
}
void disabled() {}
void competition_initialize() {}
void autonomous() {}

 extern "C" {
  int32_t  vexAdiAddrLedSet( uint32_t index, uint32_t port, uint32_t *pData, uint32_t nOffset, uint32_t nLength, uint32_t options );
  void* vexDeviceGetByIndex( uint32_t index);
  void vexDeviceAdiPortConfigSet(void* device, uint32_t port, pros::adi_port_config_e type);
  int32_t vexDeviceAdiPortConfigGet(void*, uint32_t);
}

void opcontrol() {
	uint32_t maxled = 8;
    uint32_t ledbuffer[64];
      for(int i = 0;i<maxled;i++){
          ledbuffer[i] = 0x00FF00;
      }
    

    // Use sdk calls to configure ports to digitalout
    //both port id and port index are zero-indexed. i was using (22,3), (1,1), and (1,3)
    //these are declared in v5_api.h and v5_apitypes.h
    vexDeviceAdiPortConfigSet(vexDeviceGetByIndex(0), 0, pros::E_ADI_DIGITAL_OUT );
    vexDeviceAdiPortConfigSet(vexDeviceGetByIndex(0), 2, pros::E_ADI_DIGITAL_OUT );
    vexDeviceAdiPortConfigSet(vexDeviceGetByIndex(21), 2, pros::E_ADI_DIGITAL_OUT );


    pros::delay(200); // Delay to give ports time to configure. THIS IS NEEDED!!!!!! don't know how long though
    // Set each of the three strips to turn on. 20ms delay between calls, only 10 is needed i though i think


    vexAdiAddrLedSet( 0, 0, ledbuffer, 0, 8, 0 );
    pros::delay(20);
    vexAdiAddrLedSet( 0, 2, ledbuffer, 0, 8, 0 );
    pros::delay(20);
    vexAdiAddrLedSet( 21, 2, ledbuffer, 0, 8, 0 );
}
```

This turned the lights on as-expected. This proved that there was nothing wrong with the SDK, meaning that the issue was somewhere in PROS itself. I skipped the C++ stuff and went straight to the PROS C API for addrleds. 

I tweaked my code to use `pros::c::ext_adi_led_init()` to initialize the ports, but kept setting the lights themselves with `vexAdiAddrLedSet()`. This worked. 

I then went and changed to calling `ext_adi_led_set()` instead, where things promptly broke. Doing things with ports 21 and 22 seemed to cause the program to hang, which I suspect is due to issues either with `claim_port` or `return_port` not liking it when you give it a smart port index of 22 (port 23, i.e. not real). 

Looking at the definition for `ext_adi_led_set()`:

I know from personal testing that `vexDeviceAdiPortConfigSet()` and `vexAdiAddrLedSet()` take zero-indexed port values. I also know that `ext_adi_led_init()` works, giving it a 1-indexed port value, so I know that in `ext_adi_led_set()` the `smart_port` value itself is 1-indexed as well. 

```cpp
int32_t ext_adi_led_set(ext_adi_led_t led, uint32_t* buffer, uint32_t buffer_length) {
	uint8_t smart_port, adi_port;
	get_ports(led, smart_port, adi_port);
	claim_port_i(smart_port, E_DEVICE_ADI); // <---  Need to subtract one from smart_port
	transform_adi_port(adi_port);
	validate_type(device, adi_port, smart_port - 1, E_ADI_DIGITAL_OUT);
	if (buffer_length > MAX_LED) {
		buffer_length = MAX_LED;
	}
	else if (buffer == NULL || buffer_length < 1 || buffer_length)
	{
		printf("ERROR Detected, Buffer Length: %d", buffer_length);
		errno = EINVAL;
		return PROS_ERR;
	}
	uint32_t rtv = (uint32_t)vexDeviceAdiAddrLedSet(device->device_info, adi_port, buffer, 0, buffer_length, 0);
	printf("rtv: %d", rtv);
	return_port(smart_port, rtv); // <---  Need to subtract one from smart_port
```

I _think_ this will fix the issue, but I could have it backwards, I'm not positive. Regardless I'm fairly confident the issue is in this function somewhere. 


#### Motivation:
`ext_adi_led_set()` did not work at all, and also sometimes made the program hang. I want to use addrled stuff so I was quite motivated to fix the problem.


#### Test Plan:
@WillXuCodes said they would test things tomorrow (today now I guess lol). I think that this should work to light 8 pixels of a strip plugged into port C on the port22 ADI. 

```cpp

void opcontrol() {
	uint32_t maxled = 8;
	uint32_t ledbuffer[64];
	for(int i = 0;i<maxled;i++){
		ledbuffer[i] = 0x00FF00;
	}
	pros::c::ext_adi_led_t led1 = pros::c::ext_adi_led_init(21,3);
	pros::delay(200);
	pros::c::ext_adi_led_set(led1, ledbuffer, 8);
}
```

- [ ] test item
