### PR TITLE
🐛PROS 3.8: Check for insufficient objects in vision_read_by_size()

### DIFF
--- a/src/devices/vdml_vision.c
+++ b/src/devices/vdml_vision.c
@@ -139,6 +139,7 @@ int32_t vision_read_by_size(uint8_t port, const uint32_t size_id, const uint32_t
 	}
 	uint32_t c = vexDeviceVisionObjectCountGet(device->device_info);
 	if (object_count + size_id >= c) {
+		port_mutex_give(port - 1);
 		errno = ERANGE;
 		return PROS_ERR;
 	}

--- a/src/devices/vdml_vision.c
+++ b/src/devices/vdml_vision.c
@@ -138,6 +138,10 @@ int32_t vision_read_by_size(uint8_t port, const uint32_t size_id, const uint32_t
 		object_arr[i].signature = VISION_OBJECT_ERR_SIG;
 	}
 	uint32_t c = vexDeviceVisionObjectCountGet(device->device_info);
+	if (object_count + size_id >= c) {
+		errno = ERANGE;
+		return PROS_ERR;
+	}
 	if (c <= size_id) {
 		port_mutex_give(port - 1);
 		errno = EDOM;
@@ -145,7 +149,6 @@ int32_t vision_read_by_size(uint8_t port, const uint32_t size_id, const uint32_t
 	} else if (c > object_count + size_id) {
 		c = object_count + size_id;
 	}
-
 	for (uint32_t i = size_id; i < c; i++) {
 		if (!vexDeviceVisionObjectGet(device->device_info, i, (V5_DeviceVisionObject*)(object_arr + i))) {
 			errno = EAGAIN;


### PR DESCRIPTION
#### Summary:
Added an if statement to vision_read_by_size() to check that there are enough vision objects for the device to fill object_arr and returns an error otherwise

#### Motivation:
User reported issue

##### References (optional):
#536 

#### Test Plan:
Run method with too large of a object_count value and make sure it sets errno to ERANGE.