### PR TITLE
✨ PROS 3.8: Missing Functions for Motor Groups

### DIFF
--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -1053,7 +1053,7 @@ class Motor_Group {
 	 * \return The encoder position of the motor in ticks or PROS_ERR_F if the operation
 	 * failed, setting errno.
 	 */
-	std::vector<std::int32_t> get_raw_positions(void);
+	std::vector<std::int32_t> get_raw_positions(std::vector<std::uint32_t* const> &timestamps);
 	/****************************************************************************/
 	/**                      Motor configuration functions                     **/
 	/**                                                                        **/

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -462,17 +462,6 @@ class Motor {
 	 * \return The motor's voltage in mV or PROS_ERR_F if the operation failed,
 	 * setting errno.
 	 * 
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor(1);
-	 *   while (true) {
-	 *     motor.move_voltage(12000);
-	 *     std::cout << "Motor voltage: " << motor.get_voltage() << std::endl;
-	 *     pros::delay(20);
-	 *   }
-	 * }
-	 * \endcode
 	 */
 	virtual std::int32_t get_voltage(void) const;
 
@@ -1041,11 +1030,13 @@ class Motor_Group {
 	 * \b Example
 	 * \code
 	 * void opcontrol() {
-	 *   pros::Motor_Group motors({1, 2, 3, 4});
+	 *   pros::Motor_Group motors({1, 2});
+	 *   std::vector<std::uint32_t> voltages;
 	 *   while (true) {
-	 * 	   std::vector<std::uint32_t> voltages = motors.get_voltages();
-	 *     for (std::uint32_t i = 0; i < voltages.size(); i++) {
-	 * 	     std::cout << "Motor " << i << " voltage: " << voltages[i] << std::endl;
+	 * 	   voltages = motors.get_voltages();
+	 * 
+	 *     for (uint32_t i = 0; i < voltages.size(); i++) {
+	 * 	     printf("Voltages: %ld\n", voltages[i]);
 	 *     }
 	 *     pros::delay(20);
 	 *   }
@@ -1065,6 +1056,22 @@ class Motor_Group {
 	 * 
 	 * \return The voltage limit of the motor in millivolts or PROS_ERR_F if the operation
 	 * failed, setting errno.
+	 * 
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor_Group motors({1, 2});
+	 *   std::vector<std::uint32_t> voltage_limits;
+	 *   while (true) {
+	 * 	   voltage_limits = motors.get_voltage_limits();
+	 * 
+	 *     for (uint32_t i = 0; i < voltage_limits.size(); i++) {
+	 * 	     printf("Voltage Limits: %ld\n", voltage_limits[i]);
+	 *     }
+	 *     pros::delay(20);
+	 *   }
+	 * }
+	 * \endcode
 	 */
 	std::vector<std::uint32_t> get_voltage_limits(void);
 
@@ -1086,13 +1093,17 @@ class Motor_Group {
 	 *   pros::Motor_Group motors({1, 2});
 	 *   std::vector<std::uint32_t*> timestamps;
 	 *   std::vector<std::int32_t> positions;
+	 * 	 std::uint32_t temp = 0;
+	 *   std::uint32_t temp2 = 0;
+	 *   timestamps.push_back(&temp);
+	 *   timestamps.push_back(&temp2);
+	 * 
 	 *   while (true) {
-	 *     timestamps.push_back(pros::millis());
-	 *     timestamps.push_back(pros::millis());
-	 *     positions = motors.get_raw_positions(&timestamps);
-	 *     for (std::uint32_t i = 0; i < positions.size(); i++) {
-	 *       std::cout << "Motor " << i << " position: " << positions[i] << std::endl;
-	 *     }
+	 *     positions = motors.get_raw_positions(timestamps);
+	 * 
+	 *     printf("Position: %ld, Time: %ln\n", positions[0], timestamps[0]);
+     *	   printf("Position: %ld, Time: %ln\n", positions[1], timestamps[1]);
+	 *
 	 *     pros::delay(20);
 	 *   }
 	 * }

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -1041,6 +1041,19 @@ class Motor_Group {
 	 * failed, setting errno.
 	 */
 	std::vector<std::uint32_t> get_voltage_limits(void);
+
+	/* 
+	 * Gets the raw encoder positions of a motor group at a given timestamp.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 * EACCESS - The Motor group mutex can't be taken or given
+	 * 	
+	 * \return The encoder position of the motor in ticks or PROS_ERR_F if the operation
+	 * failed, setting errno.
+	 */
+	std::vector<std::int32_t> get_raw_positions(void);
 	/****************************************************************************/
 	/**                      Motor configuration functions                     **/
 	/**                                                                        **/

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -1098,7 +1098,7 @@ class Motor_Group {
 	 * }
 	 * \endcode
 	 */
-	std::vector<std::int32_t> get_raw_positions(std::vector<std::uint32_t* const> &timestamps);
+	std::vector<std::int32_t> get_raw_positions(std::vector<std::uint32_t*> &timestamps);
 	/****************************************************************************/
 	/**                      Motor configuration functions                     **/
 	/**                                                                        **/

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -461,6 +461,18 @@ class Motor {
 	 *
 	 * \return The motor's voltage in mV or PROS_ERR_F if the operation failed,
 	 * setting errno.
+	 * 
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor(1);
+	 *   while (true) {
+	 *     motor.move_voltage(12000);
+	 *     std::cout << "Motor voltage: " << motor.get_voltage() << std::endl;
+	 *     pros::delay(20);
+	 *   }
+	 * }
+	 * \endcode
 	 */
 	virtual std::int32_t get_voltage(void) const;
 
@@ -1026,6 +1038,20 @@ class Motor_Group {
 	 * \return The voltage of the motor in millivolts or PROS_ERR_F if the operation
 	 * failed, setting errno.
 	 * 
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor_Group motors({1, 2, 3, 4});
+	 *   while (true) {
+	 * 	   std::vector<std::uint32_t> voltages = motors.get_voltages();
+	 *     for (std::uint32_t i = 0; i < voltages.size(); i++) {
+	 * 	     std::cout << "Motor " << i << " voltage: " << voltages[i] << std::endl;
+	 *     }
+	 *     pros::delay(20);
+	 *   }
+	 * }
+	 * \endcode
+	 * 
 	 */
 	std::vector<std::uint32_t> get_voltages(void);
 
@@ -1050,8 +1076,27 @@ class Motor_Group {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EACCESS - The Motor group mutex can't be taken or given
 	 * 	
-	 * \return The encoder position of the motor in ticks or PROS_ERR_F if the operation
-	 * failed, setting errno.
+	 * \return A vector of the raw encoder positions of the motors in the motor group
+	 * based on the timestamps passed in. If a timestamp is not found for a motor, the
+	 * value at that index will be PROS_ERR.
+	 * 
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor_Group motors({1, 2});
+	 *   std::vector<std::uint32_t*> timestamps;
+	 *   std::vector<std::int32_t> positions;
+	 *   while (true) {
+	 *     timestamps.push_back(pros::millis());
+	 *     timestamps.push_back(pros::millis());
+	 *     positions = motors.get_raw_positions(&timestamps);
+	 *     for (std::uint32_t i = 0; i < positions.size(); i++) {
+	 *       std::cout << "Motor " << i << " position: " << positions[i] << std::endl;
+	 *     }
+	 *     pros::delay(20);
+	 *   }
+	 * }
+	 * \endcode
 	 */
 	std::vector<std::int32_t> get_raw_positions(std::vector<std::uint32_t* const> &timestamps);
 	/****************************************************************************/

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -1014,6 +1014,33 @@ class Motor_Group {
 	 * failed, setting errno.
 	 */
 	std::int32_t brake(void);
+
+	/* 
+	 * Gets the voltages delivered to the motors in millivolts.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 * EACCESS - The Motor group mutex can't be taken or given
+	 * 
+	 * \return The voltage of the motor in millivolts or PROS_ERR_F if the operation
+	 * failed, setting errno.
+	 * 
+	 */
+	std::vector<std::uint32_t> get_voltages(void);
+
+	/* 
+	 * Get the voltage limits of the motors set by the user.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 * EACCESS - The Motor group mutex can't be taken or given
+	 * 
+	 * \return The voltage limit of the motor in millivolts or PROS_ERR_F if the operation
+	 * failed, setting errno.
+	 */
+	std::vector<std::uint32_t> get_voltage_limits(void);
 	/****************************************************************************/
 	/**                      Motor configuration functions                     **/
 	/**                                                                        **/

--- a/src/devices/vdml_motors.c
+++ b/src/devices/vdml_motors.c
@@ -425,5 +425,5 @@ int32_t motor_is_reversed(uint8_t port) {
 int32_t motor_get_voltage_limit(uint8_t port) {
 	claim_port_i(port - 1, E_DEVICE_MOTOR);
 	int32_t rtn = vexDeviceMotorVoltageLimitGet(device->device_info);
-	return_port(rtn, port - 1);
+	return_port(port - 1, rtn);
 }

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -494,17 +494,11 @@ std::vector<std::uint32_t> Motor_Group::get_voltages(void) {
 
 std::vector<std::uint32_t> Motor_Group::get_voltage_limits(void) {
 	std::vector<std::uint32_t> out;
-	printf("Created vector out to store voltage limits\n");
 	claim_mg_mutex_vector(PROS_ERR);
-	printf("Claimed mutex\n");
-	for (Motor &motor : _motors) {
-		/*
+	for (Motor &motor : _motors) {	
 		out.push_back(motor.get_voltage_limit());
-		*/
-		printf("Got voltage limit for motor\n");
 	}
 	give_mg_mutex_vector(PROS_ERR);
-	printf("Released mutex\n");
 	return out;
 }
 

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -506,7 +506,7 @@ std::vector<std::int32_t> Motor_Group::get_raw_positions(std::vector<std::uint32
 	claim_mg_mutex_vector(PROS_ERR);
 	// Create a vector size of the number of motors and fill it with PROS_ERR
 	std::vector<std::int32_t> out(_motors.size(), PROS_ERR);
-	if (timestamps == nullptr) {
+	if (timestamps.empty()) {
 		// If the timestamps vector is null, return a vector of PROS_ERR
 		give_mg_mutex_vector(PROS_ERR);
 		return out;

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -482,6 +482,26 @@ std::int32_t Motor_Group::tare_position(void) {
 	return out;
 }
 
+std::vector<std::uint32_t> Motor_Group::get_voltages(void) {
+	std::vector<std::uint32_t> out;
+	claim_mg_mutex_vector(PROS_ERR_F);
+	for (Motor motor : _motors) {
+		out.push_back(motor.get_voltage());
+	}
+	give_mg_mutex_vector(PROS_ERR_F);
+	return out;
+}
+
+std::vector<std::uint32_t> Motor_Group::get_voltage_limits(void) {
+	std::vector<std::uint32_t> out;
+	claim_mg_mutex_vector(PROS_ERR_F);
+	for (Motor motor : _motors) {
+		out.push_back(motor.get_voltage_limit());
+	}
+	give_mg_mutex_vector(PROS_ERR_F);
+	return out;
+}
+
 std::vector<double> Motor_Group::get_target_positions(void) {
 	std::vector<double> out;
 	claim_mg_mutex_vector(PROS_ERR_F);

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -484,21 +484,32 @@ std::int32_t Motor_Group::tare_position(void) {
 
 std::vector<std::uint32_t> Motor_Group::get_voltages(void) {
 	std::vector<std::uint32_t> out;
-	claim_mg_mutex_vector(PROS_ERR_F);
+	claim_mg_mutex_vector(PROS_ERR);
 	for (Motor motor : _motors) {
 		out.push_back(motor.get_voltage());
 	}
-	give_mg_mutex_vector(PROS_ERR_F);
+	give_mg_mutex_vector(PROS_ERR);
 	return out;
 }
 
 std::vector<std::uint32_t> Motor_Group::get_voltage_limits(void) {
 	std::vector<std::uint32_t> out;
-	claim_mg_mutex_vector(PROS_ERR_F);
+	claim_mg_mutex_vector(PROS_ERR);
 	for (Motor motor : _motors) {
 		out.push_back(motor.get_voltage_limit());
 	}
-	give_mg_mutex_vector(PROS_ERR_F);
+	give_mg_mutex_vector(PROS_ERR);
+	return out;
+}
+
+std::vector<std::int32_t> Motor_Group::get_raw_positions(void) {
+	std::vector<std::int32_t> out;
+	std::uint32_t* const timestamp = new std::uint32_t;
+	claim_mg_mutex_vector(PROS_ERR);
+	for (Motor motor : _motors) {
+		out.push_back(motor.get_raw_position(timestamp));
+	}
+	give_mg_mutex_vector(PROS_ERR);
 	return out;
 }
 

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -502,10 +502,10 @@ std::vector<std::uint32_t> Motor_Group::get_voltage_limits(void) {
 	return out;
 }
 
-std::vector<std::int32_t> Motor_Group::get_raw_positions(std::vector<std::uint32_t* const> &timestamps) {
-	claim_mg_mutex_vector(PROS_ERR);
+std::vector<std::int32_t> Motor_Group::get_raw_positions(std::vector<std::uint32_t*> &timestamps) {
 	// Create a vector size of the number of motors and fill it with PROS_ERR
 	std::vector<std::int32_t> out(_motors.size(), PROS_ERR);
+	claim_mg_mutex_vector(PROS_ERR);
 	if (timestamps.empty()) {
 		// If the timestamps vector is null, return a vector of PROS_ERR
 		give_mg_mutex_vector(PROS_ERR);

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -494,11 +494,17 @@ std::vector<std::uint32_t> Motor_Group::get_voltages(void) {
 
 std::vector<std::uint32_t> Motor_Group::get_voltage_limits(void) {
 	std::vector<std::uint32_t> out;
+	printf("Created vector out to store voltage limits\n");
 	claim_mg_mutex_vector(PROS_ERR);
-	for (Motor motor : _motors) {
+	printf("Claimed mutex\n");
+	for (Motor &motor : _motors) {
+		/*
 		out.push_back(motor.get_voltage_limit());
+		*/
+		printf("Got voltage limit for motor\n");
 	}
 	give_mg_mutex_vector(PROS_ERR);
+	printf("Released mutex\n");
 	return out;
 }
 
@@ -519,7 +525,7 @@ std::vector<std::int32_t> Motor_Group::get_raw_positions(std::vector<std::uint32
 	for (int i = 0; i < min_iter; i++) {
 		// Check timestamp is not nullptr before getting the raw position
 		if (timestamps[i] != nullptr) {
-			out.push_back(_motors[i].get_raw_position(timestamps[i]));
+			out[i] = _motors[i].get_raw_position(timestamps[i]);
 		}
 	}
 	give_mg_mutex_vector(PROS_ERR);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,8 +77,22 @@ void opcontrol() {
 	pros::Controller master(pros::E_CONTROLLER_MASTER);
 	pros::Motor left_mtr(1);
 	pros::Motor right_mtr(2);
+	pros::Motor_Group motors({left_mtr, right_mtr});
+	std::vector<std::uint32_t*> timestamps;
+	std::vector<std::int32_t> positions;
+	std::uint32_t temp = 0;
+	std::uint32_t temp2 = 0;
+	timestamps.push_back(&temp);
+	timestamps.push_back(&temp2);
+
+	std::vector<std::uint32_t> voltages;
+	std::vector<std::uint32_t> voltage_limits;
+
+	printf("Hello PROS User!\n");
 
 	while (true) {
+		printf("Before print buttons\n");
+
 		pros::lcd::print(0, "%d %d %d", (pros::lcd::read_buttons() & LCD_BTN_LEFT) >> 2,
 		                 (pros::lcd::read_buttons() & LCD_BTN_CENTER) >> 1,
 		                 (pros::lcd::read_buttons() & LCD_BTN_RIGHT) >> 0);
@@ -87,6 +101,34 @@ void opcontrol() {
 
 		left_mtr = left;
 		right_mtr = right;
+
+		/*
+		positions = motors.get_raw_positions(timestamps);
+
+		printf("Motor 1 position: %ld, time: %lu\n", left_mtr.get_raw_position(&temp), temp);
+
+		printf("Position: %ld, Time: %lu\n", positions[0], *timestamps[0]);
+		printf("Position: %ld, Time: %lu\n", positions[1], *timestamps[1]);
+
+		temp = pros::millis();
+		temp2 = pros::millis();
+
+		voltages = motors.get_voltages();
+
+		for (uint32_t i = 0; i < voltages.size(); i++) {
+			printf("Voltages: %ld\n", voltages[i]);
+		}
+		*/
+
+		printf("Getting voltage limits...\n");
+
+		voltage_limits = motors.get_voltage_limits();
+
+		printf("Got voltage limits!\n");
+
+		for (uint32_t i = 0; i < voltage_limits.size(); i++) {
+			printf("Voltage Limits: %ld\n", voltage_limits[i]);
+		}
 
 		pros::delay(20);
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,22 +77,8 @@ void opcontrol() {
 	pros::Controller master(pros::E_CONTROLLER_MASTER);
 	pros::Motor left_mtr(1);
 	pros::Motor right_mtr(2);
-	pros::Motor_Group motors({left_mtr, right_mtr});
-	std::vector<std::uint32_t*> timestamps;
-	std::vector<std::int32_t> positions;
-	std::uint32_t temp = 0;
-	std::uint32_t temp2 = 0;
-	timestamps.push_back(&temp);
-	timestamps.push_back(&temp2);
-
-	std::vector<std::uint32_t> voltages;
-	std::vector<std::uint32_t> voltage_limits;
-
-	printf("Hello PROS User!\n");
 
 	while (true) {
-		printf("Before print buttons\n");
-
 		pros::lcd::print(0, "%d %d %d", (pros::lcd::read_buttons() & LCD_BTN_LEFT) >> 2,
 		                 (pros::lcd::read_buttons() & LCD_BTN_CENTER) >> 1,
 		                 (pros::lcd::read_buttons() & LCD_BTN_RIGHT) >> 0);
@@ -101,34 +87,6 @@ void opcontrol() {
 
 		left_mtr = left;
 		right_mtr = right;
-
-		/*
-		positions = motors.get_raw_positions(timestamps);
-
-		printf("Motor 1 position: %ld, time: %lu\n", left_mtr.get_raw_position(&temp), temp);
-
-		printf("Position: %ld, Time: %lu\n", positions[0], *timestamps[0]);
-		printf("Position: %ld, Time: %lu\n", positions[1], *timestamps[1]);
-
-		temp = pros::millis();
-		temp2 = pros::millis();
-
-		voltages = motors.get_voltages();
-
-		for (uint32_t i = 0; i < voltages.size(); i++) {
-			printf("Voltages: %ld\n", voltages[i]);
-		}
-		*/
-
-		printf("Getting voltage limits...\n");
-
-		voltage_limits = motors.get_voltage_limits();
-
-		printf("Got voltage limits!\n");
-
-		for (uint32_t i = 0; i < voltage_limits.size(); i++) {
-			printf("Voltage Limits: %ld\n", voltage_limits[i]);
-		}
 
 		pros::delay(20);
 	}


### PR DESCRIPTION
#### Summary:
Adding following functions to motor groups:
1. get_voltages() - get voltages of all motors
2. get_voltage_limits() - get voltage limits of all motors
3. get_raw_positions() - returns a std::vectorstd::int32_t of the raw encoder positions of a motor group

Also check other motor methods that may need motor group implementations e.g. get_temperatures(), get_powers(), etc.

#### Motivation:
The users can get the voltages and voltage limits of all the motors at once instead getting voltage of individual motors in the group using the array operator. Also consider other motor methods that need to be implemented for motor groups.

##### References (optional):
Issue #495 

#### Test Plan:

- [ ] get_voltages()
- [ ] get_voltage_limits()
- [ ] get_raw_positions()
