### PR TITLE
:bug: Fix Device::get_port return value

### DIFF
--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -19,7 +19,7 @@ inline namespace v5 {
 using namespace pros::c;
 
 Motor::Motor(const std::int8_t port, const pros::v5::MotorGears gearset, const pros::v5::MotorUnits encoder_units)
-    : Device(port, DeviceType::motor), _port(port) {
+    : Device(std::abs(port), DeviceType::motor), _port(port) {
 	set_gearing(gearset);
 	set_encoder_units(encoder_units);
 }


### PR DESCRIPTION
#### Summary:

The port number -1 is passed to the constructor of the Device class when the Motor class is constructed. However, the device constructor takes an unsigned 8-bit integer instead of a signed 8-bit integer as the port number. This result in the port number being converted to an incorrect port number, which is 255.

To fix the issue, a positive number should be passed to the constructor of the Device class instead of a negative number.

```cpp
void opcontrol() {
	pros::Motor mtr(-1);
	pros::Device device(mtr);

	printf("%d\n", mtr.is_installed()); // 1
	printf("%d\n", device.is_installed()); // 1
	printf("%d\n", mtr.get_port()); // -1
	printf("%d\n", device.get_port()); // 255  <-- should be "1" instead
}
```

##### References (optional):
[Bug Report on the PROS Beta Testers Server](https://discord.com/channels/1025259843763847229/1029666535553384498/1081198206567862312)

#### Test Plan:
Run the provided test code.
