### PR TITLE
🐛 PROS 4: fix cobs_encode() name clashing at runtime

### DIFF
--- a/src/common/cobs.c
+++ b/src/common/cobs.c
@@ -54,7 +54,7 @@ size_t cobs_encode_measure(const uint8_t* restrict src, const size_t src_len, co
 
 	return write_idx;
 }
-
+//TODO: Fix this.
 int cobs_encode(uint8_t* restrict dest, const uint8_t* restrict src, const size_t src_len, const uint32_t prefix) {
 	size_t read_idx = 0;
 	size_t write_idx = 1;


### PR DESCRIPTION
#### Summary:
Change symbol for cobs_encode() to not public.


##### References (optional):
Issue #418 

#### Test Plan:
Ensure a function named cobs_encode() in a pros project calls that function when called instead of the pros one
Ensure other functions in pros doesn't have the same issue
