### PR TITLE
:recycle: Rewrite ADI Pneumatics class

### DIFF
--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -1753,7 +1753,7 @@ class Pneumatics : public DigitalOut {
 	 * }
 	 * \endcode
 	 */
-	explicit Pneumatics(std::uint8_t adi_port, bool start_extended, bool active_low = false);
+	explicit Pneumatics(std::uint8_t adi_port, bool start_extended);
 
 	/**
 	 * Creates a Pneumatics object for the given port.
@@ -1786,7 +1786,7 @@ class Pneumatics : public DigitalOut {
 	 * }
 	 * \endcode
 	 */
-	explicit Pneumatics(ext_adi_port_pair_t port_pair, bool start_extended, bool active_low = false);
+	explicit Pneumatics(ext_adi_port_pair_t port_pair, bool start_extended);
 
 	/* 
 	* Extends the piston, if not already extended.

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -1724,21 +1724,212 @@ class Pneumatics : public DigitalOut {
 	 *  @{
 	 */	
 	public:
+
 	/**
 	 * Creates a Pneumatics object for the given port.
-	 *
+	 * 
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENXIO - The given value is not within the range of ADI Ports
-	 *
+	 * 
 	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param start_extended
-	 * 		  If true, the pneumatic will start the match extended
-	 * \param active_low
-	 *        If set to true, a value of false corresponds to the pneumatic's
-	 * 		  wire being set to high.
+	 * 		  If true, the pneumatic will start extended when the program starts.
+	 *		  By default, the piston starts retracted when the program starts.
+	 * \param extended_is_low
+	 * 		  A flag to set whether the the pneumatic is extended when the ADI 
+	 * 		  it receives a high or a low value. When true, the extended state
+	 * 		  corresponds to a output low on the ADI port. This allows the user 
+	 * 		  to reverse the behavior of the pneumatics if needed.
+	 * 
+	 * /b Example:
+	 * \code
+	 * void opcontrol() {
+	 * 	 pros::adi::Pneumatics left_piston('a', false);			// Starts retracted, extends when the ADI port is high
+	 *   pros::adi::Pneumatics right_piston('b', false, true);	// Starts retracted, extends when the ADI port is low 
+	 *   
+	 *   pros::Controller master(pros::E_CONTROLLER_MASTER);
+	 * 
+	 *   while (true) {
+	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_L1)) {
+	 *       left_piston.extend();
+	 *     }
+	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_L2)) {
+	 *       left_piston.retract();
+	 *     }
+	 *     
+	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_R1)) {
+	 *       left_piston.extend();
+	 *     }
+	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_2)) {
+	 *       left_piston.retract();
+	 *     }
+	 * 
+	 *     pros::delay(10);
+	 *   }
+	 * 
+	 * \endcode
+	 */
+	explicit Pneumatics(std::uint8_t adi_port, 
+		bool start_extended, 
+		bool extended_is_low = false
+	);
+
+	/**
+	 * Creates a Pneumatics object for the given port pair.
+	 * 
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENXIO - The given value is not within the range of ADI Ports
+	 * 
+	 * \param port_pair
+	 *        The pair of the smart port number (from 1-22) and the
+	 *  	  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
+	 * \param start_extended
+	 * 		  If true, the pneumatic will start extended when the program starts.
+	 *		  By default, the piston starts retracted when the program starts.
+	 * \param extended_is_low
+	 * 		  A flag to set whether the the pneumatic is extended when the ADI 
+	 * 		  it receives a high or a low value. When true, the extended state
+	 * 		  corresponds to a output low on the ADI port. This allows the user 
+	 * 		  to reverse the behavior of the pneumatics if needed.
+	 * 
+	 * /b Example:
+	 * \code
+	 * void opcontrol() {
+	 * 	 pros::adi::Pneumatics left_piston({1, 'a'}, false);			// Starts retracted, extends when the ADI port is high
+	 *   pros::adi::Pneumatics right_piston({1, 'b'}, false, true);	    // Starts retracted, extends when the ADI port is low 
+	 *   
+	 *   pros::Controller master(pros::E_CONTROLLER_MASTER);
+	 * 
+	 *   while (true) {
+	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_L1)) {
+	 *       left_piston.extend();
+	 *     }
+	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_L2)) {
+	 *       left_piston.retract();
+	 *     }
+	 *     
+	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_R1)) {
+	 *       left_piston.extend();
+	 *     }
+	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_R2)) {
+	 *       left_piston.retract();
+	 *     }
+	 * 
+	 *     pros::delay(10);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	explicit Pneumatics(ext_adi_port_pair_t port_pair, 
+		bool start_extended, 
+		bool extended_is_low = false
+	);
+
+	/**
+	 * Extends the piston, if not already extended.
+	 * 
+	 * \return 1 if the piston newly extended, 0 if the piston was already
+	 *         extended, or PROS_ERR is the operation failed, setting errno. 
+	 * 
+	 * \b Example:
+	 * \code
+	 * void opcontrol() {
+	 * 	 pros::adi::Pneumatics piston({1, 'a'}, false);            // Starts retracted, extends when the ADI port is high
+	 *   
+	 *   pros::Controller master(pros::E_CONTROLLER_MASTER);
+	 * 
+	 *   while (true) {
+	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_X)) {
+	 *       left_piston.extend();
+	 *     }
+	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_B)) {
+	 *       left_piston.retract();
+	 *     }
+	 *     if(mastetr.get_digital(pros::E_CONTROLLER_DIGITAL_A)) {
+	 *       left_piston.toggle();
+	 *     }
+	 * 
+	 *     pros::delay(10);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::int32_t extend();
+
+	/**
+	 * Retracts the piston, if not already retracted.
 	 *
+	 * \return 1 if the piston newly retracted, 0 if the piston was already
+	 *         retracted, or PROS_ERR is the operation failed, setting errno. 
+	 *
+	 * \b Example:
+	 * \code
+	 * void opcontrol() {
+	 * 	 pros::adi::Pneumatics piston({1, 'a'}, false);            // Starts retracted, extends when the ADI port is high
+	 *   
+	 *   pros::Controller master(pros::E_CONTROLLER_MASTER);
+	 * 
+	 *   while (true) {
+	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_X)) {
+	 *       left_piston.extend();
+	 *     }
+	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_B)) {
+	 *       left_piston.retract();
+	 *     }
+	 *     if(mastetr.get_digital(pros::E_CONTROLLER_DIGITAL_A)) {
+	 *       left_piston.toggle();
+	 *     }
+	 * 
+	 *     pros::delay(10);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::int32_t retract();
+
+	/**
+	 * Puts the piston into the opposite state of its current state.
+	 * If it is retracted, it will extend. If it is extended, it will retract.
+	 *
+	 * \return 1 if the operation was successful or PROS_ERR if the operation
+	 * failed, setting errno.
+	 * 
+	 * \return 1 if the piston successfully toggled, or PROS_ERR if the 
+	 *         operation failed, setting errno.
+	 *
+	 *\b Example:
+	 * \code
+	 * void opcontrol() {
+	 * 	 pros::adi::Pneumatics piston({1, 'a'}, false);            // Starts retracted, extends when the ADI port is high
+	 *   
+	 *   pros::Controller master(pros::E_CONTROLLER_MASTER);
+	 * 
+	 *   while (true) {
+	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_X)) {
+	 *       left_piston.extend();
+	 *     }
+	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_B)) {
+	 *       left_piston.retract();
+	 *     }
+	 *     if(mastetr.get_digital(pros::E_CONTROLLER_DIGITAL_A)) {
+	 *       left_piston.toggle();
+	 *     }
+	 * 
+	 *     pros::delay(10);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::int32_t toggle();
+
+	/**
+	 * Returns whether the piston is extended or not. 
+	 * 
+	 * \return true if the piston is extended, false if it is retracted.
+	 * 
 	 * \b Example
 	 * \code
 	 * #define ADI_PNEUMATICS_PORT 'a'
@@ -1746,141 +1937,26 @@ class Pneumatics : public DigitalOut {
 	 * void opcontrol() {
 	 *   pros::adi::Pneumatics pneumatics (ADI_PNEUMATICS_PORT);
 	 *   while (true) {
-	 *     // Set the pneumatic solenoid to true
-	 *     pneumatics.set_value(true);
+	 *     // Check if the piston is extended
+	 *     if (pneumatics.is_extended()) {
+	 *       printf("The pneumatic is extended\n");
+	 *     }
+	 *     else {
+	 *       printf("The pneumatic is not extended\n");
+	 *     }
+	 * 
 	 *     pros::delay(10);
 	 *   }
 	 * }
 	 * \endcode
 	 */
-	explicit Pneumatics(std::uint8_t adi_port, bool start_extended);
-
-	/**
-	 * Creates a Pneumatics object for the given port.
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENXIO - The given value is not within the range of ADI Ports
-	 *
-	 * \param port_pair
-	 *        The pair of the smart port number (from 1-22) and the
-	 *  	  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
-	 * \param start_extended
-	 * 		  If true, the pneumatic will start the match extended
-	 * \param active_low
-	 *        If set to true, a value of false corresponds to the pneumatic's
-	 * 		  wire being set to high.
-	 *
-	 * \b Example
-	 * \code
-	 * #define ADI_PNEUMATICS_PORT 'a'
-	 * #define SMART_PORT 1
-	 *
-	 * void opcontrol() {
-	 *   pros::adi::Pneumatics pneumatics ({{ SMART_PORT , ADI_PNEUMATICS_PORT }});
-	 *   while (true) {
-	 *     // Set the pneumatic solenoid to true
-	 *     pneumatics.set_value(true);
-	 *     pros::delay(10);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	explicit Pneumatics(ext_adi_port_pair_t port_pair, bool start_extended);
-
-	/* 
-	* Extends the piston, if not already extended.
-	* 
-	* \return 1 if the operation was successful or PROS_ERR if the operation
-	* failed, setting errno.
-	*
-	* \b Example
-	* \code
-	* #define ADI_PNEUMATICS_PORT 'a'
-	*
-	* void opcontrol() {
-	*   pros::adi::Pneumatics pneumatics (ADI_PNEUMATICS_PORT);
-	*   while (true) {
-	*     // Extend the piston
-	*     pneumatics.extend();
-	*     pros::delay(10);
-	*   }
-	* }
-	* \endcode
-	*/
-	std::int32_t extend();
-
-	/*
-	* Retracts the piston, if not already retracted.
-	*
-	* \return 1 if the operation was successful or PROS_ERR if the operation
-	* failed, setting errno.
-	*
-	* \b Example
-	* \code
-	* #define ADI_PNEUMATICS_PORT 'a'
-	*
-	* void opcontrol() {
-	*   pros::adi::Pneumatics pneumatics (ADI_PNEUMATICS_PORT);
-	*   while (true) {
-	*     // Retract the piston
-	*     pneumatics.retract();
-	*     pros::delay(10);
-	*   }
-	* }
-	* \endcode
-	*/
-	std::int32_t retract();
-
-	/*
-	* Puts the piston into the opposite state of its current state.
-	* If it is retracted, it will extend. If it is extended, it will retract.
-	*
-	* \return 1 if the operation was successful or PROS_ERR if the operation
-	* failed, setting errno.
-	*
-	* \b Example
-	* \code
-	* #define ADI_PNEUMATICS_PORT 'a'
-	*
-	* void opcontrol() {
-	*   pros::adi::Pneumatics pneumatics (ADI_PNEUMATICS_PORT);
-	*   while (true) {
-	*     // Toggle the piston
-	*     pneumatics.toggle();
-	*     pros::delay(10);
-	*   }
-	* }
-	* \endcode
-	*/
-	std::int32_t toggle();
-
-	/*
-	* Returns the current state of the piston.
-	*
-	* \return true if the piston is extended, false if it is retracted.
-	*
-	* \b Example
-	* \code
-	* #define ADI_PNEUMATICS_PORT 'a'
-	*
-	* void opcontrol() {
-	*   pros::adi::Pneumatics pneumatics (ADI_PNEUMATICS_PORT);
-	*   while (true) {
-	*     // Check if the piston is extended
-	*     if (pneumatics.get_state()) {
-	*       // Do something
-	*     }
-	*     pros::delay(10);
-	*   }
-	* }
-	* \endcode
-	*/
-	bool get_state() const;
+	bool is_extended() const; 
 
 private: 
-	bool active_low;
-	bool state;
+	bool extended_is_low;	// A flag that sets whether extended corresponds to
+							// a low signal
+
+	bool state; 			// Holds the physical state of the ADI port
 };
 ///@}
 

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -269,23 +269,23 @@ std::int32_t Led::clear_pixel(uint32_t pixel_position) {
 	return ext_adi_led_clear_pixel((adi_led_t)merge_adi_ports(_smart_port, _adi_port), (uint32_t*)_buffer.data(), _buffer.size(), pixel_position);
 }
 
-Pneumatics::Pneumatics(std::uint8_t adi_port, bool start_extended, bool active_low) 
-: DigitalOut(adi_port), active_low(active_low), state(start_extended) {
+Pneumatics::Pneumatics(std::uint8_t adi_port, bool start_extended)
+	: DigitalOut(adi_port), state(start_extended) {
 	set_value(start_extended);
 }
 
-Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool start_extended, bool active_low) 
-: DigitalOut(port_pair), active_low(active_low), state(start_extended) {
+Pneumatics::Pneumatics(ext_adi_port_pair_t port_pair, bool start_extended) 
+	: DigitalOut(port_pair), state(start_extended) {
 	set_value(start_extended);
 }
 
 std::int32_t Pneumatics::extend() {
-	state = !active_low; 
+	state = true; 
 	return set_value(state);
 }
 
 std::int32_t Pneumatics::retract() {
-	state = !active_low;
+	state = false;
 	return set_value(state);
 }
 
@@ -295,7 +295,7 @@ std::int32_t Pneumatics::toggle() {
 }
 
 bool Pneumatics::get_state() const {
-	return active_low ? state : !state;
+	return state;
 }
 
 std::ostream& operator<<(std::ostream& os, pros::adi::Potentiometer& potentiometer) {


### PR DESCRIPTION
#### Summary:
The current design is too complex and buggy. Below is a list of identified anomalies in the Pneumatics class:

Anomaly Category:
**M**issing, **E**xtraneous, **A**mbiguous, **I**nconsistent, **W**rong (incorrect fact), **T**ypos (or editorial), **O**thers

```
Assume get_state get the physical state of the pneumatics

For P = Pneumatics(bool start_extended, bool active_low = false)

# P(false, false)
    extend() -> s = true;
    retract() -> s = true; [W1] should be false
    toggle() -> s = !s;
    get_state() -> false ? state : !state;
                                      ^used
        [W2] if extend() is used, state should be true and the function returns false
             but it is expected to return true as the physical state is true

# P(false, true)
    extend() -> s = false;
    retract() -> s = false; [W3] should be true
    toggle() -> s = !s;
    get_state() -> true ? state : !state;
                            ^used
        [W4] if extend() is used, state should be false and the function returns false
             but it is expected to return true as the physical state is true

# P(true, false)
    extend() -> s = true;
    retract() -> s = true; [W5] should be false
    toggle() -> s = !s;
    get_state() -> false ? state : !state;
                                      ^used
        [W6] if extend() is used, state should be true and the function returns false
             but it is expected to return true as the physical state is true
    
# P(true, true)
    [W7] if extend() is used, state should be false, and it is expected to extend the pneumatics physically
         start_extended is also expected to extend the pneumatics physically when the constructor is called
         but if start_extended set to true, the state also set to true 
    extend() -> s = false;
    retract() -> s = false; [W8] should be true
    toggle() -> s = !s;
    get_state() -> true ? state : !state;
                            ^used
        [W9] if extend() is used, state should be false and the function returns false
             but it is expected to return true as the physical state is true

[A10] state, get_state: is it physical state of the pneumatics or logical state of the pneumatics, what happen if active_low is set to true?
[I11] state and active_low inconsistent if two pneumatics classes defined using the same ADI port
```

To improve the current design, `active_low` has been removed and the implementation of some methods has been rewritten.

##### References (optional):
[Bug Report on the PROS Beta Testers Server](https://discord.com/channels/1025259843763847229/1029666535553384498/1071013266794479716)