### PR TITLE
Update Doxygen group definition for motor groups

### DIFF
--- a/include/pros/motor_group.hpp
+++ b/include/pros/motor_group.hpp
@@ -16,8 +16,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * \defgroup cpp-motor-group Motors C++ API
- * \note Additional example code for this module can be found in its [Tutorial](@ref motors).
+ * \defgroup cpp-motor-group Motor Groups C++ API
  */
 
 #ifndef _PROS_MOTOR_GROUP_HPP_


### PR DESCRIPTION
#### Summary:
The C++ API docs for Motor Groups say "Motors C++ API module" at the top, when it should be "Motor Groups C++ API module"

#### Motivation:
Correct the typo

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
N/A
