### PR TITLE
🐛 PROS 3.8: Prevent File Paths with Spaces/Parenthesis Causing Error

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -280,7 +280,7 @@ $(VV)mkdir -p $(dir $(LDTIMEOBJ))
 @# The shell command $$(($$(date +%s)+($$(date +%-z)/100*3600))) fetches the current
 @# unix timestamp, and then adds the UTC timezone offset to account for time zones.
 
-$(call test_output_2,Adding timestamp ,echo 'const int _PROS_COMPILE_TIMESTAMP_INT = $(shell echo $$(($$(date +%s)+($$(date +%-z)/100*3600)))); char const * const _PROS_COMPILE_TIMESTAMP = __DATE__ " " __TIME__; char const * const _PROS_COMPILE_DIRECTORY = "$(shell pwd | tail -c 23)";' | $(CC) -c -x c $(CFLAGS) $(EXTRA_CFLAGS) -o $(LDTIMEOBJ) -,$(OK_STRING))
+$(call test_output_2,Adding timestamp ,echo 'const int _PROS_COMPILE_TIMESTAMP_INT = $(shell echo $$(($$(date +%s)+($$(date +%-z)/100*3600)))); char const * const _PROS_COMPILE_TIMESTAMP = __DATE__ " " __TIME__; char const * const _PROS_COMPILE_DIRECTORY = "$(wildcard $(shell pwd | tail -c 23))";' | $(CC) -c -x c $(CFLAGS) $(EXTRA_CFLAGS) -o $(LDTIMEOBJ) -,$(OK_STRING))
 endef
 
 # these rules are for build-compile-commands, which just print out sysroot information


### PR DESCRIPTION
space paths from crashing

#### Summary:
<!-- Provide a concise description of your changes -->
Added a wildcard function when the char const * const _PROS_COMPILE_DIRECTORY variable is assigned.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
#472 
#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->
Tested with
Create a new pros project using pros c new "project name"

Create a project name with spaces and a project with parenthesis
![image](https://user-images.githubusercontent.com/64756497/219601585-44f4e0ee-9947-4555-8516-0385b03e3f04.png)

![image](https://user-images.githubusercontent.com/64756497/219601711-b9c4fa08-4ecd-4f82-bb9c-a99061ec8391.png)


Create a project name with both spaces and parenthesis

![image](https://user-images.githubusercontent.com/64756497/219601774-a93f0028-26b4-44e2-89b7-9280a498724d.png)


Compile and run without any errors