### PR TITLE
🐛Make display_initialize() a weak symbol for the liblvgl template

### DIFF
--- a/src/system/startup.c
+++ b/src/system/startup.c
@@ -22,7 +22,7 @@ extern void rtos_initialize();
 extern void vfs_initialize();
 extern void system_daemon_initialize();
 extern void graphical_context_daemon_initialize(void);
-//extern void display_initialize(void);
+extern __attribute__((weak)) void display_initialize(void) {}
 extern void rtos_sched_start();
 extern void vdml_initialize();
 extern void invoke_install_hot_table();
@@ -42,7 +42,7 @@ __attribute__((constructor(101))) static void pros_init(void) {
 
 	graphical_context_daemon_initialize();
 
-	//display_initialize();
+	display_initialize();
 
 	// NOTE: this function should be called after all other initialize
 	// functions. for an example of what could happen if this is not


### PR DESCRIPTION
This is a simple fix that makes display_initilialize() a weak symbol so that the implementation in the liblvgl repo can be used. 

The default implementation does not do anything. If the liblvgl template is present, the implementation in that template will be used. 