### PR TITLE
🐛Motor and motor group bug fixes

### DIFF
--- a/src/devices/vdml_motorgroup.cpp
+++ b/src/devices/vdml_motorgroup.cpp
@@ -31,7 +31,7 @@ using namespace pros::c;
 #define empty_MotorGroup_check_vector(error, vector) \
 	if (_ports.size() <= 0) {                          \
 		errno = EDOM;                                    \
-		vector.emplace_back(error);                      \
+		vector.push_back(error);                      \
 		return vector;                                   \
 	}
 
@@ -137,7 +137,7 @@ std::vector<double> MotorGroup::get_actual_velocity_all(void) const {
 	empty_MotorGroup_check_vector(PROS_ERR_F, return_vector);
 
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_get_actual_velocity(*it));
+		return_vector.push_back(motor_get_actual_velocity(*it));
 	}
 	return return_vector;
 }
@@ -154,7 +154,7 @@ std::vector<pros::v5::MotorBrake> MotorGroup::get_brake_mode_all(void) const {
 	empty_MotorGroup_check_vector(pros::v5::MotorBrake::invalid, return_vector);
 
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(static_cast<pros::v5::MotorBrake>(motor_get_brake_mode(*it)));
+		return_vector.push_back(static_cast<pros::v5::MotorBrake>(motor_get_brake_mode(*it)));
 	}
 	return return_vector;
 }
@@ -170,7 +170,7 @@ std::vector<std::int32_t> MotorGroup::get_current_draw_all(void) const {
 	empty_MotorGroup_check_vector(PROS_ERR, return_vector);
 
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_get_current_draw(*it));
+		return_vector.push_back(motor_get_current_draw(*it));
 	}
 	return return_vector;
 }
@@ -187,7 +187,7 @@ std::vector<std::int32_t> MotorGroup::get_current_limit_all(void) const {
 	empty_MotorGroup_check_vector(PROS_ERR, return_vector);
 
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_get_current_limit(*it));
+		return_vector.push_back(motor_get_current_limit(*it));
 	}
 	return return_vector;
 }
@@ -202,7 +202,7 @@ std::vector<std::int32_t> MotorGroup::is_over_current_all(void) const {
 	std::vector<std::int32_t> return_vector;
 	empty_MotorGroup_check_vector(PROS_ERR, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_is_over_current(*it));
+		return_vector.push_back(motor_is_over_current(*it));
 	}
 	return return_vector;
 }
@@ -210,14 +210,18 @@ std::vector<std::int32_t> MotorGroup::is_over_current_all(void) const {
 std::int32_t MotorGroup::get_direction(const std::uint8_t index) const {
 	empty_MotorGroup_check(PROS_ERR);
 	MotorGroup_index_check(PROS_ERR, index);
-	return motor_get_direction(_ports[index]);
+	int ret = motor_get_direction(_ports[index]);
+	ret = _ports[index] >= 0 ? ret : ret * -1;
+	return ret;
 }
 
 std::vector<std::int32_t> MotorGroup::get_direction_all(void) const {
 	std::vector<std::int32_t> return_vector;
 	empty_MotorGroup_check_vector(PROS_ERR, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_get_direction(*it));
+		int ret = motor_get_direction(*it);
+		ret = *it >= 0 ? ret : ret * -1;
+		return_vector.push_back(ret);
 	}
 	return return_vector;
 }
@@ -232,7 +236,7 @@ std::vector<double> MotorGroup::get_efficiency_all(void) const {
 	std::vector<double> return_vector;
 	empty_MotorGroup_check_vector(PROS_ERR_F, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_get_efficiency(*it));
+		return_vector.push_back(motor_get_efficiency(*it));
 	}
 	return return_vector;
 }
@@ -247,7 +251,7 @@ std::vector<pros::v5::MotorUnits> MotorGroup::get_encoder_units_all(void) const 
 	std::vector<pros::v5::MotorUnits> return_vector;
 	empty_MotorGroup_check_vector(pros::v5::MotorUnits::invalid, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(static_cast<pros::v5::MotorUnits>(motor_get_encoder_units(*it)));
+		return_vector.push_back(static_cast<pros::v5::MotorUnits>(motor_get_encoder_units(*it)));
 	}
 	return return_vector;
 }
@@ -262,7 +266,7 @@ std::vector<std::uint32_t> MotorGroup::get_faults_all(void) const {
 	std::vector<std::uint32_t> return_vector;
 	empty_MotorGroup_check_vector(PROS_ERR, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_get_faults(*it));
+		return_vector.push_back(motor_get_faults(*it));
 	}
 	return return_vector;
 }
@@ -277,7 +281,7 @@ std::vector<std::uint32_t> MotorGroup::get_flags_all(void) const {
 	std::vector<std::uint32_t> return_vector;
 	empty_MotorGroup_check_vector(PROS_ERR, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_get_flags(*it));
+		return_vector.push_back(motor_get_flags(*it));
 	}
 	return return_vector;
 }
@@ -292,7 +296,7 @@ std::vector<pros::v5::MotorGears> MotorGroup::get_gearing_all(void) const {
 	std::vector<pros::v5::MotorGears> return_vector;
 	empty_MotorGroup_check_vector(pros::v5::MotorGears::invalid, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(static_cast<pros::v5::MotorGears>(motor_get_gearing(*it)));
+		return_vector.push_back(static_cast<pros::v5::MotorGears>(motor_get_gearing(*it)));
 	}
 	return return_vector;
 }
@@ -307,7 +311,7 @@ std::vector<std::int32_t> MotorGroup::get_raw_position_all(std::uint32_t* const 
 	std::vector<std::int32_t> return_vector;
 	empty_MotorGroup_check_vector(PROS_ERR, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_get_raw_position(*it, timestamp));
+		return_vector.push_back(motor_get_raw_position(*it, timestamp));
 	}
 	return return_vector;
 }
@@ -322,7 +326,7 @@ std::vector<std::int32_t> MotorGroup::is_over_temp_all(void) const {
 	std::vector<std::int32_t> return_vector;
 	empty_MotorGroup_check_vector(PROS_ERR, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_is_over_temp(*it));
+		return_vector.push_back(motor_is_over_temp(*it));
 	}
 	return return_vector;
 }
@@ -337,7 +341,7 @@ std::vector<double> MotorGroup::get_position_all(void) const {
 	std::vector<double> return_vector;
 	empty_MotorGroup_check_vector(PROS_ERR_F, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_get_position(*it));
+		return_vector.push_back(motor_get_position(*it));
 	}
 	return return_vector;
 }
@@ -352,7 +356,7 @@ std::vector<double> MotorGroup::get_power_all(void) const {
 	std::vector<double> return_vector;
 	empty_MotorGroup_check_vector(PROS_ERR_F, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_get_power(*it));
+		return_vector.push_back(motor_get_power(*it));
 	}
 	return return_vector;
 }
@@ -367,7 +371,7 @@ std::vector<std::int32_t> MotorGroup::is_reversed_all(void) const {
 	std::vector<std::int32_t> return_vector;
 	empty_MotorGroup_check_vector(PROS_ERR, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_is_reversed(*it));
+		return_vector.push_back(motor_is_reversed(*it));
 	}
 	return return_vector;
 }
@@ -382,7 +386,7 @@ std::vector<double> MotorGroup::get_temperature_all(void) const {
 	std::vector<double> return_vector;
 	empty_MotorGroup_check_vector(PROS_ERR_F, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_get_temperature(*it));
+		return_vector.push_back(motor_get_temperature(*it));
 	}
 	return return_vector;
 }
@@ -397,7 +401,7 @@ std::vector<double> MotorGroup::get_target_position_all(void) const {
 	std::vector<double> return_vector;
 	empty_MotorGroup_check_vector(PROS_ERR_F, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_get_target_position(*it));
+		return_vector.push_back(motor_get_target_position(*it));
 	}
 	return return_vector;
 }
@@ -412,7 +416,7 @@ std::vector<double> MotorGroup::get_torque_all(void) const {
 	std::vector<double> return_vector;
 	empty_MotorGroup_check_vector(PROS_ERR_F, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_get_torque(*it));
+		return_vector.push_back(motor_get_torque(*it));
 	}
 	return return_vector;
 }
@@ -427,7 +431,7 @@ std::vector<std::int32_t> MotorGroup::get_target_velocity_all(void) const {
 	std::vector<std::int32_t> return_vector;
 	empty_MotorGroup_check_vector(PROS_ERR, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_get_target_velocity(*it));
+		return_vector.push_back(motor_get_target_velocity(*it));
 	}
 	return return_vector;
 }
@@ -441,7 +445,7 @@ std::vector<std::int32_t> MotorGroup::get_voltage_all(void) const {
 	std::vector<std::int32_t> return_vector;
 	empty_MotorGroup_check_vector(PROS_ERR, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_get_voltage(*it));
+		return_vector.push_back(motor_get_voltage(*it));
 	}
 	return return_vector;
 }
@@ -456,7 +460,7 @@ std::vector<std::int32_t> MotorGroup::get_voltage_limit_all(void) const {
 	std::vector<std::int32_t> return_vector;
 	empty_MotorGroup_check_vector(PROS_ERR, return_vector);
 	for (auto it = _ports.begin(); it < _ports.end(); it++) {
-		return_vector.emplace_back(motor_get_voltage_limit(*it));
+		return_vector.push_back(motor_get_voltage_limit(*it));
 	}
 	return return_vector;
 }
@@ -488,9 +492,6 @@ std::int32_t MotorGroup::tare_position_all(void) const {
 std::int32_t MotorGroup::set_brake_mode(const pros::motor_brake_mode_e_t mode, const std::uint8_t index) const {
 	empty_MotorGroup_check(PROS_ERR);
 	MotorGroup_index_check(PROS_ERR, index);
-	for (auto it = _ports.begin() + 1; it < _ports.end(); it++) {
-		motor_set_brake_mode(*it, mode);
-	}
 	return motor_set_brake_mode(_ports[index], mode);
 }
 
@@ -552,10 +553,7 @@ std::int32_t MotorGroup::set_encoder_units(const pros::motor_encoder_units_e_t u
 std::int32_t MotorGroup::set_encoder_units(const pros::v5::MotorUnits units, const std::uint8_t index) const {
 	empty_MotorGroup_check(PROS_ERR);
 	MotorGroup_index_check(PROS_ERR, index);
-	for (auto it = _ports.begin() + 1; it < _ports.end(); it++) {
-		motor_set_encoder_units(*it, static_cast<motor_encoder_units_e_t>(units));
-	}
-	return motor_set_encoder_units(_ports[0], static_cast<motor_encoder_units_e_t>(units));
+	return motor_set_encoder_units(_ports[index], static_cast<motor_encoder_units_e_t>(units));
 }
 
 std::int32_t MotorGroup::set_gearing(const motor_gearset_e_t gearset, const std::uint8_t index) const {
@@ -640,7 +638,7 @@ std::int8_t MotorGroup::size() const {
 
 void MotorGroup::operator+=(MotorGroup& other) {
 	for (auto it = other._ports.begin(); it < other._ports.end(); it++) {
-		_ports.emplace_back(*it);
+		_ports.push_back(*it);
 	}
 }
 

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -70,7 +70,7 @@ double Motor::get_actual_velocity(const std::uint8_t index) const {
 }
 std::vector<double> Motor::get_actual_velocity_all(void) const {
 	std::vector<double> return_vector;
-	return_vector.emplace_back(motor_get_actual_velocity(_port));
+	return_vector.push_back(motor_get_actual_velocity(_port));
 	return return_vector;
 }
 
@@ -84,7 +84,7 @@ pros::v5::MotorBrake Motor::get_brake_mode(const std::uint8_t index) const {
 
 std::vector<pros::v5::MotorBrake> Motor::get_brake_mode_all() const {
 	std::vector<pros::v5::MotorBrake> return_vector;
-	return_vector.emplace_back(static_cast<pros::v5::MotorBrake>(motor_get_brake_mode(_port)));
+	return_vector.push_back(static_cast<pros::v5::MotorBrake>(motor_get_brake_mode(_port)));
 	return return_vector;
 }
 
@@ -97,7 +97,7 @@ std::int32_t Motor::get_current_draw(const std::uint8_t index) const {
 }
 std::vector<std::int32_t> Motor::get_current_draw_all(void) const {
 	std::vector<std::int32_t> return_vector;
-	return_vector.emplace_back(motor_get_current_draw(_port));
+	return_vector.push_back(motor_get_current_draw(_port));
 	return return_vector;
 }
 std::int32_t Motor::get_current_limit(const std::uint8_t index) const {
@@ -109,7 +109,7 @@ std::int32_t Motor::get_current_limit(const std::uint8_t index) const {
 }
 std::vector<std::int32_t> Motor::get_current_limit_all(void) const {
 	std::vector<std::int32_t> return_vector;
-	return_vector.emplace_back(motor_get_current_limit(_port));
+	return_vector.push_back(motor_get_current_limit(_port));
 	return return_vector;
 }
 
@@ -123,7 +123,7 @@ std::int32_t Motor::is_over_current(const std::uint8_t index) const {
 
 std::vector<std::int32_t> Motor::is_over_current_all(void) const {
 	std::vector<std::int32_t> return_vector;
-	return_vector.emplace_back(motor_is_over_current(_port));
+	return_vector.push_back(motor_is_over_current(_port));
 
 	return return_vector;
 }
@@ -133,11 +133,15 @@ std::int32_t Motor::get_direction(const std::uint8_t index) const {
 		errno = EOVERFLOW;
 		return PROS_ERR;
 	}
-	return motor_get_direction(_port);
+	int ret = motor_get_direction(_port);
+	ret = _port >= 0 ? ret : ret * -1;
+	return ret;
 }
 std::vector<std::int32_t> Motor::get_direction_all(void) const {
 	std::vector<std::int32_t> return_vector;
-	return_vector.emplace_back(motor_get_direction(_port));
+	int ret = motor_get_direction(_port);
+	ret = _port >= 0 ? ret : ret * -1;
+	return_vector.push_back(ret);
 	return return_vector;
 }
 
@@ -150,7 +154,7 @@ double Motor::get_efficiency(const std::uint8_t index) const {
 }
 std::vector<double> Motor::get_efficiency_all(void) const {
 	std::vector<double> return_vector;
-	return_vector.emplace_back(motor_get_efficiency(_port));
+	return_vector.push_back(motor_get_efficiency(_port));
 	return return_vector;
 }
 
@@ -164,7 +168,7 @@ pros::v5::MotorUnits Motor::get_encoder_units(const std::uint8_t index) const {
 
 std::vector<pros::v5::MotorUnits> Motor::get_encoder_units_all(void) const {
 	std::vector<pros::v5::MotorUnits> return_vector;
-	return_vector.emplace_back(static_cast<pros::v5::MotorUnits>(motor_get_encoder_units(_port)));
+	return_vector.push_back(static_cast<pros::v5::MotorUnits>(motor_get_encoder_units(_port)));
 	return return_vector;
 }
 
@@ -178,7 +182,7 @@ std::uint32_t Motor::get_faults(const std::uint8_t index) const {
 
 std::vector<std::uint32_t> Motor::get_faults_all(void) const {
 	std::vector<std::uint32_t> return_vector;
-	return_vector.emplace_back(motor_get_faults(_port));
+	return_vector.push_back(motor_get_faults(_port));
 	return return_vector;
 }
 
@@ -192,7 +196,7 @@ std::uint32_t Motor::get_flags(const std::uint8_t index) const {
 
 std::vector<std::uint32_t> Motor::get_flags_all(void) const {
 	std::vector<std::uint32_t> return_vector;
-	return_vector.emplace_back(motor_get_flags(_port));
+	return_vector.push_back(motor_get_flags(_port));
 	return return_vector;
 }
 
@@ -205,7 +209,7 @@ pros::v5::MotorGears Motor::get_gearing(const std::uint8_t index) const {
 }
 std::vector<pros::v5::MotorGears> Motor::get_gearing_all(void) const {
 	std::vector<pros::v5::MotorGears> return_vector;
-	return_vector.emplace_back(static_cast<pros::v5::MotorGears>(motor_get_gearing(_port)));
+	return_vector.push_back(static_cast<pros::v5::MotorGears>(motor_get_gearing(_port)));
 	return return_vector;
 }
 
@@ -219,7 +223,7 @@ std::int32_t Motor::get_raw_position(std::uint32_t* const timestamp, std::uint8_
 
 std::vector<std::int32_t> Motor::get_raw_position_all(std::uint32_t* const timestamp) const {
 	std::vector<std::int32_t> return_vector;
-	return_vector.emplace_back(motor_get_raw_position(_port, timestamp));
+	return_vector.push_back(motor_get_raw_position(_port, timestamp));
 	return return_vector;
 }
 
@@ -233,7 +237,7 @@ std::int32_t Motor::is_over_temp(const std::uint8_t index) const {
 
 std::vector<std::int32_t> Motor::is_over_temp_all(void) const {
 	std::vector<std::int32_t> return_vector;
-	return_vector.emplace_back(motor_is_over_temp(_port));
+	return_vector.push_back(motor_is_over_temp(_port));
 	return return_vector;
 }
 
@@ -246,7 +250,7 @@ double Motor::get_position(const std::uint8_t index) const {
 }
 std::vector<double> Motor::get_position_all(void) const {
 	std::vector<double> return_vector;
-	return_vector.emplace_back(motor_get_position(_port));
+	return_vector.push_back(motor_get_position(_port));
 	return return_vector;
 }
 
@@ -260,7 +264,7 @@ double Motor::get_power(const std::uint8_t index) const {
 
 std::vector<double> Motor::get_power_all(void) const {
 	std::vector<double> return_vector;
-	return_vector.emplace_back(motor_get_power(_port));
+	return_vector.push_back(motor_get_power(_port));
 	return return_vector;
 }
 
@@ -273,7 +277,7 @@ std::int32_t Motor::is_reversed(const std::uint8_t index) const {
 }
 std::vector<std::int32_t> Motor::is_reversed_all(void) const {
 	std::vector<std::int32_t> return_vector;
-	return_vector.emplace_back(_port < 0);
+	return_vector.push_back(_port < 0);
 	return return_vector;
 }
 
@@ -287,7 +291,7 @@ double Motor::get_temperature(const std::uint8_t index) const {
 
 std::vector<double> Motor::get_temperature_all(void) const {
 	std::vector<double> return_vector;
-	return_vector.emplace_back(motor_get_temperature(_port));
+	return_vector.push_back(motor_get_temperature(_port));
 	return return_vector;
 }
 
@@ -301,7 +305,7 @@ double Motor::get_target_position(const std::uint8_t index) const {
 
 std::vector<double> Motor::get_target_position_all(void) const {
 	std::vector<double> return_vector;
-	return_vector.emplace_back(motor_get_target_position(_port));
+	return_vector.push_back(motor_get_target_position(_port));
 	return return_vector;
 }
 
@@ -314,7 +318,7 @@ double Motor::get_torque(const std::uint8_t index) const {
 }
 std::vector<double> Motor::get_torque_all(void) const {
 	std::vector<double> return_vector;
-	return_vector.emplace_back(motor_get_torque(_port));
+	return_vector.push_back(motor_get_torque(_port));
 	return return_vector;
 }
 std::int32_t Motor::get_target_velocity(const std::uint8_t index) const {
@@ -326,7 +330,7 @@ std::int32_t Motor::get_target_velocity(const std::uint8_t index) const {
 }
 std::vector<std::int32_t> Motor::get_target_velocity_all(void) const {
 	std::vector<std::int32_t> return_vector;
-	return_vector.emplace_back(motor_get_target_velocity(_port));
+	return_vector.push_back(motor_get_target_velocity(_port));
 	return return_vector;
 }
 
@@ -339,7 +343,7 @@ std::int32_t Motor::get_voltage(const std::uint8_t index) const {
 }
 std::vector<std::int32_t> Motor::get_voltage_all(void) const {
 	std::vector<std::int32_t> return_vector;
-	return_vector.emplace_back(motor_get_voltage(_port));
+	return_vector.push_back(motor_get_voltage(_port));
 	return return_vector;
 }
 
@@ -352,7 +356,7 @@ std::int32_t Motor::get_voltage_limit(const std::uint8_t index) const {
 }
 std::vector<std::int32_t> Motor::get_voltage_limit_all(void) const {
 	std::vector<std::int32_t> return_vector;
-	return_vector.emplace_back(motor_get_voltage_limit(_port));
+	return_vector.push_back(motor_get_voltage_limit(_port));
 	return return_vector;
 }
 std::int8_t Motor::get_port(const std::uint8_t index) const {
@@ -365,7 +369,7 @@ std::int8_t Motor::get_port(const std::uint8_t index) const {
 
 std::vector<std::int8_t> Motor::get_port_all(void) const {
 	std::vector<std::int8_t> return_vector;
-	return_vector.emplace_back(_port);
+	return_vector.push_back(_port);
 	return return_vector;
 }
 


### PR DESCRIPTION
#### Summary:
Fixed bug with motor get_direction and negative ports
migrate emplace_back to push back
fixed some bugs with some configuration setters

#### Motivation:
Reasoning for changing emplace back to push back is that this seems like the correct way to do it when we already have objects of the type that the vectors want. 



#### Test Plan:
manually tested return values for get direction, get_direction_all for both motors and motor groups with positive and negative directions
