### PR TITLE
🐛PROS 4: fixed erase port

### DIFF
--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -28,7 +28,6 @@
 
 #include "pros/colors.hpp"
 #include "pros/device.hpp"
-#include "pros/colors.hpp"
 #include "pros/motors.h"
 #include "rtos.hpp"
 
@@ -1356,6 +1355,7 @@ class Motor : public Motor_Group, public Device {
 	private:
 	using Motor_Group::operator+=;
 	using Motor_Group::append;
+	using Motor_Group::erase_port;
 	using Motor_Group::every_is_over_current;
 	using Motor_Group::every_is_over_temp;
 	using Motor_Group::every_is_reversed;

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -801,7 +801,7 @@ void Motor_Group::append(Motor_Group& other) {
 void Motor_Group::erase_port(std::int8_t port) {
 	auto it = _ports.begin();
 	while (it < _ports.end()) {
-		if (std::abs(*it) == port) {
+		if (std::abs(*it) == std::abs(port)) {
 			_ports.erase(it);
 		} else {
 			it++;
@@ -855,15 +855,13 @@ Motor::Motor(const std::int8_t port, const pros::v5::Motor_Gears gearset, const 
 Motor::Motor(const std::int8_t port, const pros::Color gearset_color, const bool reverse)
     : Motor_Group({port}, gearset_color, reverse), Device(port) {}
 
-Motor::Motor(const std::int8_t port, const pros::v5::Motor_Gears gearset) 
-	: Motor_Group({port}, gearset), Device(port) {}
+Motor::Motor(const std::int8_t port, const pros::v5::Motor_Gears gearset)
+    : Motor_Group({port}, gearset), Device(port) {}
 
-Motor::Motor(const std::int8_t port, const pros::Color gearset_color) 
-	: Motor_Group({port}, gearset_color), Device(port) {}
+Motor::Motor(const std::int8_t port, const pros::Color gearset_color)
+    : Motor_Group({port}, gearset_color), Device(port) {}
 
-Motor::Motor(const std::int8_t port, const bool reverse) 
-	: Motor_Group({port}, reverse), Device(port){}
-
+Motor::Motor(const std::int8_t port, const bool reverse) : Motor_Group({port}, reverse), Device(port) {}
 
 DeviceType Motor::get_type() const {
 	return DeviceType::motor;
@@ -871,11 +869,11 @@ DeviceType Motor::get_type() const {
 
 }  // namespace v5
 namespace literals {
-	const pros::Motor operator"" _mtr(const unsigned long long int m) {
-		return pros::Motor(m, false);
-	}
-	const pros::Motor operator"" _rmtr(const unsigned long long int m) {
-		return pros::Motor(m, true);
-	}
+const pros::Motor operator"" _mtr(const unsigned long long int m) {
+	return pros::Motor(m, false);
+}
+const pros::Motor operator"" _rmtr(const unsigned long long int m) {
+	return pros::Motor(m, true);
+}
 }  // namespace literals
 }  // namespace pros


### PR DESCRIPTION
Fixed erase port negative sign functionality
fixed erase port being accessible from motor



##### References (optional):
closes threads #18 and partially #19 from the beta test.
#### Test Plan:
	`pros::Motor_Group` mg({1, -2, 3, -4, 5});
	mg.erase_port(2);
	mg.erase_port(-1);
	mg.erase_port(-3);
	mg.erase_port(-4);
        mg.get_ports()[0]; //returns 5 as expected
`