### PR TITLE
🐛Removed operator<< for motor groups

### DIFF
--- a/include/pros/motor_group.hpp
+++ b/include/pros/motor_group.hpp
@@ -2300,17 +2300,6 @@ class MotorGroup : public virtual AbstractMotor {
 	 */
 	void erase_port(std::int8_t port);
 
-	/**
-	 * This is the overload for the << operator for printing to streams
-	 *
-	 * Prints in format:
-	 * Motor [port: (motor port), brake mode: (brake mode), current draw: (current draw),
-	 * current limit: (current limit), direction: (direction), efficiency: (efficiency),
-	 * encoder units: (encoder units), gearing: (gearing), is over temp: (over temp),
-	 * position: (position), reversed: (reversed boolean), temperature: (temperature),
-	 * torque: (torque), voltage: (voltage)]
-	 */
-	friend std::ostream& operator<<(std::ostream& os, pros::MotorGroup& motor);
 	///@}
 	private:
 	/**


### PR DESCRIPTION
#### Summary:
removes the << operator from motor groups
#### Motivation:
Calling the << operator on a motor group would cause linking issues
After beta release we can implement it properly

#### Test Plan:
- [] Compiles
