### PR TITLE
🐛 PROS 3.8: Fix Issue with RTOS Not Started At Constructor Runtime

### DIFF
--- a/include/kapi.h
+++ b/include/kapi.h
@@ -54,6 +54,13 @@ extern "C" {
 typedef uint32_t task_stack_t;
 
 /**
+ * If the scheduler is not running, this function will start the scheduler and
+ * return. If the scheduler is already running, this function will return. 
+ * This is to prevent constructors called before main from crashing the v5 brain.
+ */
+void rtos_start_check(void);
+
+/**
  * Suspends the scheduler without disabling interrupts. context switches will
  * not occur while the scheduler is suspended. RTOS ticks that occur while the
  * scheduler is suspended will be held pending until the scheduler has been

--- a/src/devices/vdml_imu.c
+++ b/src/devices/vdml_imu.c
@@ -145,6 +145,10 @@ quaternion_s_t imu_get_quaternion(uint8_t port) {
 	imu_data_s_t* data = (imu_data_s_t*)device->pad;
 	// To calculate the quaternion values, we first get the euler values, add the offsets,
 	// and then do the calculations.
+
+	// Wikipedia article for future devs/maintainers: (Look at C++ code section)
+	// 
+	// https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
 	double roll = fmod(euler.roll + data->roll_offset, 2.0 * IMU_EULER_LIMIT);
 	double yaw = fmod(euler.yaw + data->yaw_offset, 2.0 * IMU_EULER_LIMIT);
 	double pitch = fmod(euler.pitch + data->pitch_offset, 2.0 * IMU_EULER_LIMIT);

--- a/src/devices/vdml_imu.cpp
+++ b/src/devices/vdml_imu.cpp
@@ -13,7 +13,7 @@
 #include "pros/imu.hpp"
 
 namespace pros {
-std::int32_t Imu::reset(bool blocking /*= false*/) const {
+std::int32_t Imu::reset(bool blocking = false) const {
 	return blocking ? pros::c::imu_reset_blocking(_port) : pros::c::imu_reset(_port);
 }
 

--- a/src/devices/vdml_imu.cpp
+++ b/src/devices/vdml_imu.cpp
@@ -13,7 +13,7 @@
 #include "pros/imu.hpp"
 
 namespace pros {
-std::int32_t Imu::reset(bool blocking = false) const {
+std::int32_t Imu::reset(bool blocking /*= false*/) const {
 	return blocking ? pros::c::imu_reset_blocking(_port) : pros::c::imu_reset(_port);
 }
 

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -82,6 +82,7 @@ using namespace pros::c;
 Motor::Motor(const std::int8_t port, const motor_gearset_e_t gearset, const bool reverse,
              const motor_encoder_units_e_t encoder_units)
     : _port(abs(port)) {
+	rtos_start_check();
 	set_gearing(gearset);
 	set_reversed(reverse);
 	set_encoder_units(encoder_units);
@@ -90,6 +91,7 @@ Motor::Motor(const std::int8_t port, const motor_gearset_e_t gearset, const bool
 }
 
 Motor::Motor(const std::int8_t port, const motor_gearset_e_t gearset, const bool reverse) : _port(abs(port)) {
+	rtos_start_check();
 	set_gearing(gearset);
 	set_reversed(reverse);
 	if (port < 0) 
@@ -97,18 +99,21 @@ Motor::Motor(const std::int8_t port, const motor_gearset_e_t gearset, const bool
 }
 
 Motor::Motor(const std::int8_t port, const motor_gearset_e_t gearset) : _port(abs(port)) {
+	rtos_start_check();
 	set_gearing(gearset);
 	if (port < 0) 
 		set_reversed(true);
 }
 
 Motor::Motor(const std::int8_t port, const bool reverse) : _port(abs(port)) {
+	rtos_start_check();
 	set_reversed(reverse);
 	if (port < 0) 
 		set_reversed(true);
 }
 
 Motor::Motor(const std::int8_t port) : _port(abs(port)) {
+	rtos_start_check();
 	if (port < 0) 
 		set_reversed(true);
 }

--- a/src/devices/vdml_rotation.c
+++ b/src/devices/vdml_rotation.c
@@ -71,7 +71,12 @@ int32_t rotation_get_angle(uint8_t port) {
 
 int32_t rotation_set_reversed(uint8_t port, bool value) {
 	claim_port_i(port - 1, E_DEVICE_ROTATION);
+	rtos_start_check();
 	vexDeviceAbsEncReverseFlagSet(device->device_info, value);
+	while(vexDeviceAbsEncStatusGet(device->device_info) == 0) {
+		task_delay(5);
+	}
+	
 	return_port(port - 1, PROS_SUCCESS);
 }
 

--- a/src/devices/vdml_serial.cpp
+++ b/src/devices/vdml_serial.cpp
@@ -17,11 +17,13 @@ namespace pros {
 using namespace pros::c;
 
 Serial::Serial(std::uint8_t port, std::int32_t baudrate) : _port(port) {
+	rtos_start_check();
 	serial_enable(port);
 	set_baudrate(baudrate);
 }
 
 Serial::Serial(std::uint8_t port) : _port(port) {
+	rtos_start_check();
 	serial_enable(port);
 }
 

--- a/src/rtos/tasks.c
+++ b/src/rtos/tasks.c
@@ -1121,6 +1121,10 @@ static void prvAddNewTaskToReadyList( TCB_t *pxNewTCB )
 	void task_delay(const uint32_t milliseconds)
 	{
 	int32_t xAlreadyYielded = pdFALSE;
+	// Coverage marker in case FreeRTOS isn't started yet.
+	if(!rtos_start_check()) {
+		mtCOVERAGE_TEST_MARKER();
+	}
 
 		/* A delay time of zero just forces a reschedule. */
 		if( milliseconds > ( uint32_t ) 0U )
@@ -1865,6 +1869,20 @@ void rtos_sched_stop( void )
 	vPortEndScheduler();
 }
 /*----------------------------------------------------------*/
+
+// If the scheduler isn't start it, start it.
+// This is intentional as if anybody calls a constructor with a 
+// delay before main.cpp, it will cause a crash.
+extern void rtos_initialize();
+
+bool rtos_start_check(void) {
+	if(xTaskGetSchedulerState() == taskSCHEDULER_NOT_STARTED)
+	{
+		rtos_initialize();
+		return false;
+	}
+	return true;
+}
 
 void rtos_suspend_all( void )
 {

--- a/src/rtos/tasks.c
+++ b/src/rtos/tasks.c
@@ -906,6 +906,21 @@ static void prvAddNewTaskToReadyList( TCB_t *pxNewTCB )
 		mtCOVERAGE_TEST_MARKER();
 	}
 }
+
+// If the scheduler isn't start it, start it.
+// This is intentional as if anybody calls a constructor with a 
+// delay before main.cpp, it will cause a crash.
+extern void rtos_initialize();
+
+bool rtos_start_check(void) {
+	if(xTaskGetSchedulerState() == taskSCHEDULER_NOT_STARTED)
+	{
+		rtos_initialize();
+		return false;
+	}
+	return true;
+}
+
 /*-----------------------------------------------------------*/
 
 #if ( INCLUDE_vTaskDelete == 1 )
@@ -1869,20 +1884,6 @@ void rtos_sched_stop( void )
 	vPortEndScheduler();
 }
 /*----------------------------------------------------------*/
-
-// If the scheduler isn't start it, start it.
-// This is intentional as if anybody calls a constructor with a 
-// delay before main.cpp, it will cause a crash.
-extern void rtos_initialize();
-
-bool rtos_start_check(void) {
-	if(xTaskGetSchedulerState() == taskSCHEDULER_NOT_STARTED)
-	{
-		rtos_initialize();
-		return false;
-	}
-	return true;
-}
 
 void rtos_suspend_all( void )
 {


### PR DESCRIPTION
#### Summary:
If you call a constructor before RTOS initializes, it sometimes crashes. 

#### Test Plan:
- [ ] Test this with a pros::Serial object... calling a constructor in a header will normally lead to a crash (verify this on a non-fixed branch).
