### PR TITLE
⬆️ Change makefiles to use 'pros' instead of 'prosv5'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ template: clean-template library
 	$Dcp $(ROOT)/template-Makefile $(TEMPLATE_DIR)/Makefile
 	$Dmv $(TEMPLATE_DIR)/template-gitignore $(TEMPLATE_DIR)/.gitignore
 	@echo "Creating template"
-	$Dprosv5 c create-template $(TEMPLATE_DIR) kernel $(shell cat $(ROOT)/version) $(CREATE_TEMPLATE_ARGS)
+	$Dpros c create-template $(TEMPLATE_DIR) kernel $(shell cat $(ROOT)/version) $(CREATE_TEMPLATE_ARGS)
 
 LIBV5RTS_EXTRACTION_DIR=$(BINDIR)/libv5rts
 $(LIBAR): $(call GETALLOBJ,$(EXCLUDE_SRC_FROM_LIB)) $(EXTRA_LIB_DEPS)

--- a/common.mk
+++ b/common.mk
@@ -201,7 +201,7 @@ library: $(LIBAR)
 
 .PHONY: template
 template: clean-template $(LIBAR)
-	$Dprosv5 c create-template . $(LIBNAME) $(VERSION) $(foreach file,$(TEMPLATE_FILES) $(LIBAR),--system "$(file)") --target v5 $(CREATE_TEMPLATE_FLAGS)
+	$Dpros c create-template . $(LIBNAME) $(VERSION) $(foreach file,$(TEMPLATE_FILES) $(LIBAR),--system "$(file)") --target v5 $(CREATE_TEMPLATE_FLAGS)
 endif
 
 # if project is a library source, compile the archive and link output.elf against the archive rather than source objects


### PR DESCRIPTION
#### Summary:
This PR changes the makefiles to use the command `pros` instead of `prosv5`

#### Motivation:
When permissions issues arise on *nix systems, users have to chmod `pros` since that's what people typically use and `prosv5` since that is what the build system uses. This change would remove the need to set permissions on the latter. Additionally, we do not support the cortex anymore, so there is little reason for the build system to use `prosv5`

#### Test Plan:
- [ ] Ensure the `pros make` still works
- [ ] Ensure that `pros make template` still works
- [ ] Ensure that `pros make clean` still works

I have tested the various commands regarding the make command, and they still work on my system.
