### PR TITLE
:sparkles: PROS 4: Add LCD Initialize Weak Symbol

### DIFF
--- a/include/pros/screen.hpp
+++ b/include/pros/screen.hpp
@@ -472,6 +472,13 @@ namespace lcd {
   extern __attribute__((weak)) void register_btn1_cb(lcd_btn_cb_fn_t cb);
 
   /**
+  * Checks whether the emulated three-button LCD has already been initialized.
+  *
+  * \return True if the LCD has been initialized or false if not.
+  */
+  extern __attribute__((weak)) bool lcd_is_initialized(void);
+
+  /**
   * Displays a formatted string on the emulated three-button LCD screen.
   *
   * This function uses the following values of errno when an error state is

--- a/include/pros/screen.hpp
+++ b/include/pros/screen.hpp
@@ -476,7 +476,7 @@ namespace lcd {
   *
   * \return True if the LCD has been initialized or false if not.
   */
-  extern __attribute__((weak)) bool lcd_is_initialized(void);
+  extern __attribute__((weak)) bool is_initialized(void);
 
   /**
   * Displays a formatted string on the emulated three-button LCD screen.

--- a/src/devices/screen.cpp
+++ b/src/devices/screen.cpp
@@ -108,6 +108,7 @@ namespace screen {
         extern __attribute__((weak)) bool set_text(std::int16_t line, std::string text) {return false;} 
         extern __attribute__((weak)) bool clear_line(std::int16_t line) {return false;}
         extern __attribute__((weak)) bool initialize(void) {return false;}
+        extern __attribute__((weak)) bool is_initialized(void) {return false;}
         extern __attribute__((weak)) std::uint8_t read_buttons(void) {return 0xf;}
         extern __attribute__((weak)) void register_btn1_cb(lcd_btn_cb_fn_t cb) {}
 


### PR DESCRIPTION
Summary:
Adds pros::lcd::is_initialized to the weak symbol table for LLEMU stubs. This is a way to help templates who check for this (such as EZTemplate) to see if both LVGL is installed and LLEMU is initialized. To accomplish this, this function will return false if it is still defined as the weak symbol.

Motivation:
Porting work on EZTemplate.

References (optional):
closes https://github.com/purduesigbots/pros/issues/549

Test Plan:
- [ ] Not really much other than seeing if this PR compiles