### PR TITLE
🐛fix cobs_encode() name clashing at runtime

### DIFF
--- a/src/common/cobs.c
+++ b/src/common/cobs.c
@@ -54,7 +54,7 @@ size_t cobs_encode_measure(const uint8_t* restrict src, const size_t src_len, co
 
 	return write_idx;
 }
-
+//TODO: Fix this.
 int cobs_encode(uint8_t* restrict dest, const uint8_t* restrict src, const size_t src_len, const uint32_t prefix) {
 	size_t read_idx = 0;
 	size_t write_idx = 1;


### PR DESCRIPTION
#### Summary:
Change cobs_encode to be not be the function called when user creates a method of the same nam

##### References (optional):
Issue #418 

#### Test Plan:
Make sure cobs_encode will not call the pros function when creating a method of the same name
Check other methods to ensure they do not have the same problem