### PR TITLE
✨ PROS 4: Add ADIPneumatics Class

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -11,7 +11,7 @@ SPACE := $() $()
 COMMA := ,
 
 C_STANDARD?=gnu11
-CXX_STANDARD?=gnu++20
+CXX_STANDARD?=gnu++2a
 
 DEPDIR := .d
 $(shell mkdir -p $(DEPDIR))

--- a/common.mk
+++ b/common.mk
@@ -11,7 +11,7 @@ SPACE := $() $()
 COMMA := ,
 
 C_STANDARD?=gnu11
-CXX_STANDARD?=gnu++2a
+CXX_STANDARD?=gnu++20
 
 DEPDIR := .d
 $(shell mkdir -p $(DEPDIR))

--- a/include/api.h
+++ b/include/api.h
@@ -39,10 +39,10 @@
 #include <unistd.h>
 #endif /* __cplusplus */
 
-#define PROS_VERSION_MAJOR 4
-#define PROS_VERSION_MINOR 0
-#define PROS_VERSION_PATCH 0
-#define PROS_VERSION_STRING "4.0.0"
+#define PROS_VERSION_MAJOR 3
+#define PROS_VERSION_MINOR 7
+#define PROS_VERSION_PATCH 3
+#define PROS_VERSION_STRING "3.7.3"
 
 #include "pros/adi.h"
 #include "pros/colors.h"

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -1424,6 +1424,76 @@ class Potentiometer : public AnalogIn {
 	 */ 
 	friend std::ostream& operator<<(std::ostream& os, pros::adi::Potentiometer& potentiometer);
 };
+
+class Pneumatics : public DigitalOut {
+	public:
+	/**
+	 * Creates a Pneumatics object for the given port.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENXIO - The given value is not within the range of ADI Ports
+	 *
+	 * \param adi_port
+	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
+	 * \param initial_state
+	 *        The initial state of the pneumatic solenoid
+	 *
+	 * \b Example
+	 * \code
+	 * #define ADI_PNEUMATICS_PORT 'a'
+	 *
+	 * void opcontrol() {
+	 *   pros::adi::Pneumatics pneumatics (ADI_PNEUMATICS_PORT);
+	 *   while (true) {
+	 *     // Set the pneumatic solenoid to true
+	 *     pneumatics.set_value(true);
+	 *     pros::delay(10);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	explicit Pneumatic(int adi_port, bool initial_state = false);
+
+	/**
+	 * Creates a Pneumatics object for the given port.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENXIO - The given value is not within the range of ADI Ports
+	 *
+	 * \param port_pair
+	 *        The pair of the smart port number (from 1-22) and the
+	 *  	  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
+	 * \param initial_state
+	 *        The initial state of the pneumatic solenoid
+	 *
+	 * \b Example
+	 * \code
+	 * #define ADI_PNEUMATICS_PORT 'a'
+	 * #define SMART_PORT 1
+	 *
+	 * void opcontrol() {
+	 *   pros::adi::Pneumatics pneumatics ({{ SMART_PORT , ADI_PNEUMATICS_PORT }});
+	 *   while (true) {
+	 *     // Set the pneumatic solenoid to true
+	 *     pneumatics.set_value(true);
+	 *     pros::delay(10);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	explicit Pneumatic(pros::port_pair pair, bool initial_state = false);
+
+	void extend() const;
+
+	void retract() const;
+
+	void toggle() const;
+	
+	bool get_state() const;
+};
+
 }  // namespace adi
 
 /*

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -500,7 +500,7 @@ class AnalogOut : private Port {
 
 ///@}
 
-class DigitalOut : protected Port {
+class DigitalOut : private Port {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{
@@ -1453,7 +1453,7 @@ class Pneumatics : public DigitalOut {
 	 * }
 	 * \endcode
 	 */
-	explicit Pneumatics(int adi_port, bool initial_state = false);
+	Pneumatics(int adi_port, bool initial_state = false);
 
 	/**
 	 * Creates a Pneumatics object for the given port.
@@ -1483,7 +1483,7 @@ class Pneumatics : public DigitalOut {
 	 * }
 	 * \endcode
 	 */
-	explicit Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state = false);
+	Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state = false);
 
 	void extend() const;
 

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -1485,11 +1485,11 @@ class Pneumatics : public DigitalOut {
 	 */
 	Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state = false);
 
-	int32_t extend() const;
+	std::int32_t extend() const;
 
-	int32_t retract() const;
+	std::int32_t retract() const;
 
-	void toggle() const;
+	std::int32_t toggle() const;
 
 	bool get_state() const;
 

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -1575,8 +1575,8 @@ class Pneumatics : public DigitalOut {
 	*/
 	bool get_state() const;
 
-	private : 
-	
+private: 
+	bool initial_state;
 	bool state;
 };
 

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -1453,7 +1453,7 @@ class Pneumatics : public DigitalOut {
 	 * }
 	 * \endcode
 	 */
-	Pneumatics(int adi_port, bool initial_state = false);
+	Pneumatics(std::uint8_t adi_port, bool initial_state = false);
 
 	/**
 	 * Creates a Pneumatics object for the given port.

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -1492,6 +1492,10 @@ class Pneumatics : public DigitalOut {
 	void toggle() const;
 
 	bool get_state() const;
+
+	private : 
+	
+	bool state;
 };
 
 }  // namespace adi

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -1483,7 +1483,7 @@ class Pneumatics : public DigitalOut {
 	 * }
 	 * \endcode
 	 */
-	explicit Pneumatics(pros::port_pair pair, bool initial_state = false);
+	explicit Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state = false);
 
 	void extend() const;
 

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -1485,11 +1485,11 @@ class Pneumatics : public DigitalOut {
 	 */
 	Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state = false);
 
-	std::int32_t extend() const;
+	std::int32_t extend();
 
-	std::int32_t retract() const;
+	std::int32_t retract();
 
-	std::int32_t toggle() const;
+	std::int32_t toggle();
 
 	bool get_state() const;
 

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -1436,6 +1436,8 @@ class Pneumatics : public DigitalOut {
 	 *
 	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
+	 * \param start_extended
+	 * 		  If true, the pneumatic will start the match extended
 	 * \param active_low
 	 *        If set to true, a value of false corresponds to the pneumatic's
 	 * 		  wire being set to high.
@@ -1454,7 +1456,7 @@ class Pneumatics : public DigitalOut {
 	 * }
 	 * \endcode
 	 */
-	Pneumatics(std::uint8_t adi_port, bool active_low = false);
+	Pneumatics(std::uint8_t adi_port, bool start_extended, bool active_low = false);
 
 	/**
 	 * Creates a Pneumatics object for the given port.
@@ -1466,6 +1468,8 @@ class Pneumatics : public DigitalOut {
 	 * \param port_pair
 	 *        The pair of the smart port number (from 1-22) and the
 	 *  	  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
+	 * \param start_extended
+	 * 		  If true, the pneumatic will start the match extended
 	 * \param active_low
 	 *        If set to true, a value of false corresponds to the pneumatic's
 	 * 		  wire being set to high.
@@ -1485,7 +1489,7 @@ class Pneumatics : public DigitalOut {
 	 * }
 	 * \endcode
 	 */
-	Pneumatics(ext_adi_port_pair_t port_pair, bool active_low = false);
+	Pneumatics(ext_adi_port_pair_t port_pair, bool start_extended, bool active_low = false);
 
 	/* 
 	* Extends the piston, if not already extended.

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -1453,7 +1453,7 @@ class Pneumatics : public DigitalOut {
 	 * }
 	 * \endcode
 	 */
-	explicit Pneumatic(int adi_port, bool initial_state = false);
+	explicit Pneumatics(int adi_port, bool initial_state = false);
 
 	/**
 	 * Creates a Pneumatics object for the given port.
@@ -1483,14 +1483,14 @@ class Pneumatics : public DigitalOut {
 	 * }
 	 * \endcode
 	 */
-	explicit Pneumatic(pros::port_pair pair, bool initial_state = false);
+	explicit Pneumatics(pros::port_pair pair, bool initial_state = false);
 
 	void extend() const;
 
 	void retract() const;
 
 	void toggle() const;
-	
+
 	bool get_state() const;
 };
 

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -1485,9 +1485,9 @@ class Pneumatics : public DigitalOut {
 	 */
 	Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state = false);
 
-	void extend() const;
+	int32_t extend() const;
 
-	void retract() const;
+	int32_t retract() const;
 
 	void toggle() const;
 

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -500,7 +500,7 @@ class AnalogOut : private Port {
 
 ///@}
 
-class DigitalOut : private Port {
+class DigitalOut : protected Port {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -1436,8 +1436,9 @@ class Pneumatics : public DigitalOut {
 	 *
 	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
-	 * \param initial_state
-	 *        The initial state of the pneumatic solenoid
+	 * \param active_low
+	 *        If set to true, a value of false corresponds to the pneumatic's
+	 * 		  wire being set to high.
 	 *
 	 * \b Example
 	 * \code
@@ -1453,7 +1454,7 @@ class Pneumatics : public DigitalOut {
 	 * }
 	 * \endcode
 	 */
-	Pneumatics(std::uint8_t adi_port, bool initial_state = false);
+	Pneumatics(std::uint8_t adi_port, bool active_low = false);
 
 	/**
 	 * Creates a Pneumatics object for the given port.
@@ -1465,8 +1466,9 @@ class Pneumatics : public DigitalOut {
 	 * \param port_pair
 	 *        The pair of the smart port number (from 1-22) and the
 	 *  	  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
-	 * \param initial_state
-	 *        The initial state of the pneumatic solenoid
+	 * \param active_low
+	 *        If set to true, a value of false corresponds to the pneumatic's
+	 * 		  wire being set to high.
 	 *
 	 * \b Example
 	 * \code
@@ -1483,7 +1485,7 @@ class Pneumatics : public DigitalOut {
 	 * }
 	 * \endcode
 	 */
-	Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state = false);
+	Pneumatics(ext_adi_port_pair_t port_pair, bool active_low = false);
 
 	/* 
 	* Extends the piston, if not already extended.
@@ -1576,7 +1578,7 @@ class Pneumatics : public DigitalOut {
 	bool get_state() const;
 
 private: 
-	bool initial_state;
+	bool active_low;
 	bool state;
 };
 

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -1485,12 +1485,25 @@ class Pneumatics : public DigitalOut {
 	 */
 	Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state = false);
 
+	/* 
+	* Extends the piston, if not already extended.
+	*/
 	std::int32_t extend();
 
+	/*
+	* Retracts the piston, if not already retracted.
+	*/
 	std::int32_t retract();
 
+	/*
+	* Puts the piston into the opposite state of its current state.
+	* If it is retracted, it will extend. If it is extended, it will retract.
+	*/
 	std::int32_t toggle();
 
+	/*
+	* Returns the current state of the piston.
+	*/
 	bool get_state() const;
 
 	private : 

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -1487,22 +1487,91 @@ class Pneumatics : public DigitalOut {
 
 	/* 
 	* Extends the piston, if not already extended.
+	* 
+	* \return 1 if the operation was successful or PROS_ERR if the operation
+	* failed, setting errno.
+	*
+	* \b Example
+	* \code
+	* #define ADI_PNEUMATICS_PORT 'a'
+	*
+	* void opcontrol() {
+	*   pros::adi::Pneumatics pneumatics (ADI_PNEUMATICS_PORT);
+	*   while (true) {
+	*     // Extend the piston
+	*     pneumatics.extend();
+	*     pros::delay(10);
+	*   }
+	* }
+	* \endcode
 	*/
 	std::int32_t extend();
 
 	/*
 	* Retracts the piston, if not already retracted.
+	*
+	* \return 1 if the operation was successful or PROS_ERR if the operation
+	* failed, setting errno.
+	*
+	* \b Example
+	* \code
+	* #define ADI_PNEUMATICS_PORT 'a'
+	*
+	* void opcontrol() {
+	*   pros::adi::Pneumatics pneumatics (ADI_PNEUMATICS_PORT);
+	*   while (true) {
+	*     // Retract the piston
+	*     pneumatics.retract();
+	*     pros::delay(10);
+	*   }
+	* }
+	* \endcode
 	*/
 	std::int32_t retract();
 
 	/*
 	* Puts the piston into the opposite state of its current state.
 	* If it is retracted, it will extend. If it is extended, it will retract.
+	*
+	* \return 1 if the operation was successful or PROS_ERR if the operation
+	* failed, setting errno.
+	*
+	* \b Example
+	* \code
+	* #define ADI_PNEUMATICS_PORT 'a'
+	*
+	* void opcontrol() {
+	*   pros::adi::Pneumatics pneumatics (ADI_PNEUMATICS_PORT);
+	*   while (true) {
+	*     // Toggle the piston
+	*     pneumatics.toggle();
+	*     pros::delay(10);
+	*   }
+	* }
+	* \endcode
 	*/
 	std::int32_t toggle();
 
 	/*
 	* Returns the current state of the piston.
+	*
+	* \return true if the piston is extended, false if it is retracted.
+	*
+	* \b Example
+	* \code
+	* #define ADI_PNEUMATICS_PORT 'a'
+	*
+	* void opcontrol() {
+	*   pros::adi::Pneumatics pneumatics (ADI_PNEUMATICS_PORT);
+	*   while (true) {
+	*     // Check if the piston is extended
+	*     if (pneumatics.get_state()) {
+	*       // Do something
+	*     }
+	*     pros::delay(10);
+	*   }
+	* }
+	* \endcode
 	*/
 	bool get_state() const;
 

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -227,6 +227,15 @@ std::int32_t Pneumatics::retract() const {
 	return set_value(state);
 }
 
+std::int32_t Pneumatics::toggle() const {
+	state = !state;
+	return set_value(state);
+}
+
+bool Pneumatics::get_state() const {
+	return state;
+}
+
 std::ostream& operator<<(std::ostream& os, pros::adi::Potentiometer& potentiometer) {
 	os << "Potentiometer [";
 	os << "value: " << potentiometer.get_value();

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -211,12 +211,14 @@ double Potentiometer::get_angle() const {
 	return ext_adi_potentiometer_get_angle(merge_adi_ports(temp_smart, _adi_port));
 }
 
-Pneumatics::Pneumatics(std::uint8_t adi_port, bool active_low) 
-: DigitalOut(adi_port), active_low(active_low), state(active_low) {
+Pneumatics::Pneumatics(std::uint8_t adi_port, bool start_extended, bool active_low) 
+: DigitalOut(adi_port), active_low(active_low), state(start_extended) {
+	set_value(start_extended);
 }
 
-Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool active_low) 
-: DigitalOut(port_pair), active_low(active_low), state(active_low) {
+Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool start_extended, bool active_low) 
+: DigitalOut(port_pair), active_low(active_low), state(start_extended) {
+	set_value(start_extended);
 }
 
 std::int32_t Pneumatics::extend() {

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -211,21 +211,21 @@ double Potentiometer::get_angle() const {
 	return ext_adi_potentiometer_get_angle(merge_adi_ports(temp_smart, _adi_port));
 }
 
-Pneumatics::Pneumatics(std::uint8_t adi_port, bool initial_state) 
-: DigitalOut(adi_port), initial_state(initial_state), state(initial_state) {
+Pneumatics::Pneumatics(std::uint8_t adi_port, bool active_low) 
+: DigitalOut(adi_port), active_low(active_low), state(active_low) {
 }
 
-Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state) 
-: DigitalOut(port_pair), initial_state(initial_state), state(initial_state) {
+Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool active_low) 
+: DigitalOut(port_pair), active_low(active_low), state(active_low) {
 }
 
 std::int32_t Pneumatics::extend() {
-	state = initial_state; 
+	state = !active_low; 
 	return set_value(state);
 }
 
 std::int32_t Pneumatics::retract() {
-	state = !initial_state;
+	state = !active_low;
 	return set_value(state);
 }
 
@@ -235,7 +235,7 @@ std::int32_t Pneumatics::toggle() {
 }
 
 bool Pneumatics::get_state() const {
-	return initial_state ? state : !state;
+	return active_low ? state : !state;
 }
 
 std::ostream& operator<<(std::ostream& os, pros::adi::Potentiometer& potentiometer) {

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -217,14 +217,12 @@ Pneumatics::Pneumatics(std::uint8_t adi_port, bool initial_state) : DigitalOut(a
 Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state) : DigitalOut(std::get<1>(port_pair)), state(initial_state) {
 }
 
-void Pneumatics::extend() const {
-	state = true;
-	set_value(state);
+std::int32_t Pneumatics::extend() const {
+	set_value(true);
 }
 
-void Pneumatics::retract() const {
-	state = false;
-	set_value(state);
+std::int32_t Pneumatics::retract() const {
+	set_value(false);
 }
 
 std::ostream& operator<<(std::ostream& os, pros::adi::Potentiometer& potentiometer) {

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -217,12 +217,12 @@ Pneumatics::Pneumatics(std::uint8_t adi_port, bool initial_state) : DigitalOut(a
 Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state) : DigitalOut(std::get<1>(port_pair)), state(initial_state) {
 }
 
-std::int32_t Pneumatics::extend() {
+std::int32_t Pneumatics::extend() const {
 	state = true;
 	return set_value(state);
 }
 
-std::int32_t Pneumatics::retract() {
+std::int32_t Pneumatics::retract() const {
 	state = false;
 	return set_value(state);
 }

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -211,14 +211,10 @@ double Potentiometer::get_angle() const {
 	return ext_adi_potentiometer_get_angle(merge_adi_ports(temp_smart, _adi_port));
 }
 
-Pneumatics::Pneumatics(std::uint8_t adi_port, bool initial_state) : DigitalOut(adi_port) {
-	std::int32_t _port = ext_adi_pneumatics_init(INTERNAL_ADI_PORT, adi_port, initial_state);
-	get_ports(_port, _smart_port, _adi_port);
+Pneumatics::Pneumatics(std::uint8_t adi_port, bool initial_state) : DigitalOut(adi_port), state(initial_state) {
 }
 
-Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state) : DigitalOut(std::get<1>(port_pair)) {
-	std::int32_t _port = ext_adi_pneumatics_init(port_pair.first, port_pair.second, initial_state);
-	get_ports(_port, _smart_port, _adi_port);
+Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state) : DigitalOut(std::get<1>(port_pair)), state(initial_state) {
 }
 
 std::ostream& operator<<(std::ostream& os, pros::adi::Potentiometer& potentiometer) {

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -217,14 +217,14 @@ Pneumatics::Pneumatics(std::uint8_t adi_port, bool initial_state) : DigitalOut(a
 Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state) : DigitalOut(std::get<1>(port_pair)), state(initial_state) {
 }
 
-Pneumatics::extend() const {
+int32_t Pneumatics::extend() const {
 	state = true;
-	set_value(state);
+	return set_value(state);
 }
 
-Pneumatics::retract() const {
+int32_t Pneumatics::retract() const {
 	state = false;
-	set_value(state);
+	return set_value(state);
 }
 
 std::ostream& operator<<(std::ostream& os, pros::adi::Potentiometer& potentiometer) {

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -217,6 +217,16 @@ Pneumatics::Pneumatics(std::uint8_t adi_port, bool initial_state) : DigitalOut(a
 Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state) : DigitalOut(std::get<1>(port_pair)), state(initial_state) {
 }
 
+void Pneumatics::extend() const {
+	state = true;
+	set_value(state);
+}
+
+void Pneumatics::retract() const {
+	state = false;
+	set_value(state);
+}
+
 std::ostream& operator<<(std::ostream& os, pros::adi::Potentiometer& potentiometer) {
 	os << "Potentiometer [";
 	os << "value: " << potentiometer.get_value();

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -217,12 +217,14 @@ Pneumatics::Pneumatics(std::uint8_t adi_port, bool initial_state) : DigitalOut(a
 Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state) : DigitalOut(std::get<1>(port_pair)), state(initial_state) {
 }
 
-std::int32_t Pneumatics::extend() const {
-	set_value(true);
+Pneumatics::extend() const {
+	state = true;
+	set_value(state);
 }
 
-std::int32_t Pneumatics::retract() const {
-	set_value(false);
+Pneumatics::retract() const {
+	state = false;
+	set_value(state);
 }
 
 std::ostream& operator<<(std::ostream& os, pros::adi::Potentiometer& potentiometer) {

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -211,19 +211,21 @@ double Potentiometer::get_angle() const {
 	return ext_adi_potentiometer_get_angle(merge_adi_ports(temp_smart, _adi_port));
 }
 
-Pneumatics::Pneumatics(std::uint8_t adi_port, bool initial_state) : DigitalOut(adi_port), state(initial_state) {
+Pneumatics::Pneumatics(std::uint8_t adi_port, bool initial_state) 
+: DigitalOut(adi_port), initial_state(initial_state), state(initial_state) {
 }
 
-Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state) : DigitalOut(std::get<1>(port_pair)), state(initial_state) {
+Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state) 
+: DigitalOut(std::get<1>(port_pair)), initial_state(initial_state), state(initial_state) {
 }
 
 std::int32_t Pneumatics::extend() {
-	state = true;
+	state = initial_state; 
 	return set_value(state);
 }
 
 std::int32_t Pneumatics::retract() {
-	state = false;
+	state = !initial_state;
 	return set_value(state);
 }
 
@@ -233,7 +235,7 @@ std::int32_t Pneumatics::toggle() {
 }
 
 bool Pneumatics::get_state() const {
-	return state;
+	return initial_state ? state : !state;
 }
 
 std::ostream& operator<<(std::ostream& os, pros::adi::Potentiometer& potentiometer) {

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -216,8 +216,8 @@ Pneumatics::Pneumatics(std::uint8_t adi_port, bool initial_state) : DigitalOut(a
 	get_ports(_port, _smart_port, _adi_port);
 }
 
-Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state) : DigitalOut(std::get<1>(port_pair)) {
-	std::int32_t _port = ext_adi_pneumatics_init(port_pair.first, port_pair.second, initial_state);
+Pneumatics::Pneumatics(pros::port_pair pair, bool initial_state) : DigitalOut(pair.second) {
+	std::int32_t _port = ext_adi_pneumatics_init(pair.first, pair.second, initial_state);
 	get_ports(_port, _smart_port, _adi_port);
 }
 

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -217,17 +217,17 @@ Pneumatics::Pneumatics(std::uint8_t adi_port, bool initial_state) : DigitalOut(a
 Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state) : DigitalOut(std::get<1>(port_pair)), state(initial_state) {
 }
 
-std::int32_t Pneumatics::extend() const {
+std::int32_t Pneumatics::extend() {
 	state = true;
 	return set_value(state);
 }
 
-std::int32_t Pneumatics::retract() const {
+std::int32_t Pneumatics::retract() {
 	state = false;
 	return set_value(state);
 }
 
-std::int32_t Pneumatics::toggle() const {
+std::int32_t Pneumatics::toggle() {
 	state = !state;
 	return set_value(state);
 }

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -211,6 +211,16 @@ double Potentiometer::get_angle() const {
 	return ext_adi_potentiometer_get_angle(merge_adi_ports(temp_smart, _adi_port));
 }
 
+Pneumatics::Pneumatics(std::uint8_t adi_port, bool initial_state) : DigitalOut(adi_port) {
+	std::int32_t _port = ext_adi_pneumatics_init(INTERNAL_ADI_PORT, adi_port, initial_state);
+	get_ports(_port, _smart_port, _adi_port);
+}
+
+Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state) : DigitalOut(std::get<1>(port_pair)) {
+	std::int32_t _port = ext_adi_pneumatics_init(port_pair.first, port_pair.second, initial_state);
+	get_ports(_port, _smart_port, _adi_port);
+}
+
 std::ostream& operator<<(std::ostream& os, pros::adi::Potentiometer& potentiometer) {
 	os << "Potentiometer [";
 	os << "value: " << potentiometer.get_value();

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -217,12 +217,12 @@ Pneumatics::Pneumatics(std::uint8_t adi_port, bool initial_state) : DigitalOut(a
 Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state) : DigitalOut(std::get<1>(port_pair)), state(initial_state) {
 }
 
-int32_t Pneumatics::extend() const {
+std::int32_t Pneumatics::extend() {
 	state = true;
 	return set_value(state);
 }
 
-int32_t Pneumatics::retract() const {
+std::int32_t Pneumatics::retract() {
 	state = false;
 	return set_value(state);
 }

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -216,7 +216,7 @@ Pneumatics::Pneumatics(std::uint8_t adi_port, bool initial_state)
 }
 
 Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state) 
-: DigitalOut(std::get<1>(port_pair)), initial_state(initial_state), state(initial_state) {
+: DigitalOut(port_pair), initial_state(initial_state), state(initial_state) {
 }
 
 std::int32_t Pneumatics::extend() {

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -216,8 +216,8 @@ Pneumatics::Pneumatics(std::uint8_t adi_port, bool initial_state) : DigitalOut(a
 	get_ports(_port, _smart_port, _adi_port);
 }
 
-Pneumatics::Pneumatics(pros::port_pair pair, bool initial_state) : DigitalOut(pair.second) {
-	std::int32_t _port = ext_adi_pneumatics_init(pair.first, pair.second, initial_state);
+Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool initial_state) : DigitalOut(std::get<1>(port_pair)) {
+	std::int32_t _port = ext_adi_pneumatics_init(port_pair.first, port_pair.second, initial_state);
 	get_ports(_port, _smart_port, _adi_port);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,8 @@ void opcontrol() {
 	pros::Motor left_mtr(1);
 	pros::Motor right_mtr(2);
 
+	pros::adi::Pneumatics n('H', true);
+
 	while (true) {
 		pros::lcd::print(0, "%d %d %d", (pros::lcd::read_buttons() & LCD_BTN_LEFT) >> 2,
 		                 (pros::lcd::read_buttons() & LCD_BTN_CENTER) >> 1,
@@ -86,6 +88,22 @@ void opcontrol() {
 		int left = master.get_analog(ANALOG_LEFT_Y);
 		int right = master.get_analog(ANALOG_RIGHT_Y);
 
+		if(master.get_digital_new_press(pros::E_CONTROLLER_DIGITAL_A)){
+			printf("Toggling Pnuematic\n");
+			n.toggle();
+		}
+		if(master.get_digital_new_press(pros::E_CONTROLLER_DIGITAL_X)) {
+			printf("Extending Pnuematic\n");
+			n.extend();
+		}
+		if(master.get_digital_new_press(pros::E_CONTROLLER_DIGITAL_B)) {
+			printf("Retracting Pnuematic\n");
+			n.retract();
+		}
+		if(master.get_digital_new_press(pros::E_CONTROLLER_DIGITAL_Y)) {
+			printf("Pneumatic state is: %i\n", (int)n.get_state());
+		}
+ 
 		left_mtr = left;
 		right_mtr = right;
 		pros::delay(20);

--- a/src/tests/pnuematics.cpp
+++ b/src/tests/pnuematics.cpp
@@ -6,6 +6,7 @@
  * When this callback is fired, it will toggle line 2 of the LCD text between
  * "I was pressed!" and nothing.
  */
+
 void on_center_button() {
 	static bool pressed = false;
 	pressed = !pressed;
@@ -23,10 +24,11 @@ void on_center_button() {
  * to keep execution time for this mode under a few seconds.
  */
 void initialize() {
+	lvgl_init();
 	pros::lcd::initialize();
 	pros::lcd::set_text(1, "Hello PROS User!");
-
 	pros::lcd::register_btn1_cb(on_center_button);
+
 }
 
 /**
@@ -75,19 +77,30 @@ void autonomous() {}
  */
 void opcontrol() {
 	pros::Controller master(pros::E_CONTROLLER_MASTER);
-	pros::Motor left_mtr(1);
-	pros::Motor right_mtr(2);
+
+	pros::adi::Pneumatics n('H', true);
 
 	while (true) {
 		pros::lcd::print(0, "%d %d %d", (pros::lcd::read_buttons() & LCD_BTN_LEFT) >> 2,
 		                 (pros::lcd::read_buttons() & LCD_BTN_CENTER) >> 1,
 		                 (pros::lcd::read_buttons() & LCD_BTN_RIGHT) >> 0);
-		int left = master.get_analog(ANALOG_LEFT_Y);
-		int right = master.get_analog(ANALOG_RIGHT_Y);
 
-		left_mtr = left;
-		right_mtr = right;
-
+		if(master.get_digital_new_press(pros::E_CONTROLLER_DIGITAL_A)){
+			printf("Toggling Pnuematic\n");
+			n.toggle();
+		}
+		if(master.get_digital_new_press(pros::E_CONTROLLER_DIGITAL_X)) {
+			printf("Extending Pnuematic\n");
+			n.extend();
+		}
+		if(master.get_digital_new_press(pros::E_CONTROLLER_DIGITAL_B)) {
+			printf("Retracting Pnuematic\n");
+			n.retract();
+		}
+		if(master.get_digital_new_press(pros::E_CONTROLLER_DIGITAL_Y)) {
+			printf("Pneumatic state is: %i\n", (int)n.get_state());
+		}
+ 
 		pros::delay(20);
 	}
 }


### PR DESCRIPTION
#### Summary:
Add the Pneumatics Class. Functions in this class are extend(), retract(), toggle(), and get_state(). 

extend() - Extends the piston, if not already extended.
retract() - Retracts the piston, if not already retracted.
toggle() - Puts the piston into the opposite state of its current state.
get_state() - Returns the current state of the piston.

#### References:
#466

#### Motivation:
Pneumatics class will help adjust and know the state of the piston.

#### Test Plan:
Test the functions of the class.

- [x] extend() 
- [x] retract()
- [x] toggle()
- [x] get_state()
