### PR TITLE
🚸 PROS 4: Update behavior of GPS to return a struct with offset, add get_position. 

### DIFF
--- a/include/pros/gps.h
+++ b/include/pros/gps.h
@@ -41,6 +41,16 @@ namespace pros {
  */
 
 /**
+ * \struct gps_position_s_t
+ */
+typedef struct __attribute__((__packed__)) gps_position_s {
+	/// X Position (meters)
+	double x;
+	/// Y Position (meters)
+	double y;
+} gps_position_s_t;
+
+/**
  * \struct gps_status_s_t
  */
 typedef struct __attribute__((__packed__)) gps_status_s {
@@ -177,6 +187,24 @@ int32_t gps_set_offset(uint8_t port, double xOffset, double yOffset);
 gps_status_s_t gps_get_status(uint8_t port);
 
 /**
+ * Gets the x and y position on the field of the GPS in meters.
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * ENXIO - The given value is not within the range of V5 ports (1-21).
+ * ENODEV - The port cannot be configured as a GPS
+ * EAGAIN - The sensor is still calibrating
+ *
+ * \param  port
+ * 				 The V5 GPS port number from 1-21
+ *
+ * \return A struct (gps_position_s_t) containing values mentioned above.
+ * If the operation failed, all the structure's members are filled with
+ * PROS_ERR_F and errno is set.
+ */
+gps_position_s_t get_position(uint8_t port);
+
+/**
  * Get the GPS's raw gyroscope values
  *
  * This function uses the following values of errno when an error state is
@@ -209,7 +237,7 @@ gps_gyro_s_t gps_get_gyro_rate(uint8_t port);
 gps_accel_s_t gps_get_accel(uint8_t port);
 
 /**
- * Get the GPS's location relative to the center of turning/origin in meters.
+ * Get the GPS's cartesian location relative to the center of turning/origin in meters.
  *
  * This function uses the following values of errno when an error state is
  * reached:
@@ -219,11 +247,7 @@ gps_accel_s_t gps_get_accel(uint8_t port);
  *
  * \param  port
  * 				 The V5 GPS port number from 1-21
- * \param  xOffset
- * 				 Pointer to cartesian 4-Quadrant X offset from center of turning (meters)
- * \param  yOffset
- * 				 Pointer to cartesian 4-Quadrant Y offset from center of turning (meters)
- * \return 1 if the operation was successful or PROS_ERR if the operation
+ * \return A struct (gps_position_s_t) containing the X and Y values if the operation
  * failed, setting errno.
  * 
  * \b Example
@@ -231,18 +255,17 @@ gps_accel_s_t gps_get_accel(uint8_t port);
  * #define GPS_PORT 1
  * 
  * void opcontrol() {
- *   int *x;
- *   int *y;
+ *   gps_position_s_t pos;
  * 
  *   while (true) {
- *     gps_get_offset(GPS_PORT, x, y);
- *     screen_print(TEXT_MEDIUM, 1, "X Offset: %4d, Y Offset: %4d", *x, *y);
+ *     pos = gps_get_offset(GPS_PORT, x, y);
+ *     screen_print(TEXT_MEDIUM, 1, "X Offset: %4d, Y Offset: %4d", pos.x, pos.y);
  *     delay(20);
  *   }
  * }
  * \endcode
  */
-int32_t gps_get_offset(uint8_t port, double* xOffset, double* yOffset);
+gps_position_s_t gps_get_offset(uint8_t port);
 
 /**
  * Sets the robot's location relative to the center of the field in meters.

--- a/include/pros/gps.h
+++ b/include/pros/gps.h
@@ -202,7 +202,7 @@ gps_status_s_t gps_get_status(uint8_t port);
  * If the operation failed, all the structure's members are filled with
  * PROS_ERR_F and errno is set.
  */
-gps_position_s_t get_position(uint8_t port);
+gps_position_s_t gps_get_position(uint8_t port);
 
 /**
  * Get the GPS's raw gyroscope values

--- a/include/pros/gps.hpp
+++ b/include/pros/gps.hpp
@@ -104,22 +104,35 @@ class Gps : public Device {
 	virtual std::int32_t set_offset(double xOffset, double yOffset) const;
 
 	/**
-	 * Get the GPS's location relative to the center of turning/origin in meters.
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENXIO - The given value is not within the range of V5 ports (1-21).
-	 * ENODEV - The port cannot be configured as a GPS
-	 * EAGAIN - The sensor is still calibrating
-	 *
-	 * \param  xOffset
-	 * 				 Pointer to cartesian 4-Quadrant X offset from center of turning (meters)
-	 * \param  yOffset
-	 * 				 Pointer to cartesian 4-Quadrant Y offset from center of turning (meters)
-	 * \return 1 if the operation was successful or PROS_ERR if the operation
-	 * failed, setting errno.
-	 */
-	virtual std::int32_t get_offset(double* xOffset, double* yOffset) const;
+	* Get the GPS's cartesian location relative to the center of turning/origin in meters.
+	*
+	* This function uses the following values of errno when an error state is
+	* reached:
+	* ENXIO - The given value is not within the range of V5 ports (1-21).
+	* ENODEV - The port cannot be configured as a GPS
+	* EAGAIN - The sensor is still calibrating
+	*
+	* \param  port
+	* 				 The V5 GPS port number from 1-21
+	* \return A struct (gps_position_s_t) containing the X and Y values if the operation
+	* failed, setting errno.
+	* 
+	* \b Example
+	* \code
+	* #define GPS_PORT 1
+	* 
+	* void opcontrol() {
+	*   gps_position_s_t pos;
+	* 	Gps gps(GPS_PORT);
+	*   while (true) {
+	*     pos = gps.get_offset();
+	*     screen_print(TEXT_MEDIUM, 1, "X Offset: %4d, Y Offset: %4d", pos.x, pos.y);
+	*     delay(20);
+	*   }
+	* }
+	* \endcode
+	*/
+	virtual pros::gps_position_s_t get_offset() const;
 
 	/**
 	 * Sets the robot's location relative to the center of the field in meters.
@@ -186,6 +199,21 @@ class Gps : public Device {
 	 * PROS_ERR_F and errno is set.
 	 */
 	virtual pros::gps_status_s_t get_status() const;
+
+	/**
+	 * Gets the x and y position on the field of the GPS in meters.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENXIO - The given value is not within the range of V5 ports (1-21).
+	 * ENODEV - The port cannot be configured as a GPS
+	 * EAGAIN - The sensor is still calibrating
+	 *
+	 * \return A struct (gps_position_s_t) containing values mentioned above.
+	 * If the operation failed, all the structure's members are filled with
+	 * PROS_ERR_F and errno is set.
+	 */
+	virtual pros::gps_position_s_t gps_get_position() const;
 
 	/**
 	 * Get the heading in [0,360) degree values.

--- a/include/pros/gps.hpp
+++ b/include/pros/gps.hpp
@@ -213,7 +213,7 @@ class Gps : public Device {
 	 * If the operation failed, all the structure's members are filled with
 	 * PROS_ERR_F and errno is set.
 	 */
-	virtual pros::gps_position_s_t gps_get_position() const;
+	virtual pros::gps_position_s_t get_position() const;
 
 	/**
 	 * Get the heading in [0,360) degree values.

--- a/src/devices/vdml_gps.c
+++ b/src/devices/vdml_gps.c
@@ -44,7 +44,14 @@ gps_position_s_t gps_get_offset(uint8_t port) {
 	if (!claim_port_try(port - 1, E_DEVICE_GPS)) {
 		return rtv;
 	}
-	vexDeviceGpsOriginGet(device->device_info, &rtv.x, &rtv.y);
+	// This is necessary for warning suppression as a packed struct's address
+	// may be misaligned. 
+	double x = PROS_ERR_F;
+	double y = PROS_ERR_F;
+	v5_smart_device_s_t* device = registry_get_device(port - 1);
+	vexDeviceGpsOriginGet(device->device_info, &x, &y);
+	rtv.x = x;
+	rtv.y = y;
 	return_port(port - 1, rtv);
 }
 

--- a/src/devices/vdml_gps.c
+++ b/src/devices/vdml_gps.c
@@ -39,10 +39,13 @@ int32_t gps_set_offset(uint8_t port, double xOffset, double yOffset) {
 	return_port(port - 1, PROS_SUCCESS);
 }
 
-int32_t gps_get_offset(uint8_t port, double* xOffset, double* yOffset) {
-	claim_port_i(port - 1, E_DEVICE_GPS);
-	vexDeviceGpsOriginGet(device->device_info, xOffset, yOffset);
-	return_port(port - 1, PROS_SUCCESS);
+gps_position_s_t gps_get_offset(uint8_t port) {
+	gps_position_s_t rtv = {PROS_ERR_F, PROS_ERR_F};
+	if (!claim_port_try(port - 1, E_DEVICE_GPS)) {
+		return rtv;
+	}
+	vexDeviceGpsOriginGet(device->device_info, &rtv.x, &rtv.y);
+	return_port(port - 1, rtv);
 }
 
 int32_t gps_set_position(uint8_t port, double xInitial, double yInitial, double headingInitial) {
@@ -84,6 +87,19 @@ gps_status_s_t gps_get_status(uint8_t port) {
 	rtv.pitch = data.pitch;
 	rtv.roll = data.roll;
 	rtv.yaw = data.yaw;
+	return_port(port - 1, rtv);
+}
+
+gps_position_s_t gps_get_position(uint8_t port) {
+	gps_position_s_t rtv = {PROS_ERR_F, PROS_ERR_F};
+	if (!claim_port_try(port - 1, E_DEVICE_GPS)) {
+		return rtv;
+	}
+	v5_smart_device_s_t* device = registry_get_device(port - 1);
+	V5_DeviceGpsAttitude data;
+	vexDeviceGpsAttitudeGet(device->device_info, &data, false);
+	rtv.x = data.position_x;
+	rtv.y = data.position_y;
 	return_port(port - 1, rtv);
 }
 

--- a/src/devices/vdml_gps.cpp
+++ b/src/devices/vdml_gps.cpp
@@ -24,8 +24,8 @@ std::int32_t Gps::set_offset(double xOffset, double yOffset) const {
 	return pros::c::gps_set_offset(_port, xOffset, yOffset);
 }
 
-std::int32_t Gps::get_offset(double* xOffset, double* yOffset) const {
-	return pros::c::gps_get_offset(_port, xOffset, yOffset);
+pros::gps_position_s_t Gps::get_offset() const {
+	return pros::c::gps_get_offset(_port);
 }
 
 std::int32_t Gps::set_position(double xInitial, double yInitial, double headingInitial) const {
@@ -42,6 +42,10 @@ double Gps::get_error() const {
 
 pros::gps_status_s_t Gps::get_status() const {
 	return pros::c::gps_get_status(_port);
+}
+
+pros::gps_position_s_t Gps::get_position() const {
+	return pros::c::gps_get_position(_port);
 }
 
 double Gps::get_heading() const {


### PR DESCRIPTION
#### Summary:
Updated behavior of GPS's `get_offset` to return a struct with offset, added a `get_position` while I was at it to return just the X and Y position. 

#### Motivation:
Community pointed it out, I was always bothered by how we did this. 

#### Test Plan:
- [x] Test `get_position` and `get_offset` with an actual GPS. 
