### PR TITLE
🐛 PROS 4 - Remove the Competition Namespace From the v5 Namespace

### DIFF
--- a/src/devices/controller.cpp
+++ b/src/devices/controller.cpp
@@ -64,6 +64,8 @@ std::int32_t Controller::rumble(const char* rumble_pattern) {
 	return controller_rumble(_id, rumble_pattern);
 }
 
+}  // namespace v5
+
 namespace competition {
 std::uint8_t get_status(void) {
 	return competition_get_status();
@@ -81,5 +83,4 @@ std::uint8_t is_disabled(void) {
 	return competition_is_disabled();
 }
 }  // namespace competition
-}  // namespace v5
 }  // namespace pros


### PR DESCRIPTION
#### Summary:
The `competition` namespace was accidentally in the `pros::v5` namespace, at least inside `controller.cpp`. This was not the case in `misc.hpp`, which lead to linker issues when building user projects. This PR fixes the issue.


#### Test Plan:
This PR was tested by building the kernel and applying it to a new project, with calls to all four of the competition namespace functions:
```cpp
pros::competition::is_autonomous();
pros::competition::is_connected();
pros::competition::is_disabled();
pros::competition::get_status();
```
The project linked without errors.