### PR TITLE
🐛Add mutex control for printf and cout

### DIFF
--- a/src/rtos/stream_buffer.c
+++ b/src/rtos/stream_buffer.c
@@ -537,6 +537,7 @@ TimeOut_t xTimeOut;
 					break;
 				}
 			}
+			taskEXIT_CRITICAL();
 
 			traceBLOCKING_ON_STREAM_BUFFER_SEND( xStreamBuffer );
 			( void ) task_notify_wait( ( uint32_t ) 0, UINT32_MAX, NULL, xTicksToWait );

--- a/src/rtos/stream_buffer.c
+++ b/src/rtos/stream_buffer.c
@@ -537,7 +537,6 @@ TimeOut_t xTimeOut;
 					break;
 				}
 			}
-			taskEXIT_CRITICAL();
 
 			traceBLOCKING_ON_STREAM_BUFFER_SEND( xStreamBuffer );
 			( void ) task_notify_wait( ( uint32_t ) 0, UINT32_MAX, NULL, xTicksToWait );
@@ -559,7 +558,9 @@ TimeOut_t xTimeOut;
 		mtCOVERAGE_TEST_MARKER();
 	}
 
+	taskENTER_CRITICAL();
 	xReturn = prvWriteMessageToBuffer( pxStreamBuffer, pvTxData, xDataLengthBytes, xSpace, xRequiredSpace );
+	taskEXIT_CRITICAL();
 
 	if( xReturn > ( size_t ) 0 )
 	{
@@ -666,7 +667,9 @@ static size_t prvWriteMessageToBuffer( StreamBuffer_t * const pxStreamBuffer,
 		into the buffer.  Start by writing the length of the data, the data
 		itself will be written later in this function. */
 		xShouldWrite = pdTRUE;
+		taskENTER_CRITICAL();
 		( void ) prvWriteBytesToBuffer( pxStreamBuffer, ( const uint8_t * ) &( xDataLengthBytes ), sbBYTES_TO_STORE_MESSAGE_LENGTH );
+		taskEXIT_CRITICAL();
 	}
 	else
 	{
@@ -677,7 +680,9 @@ static size_t prvWriteMessageToBuffer( StreamBuffer_t * const pxStreamBuffer,
 	if( xShouldWrite != pdFALSE )
 	{
 		/* Writes the data itself. */
+		taskENTER_CRITICAL();
 		xReturn = prvWriteBytesToBuffer( pxStreamBuffer, ( const uint8_t * ) pvTxData, xDataLengthBytes ); /*lint !e9079 Storage buffer is implemented as uint8_t for ease of sizing, alighment and access. */
+		taskEXIT_CRITICAL();
 	}
 	else
 	{
@@ -864,7 +869,9 @@ size_t xOriginalTail, xReceivedLength, xNextMessageLength;
 		returned to its prior state if the length of the message is too
 		large for the provided buffer. */
 		xOriginalTail = pxStreamBuffer->xTail;
+		taskENTER_CRITICAL();
 		( void ) prvReadBytesFromBuffer( pxStreamBuffer, ( uint8_t * ) &xNextMessageLength, xBytesToStoreMessageLength, xBytesAvailable );
+		taskEXIT_CRITICAL();
 
 		/* Reduce the number of bytes available by the number of bytes just
 		read out. */
@@ -893,7 +900,9 @@ size_t xOriginalTail, xReceivedLength, xNextMessageLength;
 	}
 
 	/* Read the actual data. */
+	taskENTER_CRITICAL();
 	xReceivedLength = prvReadBytesFromBuffer( pxStreamBuffer, ( uint8_t * ) pvRxData, xNextMessageLength, xBytesAvailable ); /*lint !e9079 Data storage area is implemented as uint8_t array for ease of sizing, indexing and alignment. */
+	taskEXIT_CRITICAL();
 
 	return xReceivedLength;
 }


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
Added mutex control to protect printf and cout from causing utf-8 encoding errors due to race conditions. This is done by preventing context switches while prvWriteBytesToBuffer() and prvReadBytesToBuffer() is executing.

#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
 BUG: Multiple threads writing to stdout can cause encoding errors #500 

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->
It is difficult to verify that the changes entirely prevents utf-8 encoding errors since the race condition is difficult to reproduce consistently.

- [x] Compile.
- [ ] Implementation prevents utf-8 encoding from happening.
