### PR TITLE
💀 PROS 4: Remove dead VDML logging code

### DIFF
--- a/include/vdml/vdml.h
+++ b/include/vdml/vdml.h
@@ -140,11 +140,6 @@ void vdml_unset_port_error(uint8_t port);
 bool vdml_get_port_error(uint8_t port);
 
 /**
- * Reset all ports' error bits.
- */
-void vdml_reset_port_error();
-
-/**
  * Claims the mutex for the given port.
  *
  * Reserves the mutex for this port. Any other tasks trying to access this port

--- a/src/devices/vdml.c
+++ b/src/devices/vdml.c
@@ -161,6 +161,10 @@ void vdml_reset_port_error() {
  * On warnings, no operation is performed.
  */
 void vdml_background_processing() {
+
+// We're not removing this outright since we want to revisit the idea of logging
+// the errors with devices in the future
+#if 0
 	static int32_t last_port_errors = 0;
 	static int cycle = 0;
 	cycle++;
@@ -168,10 +172,12 @@ void vdml_background_processing() {
 		vdml_reset_port_error();
 		last_port_errors = 0;
 	}
+#endif
 
-	// Refresh actual device types
+	// Refresh actual device types.
 	registry_update_types();
 
+#if 0
 	// Validate the ports. Warn if mismatch.
 	uint8_t error_arr[NUM_V5_PORTS];
 	int num_errors = 0;
@@ -257,4 +263,5 @@ void vdml_background_processing() {
 	end_render_errors:
 		last_port_errors = port_errors;
 	}
+#endif
 }

--- a/src/devices/vdml.c
+++ b/src/devices/vdml.c
@@ -144,9 +144,11 @@ bool vdml_get_port_error(uint8_t port) {
 	}
 }
 
+#if 0
 void vdml_reset_port_error() {
 	port_errors = 0;
 }
+#endif
 
 /**
  * Background processing function for the VDML system.


### PR DESCRIPTION
#### Summary:
This disables (not removes) the logging code that the VDML had. Since PROS 4 no longer shows messages for device disconnects, mismatches, etc. this code is no longer needed. It was not completely removed since we want to add better logging in the future. See #518 

#### Test Plan:
- [x] Run the kernel on the brain and make sure it doesn't crash
- [x] Unplug a device while the kernel is running to ensure that an event like this doesn't do anything weird. 


