### PR TITLE
✨ PROS 3.8: Add "at()" Method To Motor Groups

### DIFF
--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -1037,6 +1037,20 @@ class Motor_Group {
 
 
 	/**
+	 * Indexes Motor in the Motor_Group.
+	 * 
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * Throws an std::out_of_range error when indexing out of range
+	 * 
+	 * \param i
+	 *        The index value in the motor group.
+	 *
+	 * \return the appropriate Motor reference.
+	 */ 	
+	pros::Motor& at(int i);
+
+	/**
 	 * Indexes Motor in the Motor_Group in the same way as an array.
 	 * 
 	 * \return the size of the vector containing motors

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -375,6 +375,14 @@ pros::Motor& Motor_Group::operator[](int i) {
 	return _motors.at(i);
 }
 
+pros::Motor& Motor_Group::at(int i) {
+	if (i >= _motor_count || _motors.empty()) {
+		throw std::out_of_range("Out of Range! 
+			Motor_Group for at() method is out of range");
+	}
+	return _motors[i];
+}
+
 std::int32_t Motor_Group::size() {
 	return _motor_count;
 }

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -377,8 +377,7 @@ pros::Motor& Motor_Group::operator[](int i) {
 
 pros::Motor& Motor_Group::at(int i) {
 	if (i >= _motor_count || _motors.empty()) {
-		throw std::out_of_range("Out of Range! 
-			Motor_Group for at() method is out of range");
+		throw std::out_of_range("Out of Range! Motor_Group for at() method is out of range");
 	}
 	return _motors[i];
 }


### PR DESCRIPTION
#### Summary:
Adds the at() operator to the Motor_Groups. Throws an error if the bozo attempts to go out of ranges. 

#### Motivation:
Issues with smart pointers make the process of using the [] operator a headache. This method should offer a simple solution while being similar to C++ syntax. 

##### References (optional):
#494 

#### Test Plan:
Will test on simple program that controls multiple motors and I will check if I can use them when using a smart pointer. Will post here with update on proper test. 
