### PR TITLE
✨ PROS 4: Add numerical color override for pen/eraser

### DIFF
--- a/include/pros/screen.h
+++ b/include/pros/screen.h
@@ -151,7 +151,7 @@ namespace c {
  * }
  * \endcode
  */
-uint32_t screen_set_pen(color_e_t color);
+uint32_t screen_set_pen(uint32_t color);
 
 /**
  * Set the eraser color for erasing and the current background.
@@ -180,7 +180,7 @@ uint32_t screen_set_pen(color_e_t color);
  * }
  * \endcode
  */
-uint32_t screen_set_eraser(color_e_t color);
+uint32_t screen_set_eraser(uint32_t color);
 
 /**
  *  Get the current pen color.

--- a/include/pros/screen.hpp
+++ b/include/pros/screen.hpp
@@ -64,12 +64,26 @@ const char* convert_args(const std::string& arg) {
      * EACCESS - Another resource is currently trying to access the screen mutex.
      *
      * \param color	The pen color to set (it is recommended to use values
-     * 		 from the enum defined in colors.h)
+     * 		 from the enum defined in colors.hpp)
      * 
      * \return Returns 1 if the mutex was successfully returned, or PROS_ERR if 
      * there was an error either taking or returning the screen mutex.
      */
     std::uint32_t set_pen(pros::Color color);
+
+    /**
+     * Set the pen color for subsequent graphics operations
+     * 
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     *
+     * \param color	The pen color to set (in hex form)
+     * 
+     * \return Returns 1 if the mutex was successfully returned, or PROS_ERR if 
+     * there was an error either taking or returning the screen mutex.
+     */
+    std::uint32_t set_pen(std::uint32_t color);
 
     /**
      * Set the eraser color for erasing and the current background.
@@ -79,12 +93,26 @@ const char* convert_args(const std::string& arg) {
      * EACCESS - Another resource is currently trying to access the screen mutex.
      * 
      * \param color	The background color to set (it is recommended to use values
-     * 					from the enum defined in colors.h)
+     * 					from the enum defined in colors.hpp)
      * 
      * \return Returns 1 if the mutex was successfully returned, or PROS_ERR
      *  if there was an error either taking or returning the screen mutex.
      */
     std::uint32_t set_eraser(pros::Color color);
+
+    /**
+     * Set the eraser color for erasing and the current background.
+     *
+     * This function uses the following values of errno when an error state is
+     * reached:
+     * EACCESS - Another resource is currently trying to access the screen mutex.
+     * 
+     * \param color	The background color to set to set (in hex form)
+     * 
+     * \return Returns 1 if the mutex was successfully returned, or PROS_ERR
+     *  if there was an error either taking or returning the screen mutex.
+     */
+    std::uint32_t set_eraser(std::uint32_t color);
 
     /**
      *  Get the current pen color.

--- a/src/devices/screen.c
+++ b/src/devices/screen.c
@@ -36,7 +36,7 @@ typedef struct touch_event_position_data_s {
 	int16_t y;
 } touch_event_position_data_s_t;
 
-uint32_t screen_set_pen(color_e_t color){
+uint32_t screen_set_pen(uint32_t color){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;
@@ -49,7 +49,7 @@ uint32_t screen_set_pen(color_e_t color){
 	}
 }
 
-uint32_t screen_set_eraser(color_e_t color){
+uint32_t screen_set_eraser(uint32_t color){
 	if (!mutex_take(_screen_mutex, TIMEOUT_MAX)) {
 		errno = EACCES;
 		return PROS_ERR;

--- a/src/devices/screen.cpp
+++ b/src/devices/screen.cpp
@@ -13,24 +13,25 @@
  */
 
 #include "pros/screen.hpp"
+#include <stdint.h>
 
 namespace pros {
 namespace screen {
 
     std::uint32_t set_pen(pros::Color color){
-        return pros::c::screen_set_pen(static_cast<pros::c::color_e_t>(color));
+        return pros::c::screen_set_pen((uint32_t)color);
     }
     
     std::uint32_t set_eraser(pros::Color color){
-        return pros::c::screen_set_eraser(static_cast<pros::c::color_e_t>(color));
+        return pros::c::screen_set_eraser((uint32_t)color);
     }
 
     std::uint32_t set_pen(std::uint32_t color){
-        return pros::c::screen_set_pen(static_cast<pros::c::color_e_t>(color));
+        return pros::c::screen_set_pen(color);
     }
 
     std::uint32_t set_eraser(std::uint32_t color) {
-        return pros::c::screen_set_pen(static_cast<pros::c::color_e_t>(color));
+        return pros::c::screen_set_pen(color);
     }
 
     std::uint32_t get_pen(){

--- a/src/devices/screen.cpp
+++ b/src/devices/screen.cpp
@@ -25,6 +25,14 @@ namespace screen {
         return pros::c::screen_set_eraser(static_cast<pros::c::color_e_t>(color));
     }
 
+    std::uint32_t set_pen(std::uint32_t color){
+        return pros::c::screen_set_pen(static_cast<pros::c::color_e_t>(color));
+    }
+
+    std::uint32_t set_eraser(std::uint32_t color) {
+        return pros::c::screen_set_pen(static_cast<pros::c::color_e_t>(color));
+    }
+
     std::uint32_t get_pen(){
         return pros::c::screen_get_pen();
     }

--- a/src/devices/screen.cpp
+++ b/src/devices/screen.cpp
@@ -31,7 +31,7 @@ namespace screen {
     }
 
     std::uint32_t set_eraser(std::uint32_t color) {
-        return pros::c::screen_set_pen(color);
+        return pros::c::screen_set_eraser(color);
     }
 
     std::uint32_t get_pen(){


### PR DESCRIPTION
Summary:
added pros::screen::set_pen and set_eraser with a uint32_t as an input since values outside of pros::Color do not work without it.

Motivation:
Template/porting work is a hassle without custom colors, and it would be nice for our users.

References (optional):
closes https://github.com/purduesigbots/pros/issues/548

Test Plan:
 - [x] [test item](See if this compiles: pros::screen::set_eraser(0x00FF1234);)
 - [x] [test item](See if this compiles: pros::screen::set_pen(0x00FF1234);)