### PR TITLE
🐛PROS4 Fixed spelling of reciever to receiver

### DIFF
--- a/include/pros/link.h
+++ b/include/pros/link.h
@@ -41,20 +41,20 @@ namespace pros {
  * \brief Enum for the type of link (TX or RX)
  */
 typedef enum link_type_e {
-	E_LINK_RECIEVER = 0, ///< Indicates that the radio is a reciever.
+	E_LINK_RECEIVER = 0, ///< Indicates that the radio is a receiver.
 	E_LINK_TRANSMITTER, ///< Indicates that the link is a transmitter.
-	E_LINK_RX = E_LINK_RECIEVER, ///< Alias for E_LINK_RECIEVER
+	E_LINK_RX = E_LINK_RECEIVER, ///< Alias for E_LINK_RECEIVER
 	E_LINK_TX = E_LINK_TRANSMITTER ///< Alias for E_LINK_TRANSMITTER
 } link_type_e_t;
 
 #ifdef PROS_USE_SIMPLE_NAMES
 #ifdef __cplusplus
-#define LINK_RECIEVER pros::E_LINK_RECIEVER
+#define LINK_RECEIVER pros::E_LINK_RECEIVER
 #define LINK_TRANSMITTER pros::E_LINK_TRANSMITTER
 #define LINK_RX pros::E_LINK_RX
 #define LINK_TX pros::E_LINK_TX
 #else
-#define LINK_RECIEVER E_LINK_RECIEVER
+#define LINK_RECEIVER E_LINK_RECEIVER
 #define LINK_TRANSMITTER E_LINK_TRANSMITTER
 #define LINK_RX E_LINK_RX
 #define LINK_TX E_LINK_TX
@@ -86,7 +86,7 @@ namespace c {
  *      Unique link ID in the form of a string, needs to be different from other links in
  *      the area.
  * \param type
- *      Indicates whether the radio link on the brain is a transmitter or reciever,
+ *      Indicates whether the radio link on the brain is a transmitter or receiver,
  *      with the transmitter having double the transmitting bandwidth as the recieving
  *      end (1040 bytes/s vs 520 bytes/s).
  *
@@ -122,7 +122,7 @@ uint32_t link_init(uint8_t port, const char* link_id, link_type_e_t type);
  *      Unique link ID in the form of a string, needs to be different from other links in
  *      the area.
  * \param type
- *      Indicates whether the radio link on the brain is a transmitter or reciever,
+ *      Indicates whether the radio link on the brain is a transmitter or receiver,
  *      with the transmitter having double the transmitting bandwidth as the recieving
  *      end (1040 bytes/s vs 520 bytes/s).
  *

--- a/include/pros/link.h
+++ b/include/pros/link.h
@@ -87,7 +87,7 @@ namespace c {
  *      the area.
  * \param type
  *      Indicates whether the radio link on the brain is a transmitter or receiver,
- *      with the transmitter having double the transmitting bandwidth as the recieving
+ *      with the transmitter having double the transmitting bandwidth as the receiving
  *      end (1040 bytes/s vs 520 bytes/s).
  *
  * \return PROS_ERR if initialization fails, 1 if the initialization succeeds.
@@ -123,7 +123,7 @@ uint32_t link_init(uint8_t port, const char* link_id, link_type_e_t type);
  *      the area.
  * \param type
  *      Indicates whether the radio link on the brain is a transmitter or receiver,
- *      with the transmitter having double the transmitting bandwidth as the recieving
+ *      with the transmitter having double the transmitting bandwidth as the receiving
  *      end (1040 bytes/s vs 520 bytes/s).
  *
  * \return PROS_ERR if initialization fails, 1 if the initialization succeeds.

--- a/include/pros/link.hpp
+++ b/include/pros/link.hpp
@@ -53,7 +53,7 @@ class Link : public Device {
 	 *      the area.
 	 * \param type
 	 *      Indicates whether the radio link on the brain is a transmitter or receiver,
-	 *      with the transmitter having double the transmitting bandwidth as the recieving
+	 *      with the transmitter having double the transmitting bandwidth as the receiving
 	 *      end (1040 bytes/s vs 520 bytes/s).
 	 * \param ov
 	 * 		Indicates if the radio on the given port needs vexlink to override the controller radio

--- a/include/pros/link.hpp
+++ b/include/pros/link.hpp
@@ -52,7 +52,7 @@ class Link : public Device {
 	 *      Unique link ID in the form of a string, needs to be different from other links in
 	 *      the area.
 	 * \param type
-	 *      Indicates whether the radio link on the brain is a transmitter or reciever,
+	 *      Indicates whether the radio link on the brain is a transmitter or receiver,
 	 *      with the transmitter having double the transmitting bandwidth as the recieving
 	 *      end (1040 bytes/s vs 520 bytes/s).
 	 * \param ov


### PR DESCRIPTION
#### Summary:
Fixed spelling of reciever to receiver

#### Motivation:
It was a typo

##### References (optional):
Brought up as an issue in https://github.com/purduesigbots/pros-docs/pull/334
#### Test Plan:
Compiles

