### PR TITLE
✨Negative port values for Rotation class

### DIFF
--- a/include/pros/rotation.hpp
+++ b/include/pros/rotation.hpp
@@ -56,26 +56,6 @@ class Rotation : public Device {
 	explicit Rotation(const std::int8_t port) : Device(port, DeviceType::rotation) {};
 
 	/**
-	 * Constructs a new Rotation Sensor object
-	 * 
-	 * ENXIO - The given value is not within the range of V5 ports |1-21|.
- 	 * ENODEV - The port cannot be configured as a Rotation Sensor
-	 * 
-	 * \param port
- 	 *        The V5 port number from 1 to 21, or from -21 to -1 for reversed Rotation Sensors. 
-	 * \param reverse_flag
-	 * 		  Determines if the Rotation Sensor is reversed or not.
-	 * 		  
-	 * 	\b Example
- 	 * \code
- 	 * void opcontrol() {
-	 * 	 pros::Rotation rotation_sensor(1, true); //Creates a reversed Rotation Sensor on port 1 
-	 * }
- 	 * \endcode
-	*/
-	explicit Rotation(const std::int8_t port, const bool reverse_flag);
-
-	/**
 	 * Reset the Rotation Sensor
 	 *
 	 * Reset the current absolute position to be the same as the

--- a/include/pros/rotation.hpp
+++ b/include/pros/rotation.hpp
@@ -53,7 +53,7 @@ class Rotation : public Device {
  	 * }
  	 * \endcode
 	*/
-	explicit Rotation(const std::int8_t port) : Device(port, DeviceType::rotation) {};
+	explicit Rotation(const std::int8_t port);
 
 	/**
 	 * Reset the Rotation Sensor

--- a/include/pros/rotation.hpp
+++ b/include/pros/rotation.hpp
@@ -53,7 +53,7 @@ class Rotation : public Device {
  	 * }
  	 * \endcode
 	*/
-	explicit Rotation(const std::uint8_t port) : Device(port, DeviceType::rotation) {};
+	explicit Rotation(const std::int8_t port) : Device(port, DeviceType::rotation) {};
 
 	/**
 	 * Constructs a new Rotation Sensor object
@@ -73,7 +73,7 @@ class Rotation : public Device {
 	 * }
  	 * \endcode
 	*/
-	explicit Rotation(const std::uint8_t port, const bool reverse_flag);
+	explicit Rotation(const std::int8_t port, const bool reverse_flag);
 
 	/**
 	 * Reset the Rotation Sensor

--- a/src/devices/vdml_rotation.cpp
+++ b/src/devices/vdml_rotation.cpp
@@ -16,8 +16,12 @@
 namespace pros {
 inline namespace v5 {
     
-Rotation::Rotation(const std::uint8_t port, const bool reverse_flag) : Device(port, DeviceType::rotation) {
-	pros::c::rotation_set_reversed(port, reverse_flag);
+Rotation::Rotation(const std::int8_t port, const bool reverse_flag) : Device(port, DeviceType::rotation) {
+    if (port < 0) {
+        pros::c::rotation_set_reversed(Math.abs(port), true);
+    } else {
+        pros::c::rotation_set_reversed(port, reverse_flag);
+    }
 }
 
 std::int32_t Rotation::reset() {

--- a/src/devices/vdml_rotation.cpp
+++ b/src/devices/vdml_rotation.cpp
@@ -16,11 +16,11 @@
 namespace pros {
 inline namespace v5 {
     
-Rotation::Rotation(const std::int8_t port, const bool reverse_flag) : Device(port, DeviceType::rotation) {
+Rotation::Rotation(const std::int8_t port) : Device(port, DeviceType::rotation) {
     if (port < 0) {
         pros::c::rotation_set_reversed(abs(port), true);
     } else {
-        pros::c::rotation_set_reversed(port, reverse_flag);
+        pros::c::rotation_set_reversed(port, false);
     }
 }
 

--- a/src/devices/vdml_rotation.cpp
+++ b/src/devices/vdml_rotation.cpp
@@ -18,7 +18,7 @@ inline namespace v5 {
     
 Rotation::Rotation(const std::int8_t port, const bool reverse_flag) : Device(port, DeviceType::rotation) {
     if (port < 0) {
-        pros::c::rotation_set_reversed(Math.abs(port), true);
+        pros::c::rotation_set_reversed(abs(port), true);
     } else {
         pros::c::rotation_set_reversed(port, reverse_flag);
     }


### PR DESCRIPTION
#### Summary:
Changed unsigned port parameter in Rotation constructor to signed
Allow for negative port values to reverse their positive port

#### Motivation:
Generalize negative port = reverse functionality for more classes

##### References:
#588

#### Test Plan:
Ensure rotation sensor is reversed when a negative port is input, regardless of reverse_flag value. 
