### PR TITLE
Correct misspelled word

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -22,7 +22,7 @@
  *
  * For instance, E_CONTROLLER_MASTER has a shorter name: CONTROLLER_MASTER.
  * E_CONTROLLER_MASTER is pedantically correct within the PROS styleguide, but
- * not convienent for most student programmers.
+ * not convenient for most student programmers.
  */
 #define PROS_USE_SIMPLE_NAMES
 


### PR DESCRIPTION
Convenient was misspelled as "convienent."

#### Summary:
Changed the word "convienent" to convenient.

#### Motivation:
To make the document clearer and more professional.
