### PR TITLE
:bug: Fixed broken TEXT_LARGE_CENTER macro

### DIFF
--- a/include/pros/screen.h
+++ b/include/pros/screen.h
@@ -67,7 +67,7 @@ typedef struct screen_touch_status_s {
 #define TEXT_MEDIUM pros::E_TEXT_MEDIUM
 #define TEXT_LARGE pros::E_TEXT_LARGE
 #define TEXT_MEDIUM_CENTER pros::E_TEXT_MEDIUM_CENTER
-#define TEXT_LARGE_CENTER pros::E_LARGE_CENTER
+#define TEXT_LARGE_CENTER pros::E_TEXT_LARGE_CENTER
 #define TOUCH_RELEASED pros::E_TOUCH_RELEASED
 #define TOUCH_PRESSED pros::E_TOUCH_PRESSED
 #define TOUCH_HELD pros::E_TOUCH_HELD


### PR DESCRIPTION
#### Summary:
Small change to fix centered large text display

#### Motivation:
Because the macro prevented compilation

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:

- [x] Try pros::screen::print(TEXT_LARGE_CENTER, 1, "Test"); to see if it compiles
