### PR TITLE
:bug: PROS 3.8: ADIEncoder Ambiguous Default Constructor

### DIFF
--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -494,7 +494,7 @@ class ADIEncoder : private ADIPort {
 	 * 		  sensor with the removable cover side up, and the "bottom" wire from
 	 * 		  the encoder sensor
 	 * \param reverse
-	 *        If "true", the sensor will count in theopposite direction
+	 *        If "true", the sensor will count in the opposite direction
 	 */
 	ADIEncoder(ext_adi_port_tuple_t port_tuple, bool reversed = false);
 

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -498,6 +498,9 @@ class ADIEncoder : private ADIPort {
 	 */
 	ADIEncoder(ext_adi_port_tuple_t port_tuple, bool reversed = false);
 
+	// Delete copy constructor to prevent a compilation error from the constructor above.
+	ADIEncoder(ADIEncoder &) = delete;
+	
 	/**
 	 * Sets the encoder value to zero.
 	 *


### PR DESCRIPTION
#### Summary:
Closes:
#526 

Makes it unambigious by deleting the copy constructor for ADIEncoder. While this is a breaking change this should not really effect many codebases that attempt to do this.  

#### Test Plan:

![image](https://user-images.githubusercontent.com/54247087/220501444-62ef4db3-3829-400e-bb8f-7ce383cfff18.png)

Does not break ABI for any of these major templates. 
