### PR TITLE
:bug: PROS 4: Fix Motor Behavior for move_absolute and move_relative

### DIFF
--- a/include/pros/motors.h
+++ b/include/pros/motors.h
@@ -195,7 +195,7 @@ int32_t motor_move_absolute(int8_t port, const double position, const int32_t ve
  * }
  * \endcode
  */
-int32_t motor_move_relative(int8_t port, const double position, const int32_t velocity);
+int32_t motor_move_relative(int8_t port, double position, const int32_t velocity);
 
 /**
  * Sets the velocity for the motor.

--- a/include/pros/motors.h
+++ b/include/pros/motors.h
@@ -120,7 +120,7 @@ int32_t motor_brake(int8_t port);
  * ENODEV - The port cannot be configured as a motor
  *
  * \param port
- *        The V5 port number from 1-21
+ *        The V5 port number from 1-21. 
  * \param position
  *        The absolute position to move to in the motor's encoder units
  * \param velocity

--- a/src/devices/vdml_motors.c
+++ b/src/devices/vdml_motors.c
@@ -52,7 +52,6 @@ int32_t motor_brake(int8_t port) {
 int32_t motor_move_absolute(int8_t port, const double position, int32_t velocity) {
 	uint8_t abs_port = abs(port);
 	claim_port_i(abs_port - 1, E_DEVICE_MOTOR);
-	if (port < 0) velocity = -velocity;
 	vexDeviceMotorAbsoluteTargetSet(device->device_info, position, velocity);
 	return_port(abs_port - 1, PROS_SUCCESS);
 }
@@ -60,7 +59,7 @@ int32_t motor_move_absolute(int8_t port, const double position, int32_t velocity
 int32_t motor_move_relative(int8_t port, const double position, int32_t velocity) {
 	uint8_t abs_port = abs(port);
 	claim_port_i(abs_port - 1, E_DEVICE_MOTOR);
-	if (port < 0) velocity = -velocity;
+	if (port < 0) position = -position;
 	vexDeviceMotorRelativeTargetSet(device->device_info, position, velocity);
 	return_port(abs_port - 1, PROS_SUCCESS);
 }

--- a/src/devices/vdml_motors.c
+++ b/src/devices/vdml_motors.c
@@ -56,7 +56,7 @@ int32_t motor_move_absolute(int8_t port, const double position, int32_t velocity
 	return_port(abs_port - 1, PROS_SUCCESS);
 }
 
-int32_t motor_move_relative(int8_t port, const double position, int32_t velocity) {
+int32_t motor_move_relative(int8_t port, double position, int32_t velocity) {
 	uint8_t abs_port = abs(port);
 	claim_port_i(abs_port - 1, E_DEVICE_MOTOR);
 	if (port < 0) position = -position;


### PR DESCRIPTION
#### Summary:
Fixes behavior of move absolute and move relative for motors
New behavior: 
motor_move_absolute does not care about sign of the port as it is absolute movement. 
motor_move_relative with a negative port value should move in the reversed direction if the distance is positive.
PROS 3 behavior is still functional if you use the c api motor_set_reversed and only positive port numbers

#### Motivation:
Current code does not behave as expected

#### Test Plan:
Test 1:
- [x] motor_move_absolute(1, 3000, 100);
- [x] After it stops moving motor_get_position(1); returns ~3000
- [x]  motor_move_absolute(-1, 3000, 100); No movement should occur
- [x] motor_move_absolute(-1, 5000, 100)
- [x] After it stops moving motor_get_position(1); returns ~5000
 - [x] motor_move_absolute(1, 5000, 100); No movement should occur
- [x] After it stops moving motor_get_position(1); returns ~5000
Test 2:

- [x] motor_move_relative(1, 3000, 100);
- [x] After it stops moving motor_get_position(1); returns ~3000
- [x]  motor_move_relative(-1, 3000, 100);
- [x] After it stops moving motor_get_position(1); returns ~0
- [x] motor_move_relative(-1, 5000, 100)
- [x] After it stops moving motor_get_position(1); returns ~-5000
