### PR TITLE
Update default index of get_target_position in motor groups

### DIFF
--- a/include/pros/motor_group.hpp
+++ b/include/pros/motor_group.hpp
@@ -442,7 +442,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * }
 	 * \endcode
 	 */
-	double get_target_position(const std::uint8_t index) const;
+	double get_target_position(const std::uint8_t index = 0) const;
 
 	/**
 	 * Gets a vector of the the target positions set for the motor group


### PR DESCRIPTION
#### Summary:
Motor Groups method get_target_velocity() does not have a default index of 0. You should be able to provide no arguments to get_target_velocity() and have it return the target velocity of the first motor in the list (motor @ index 0). 

#### Motivation:
Every other similar motor group method has the default index set to 0.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
Manually Tested
