### PR TITLE
📝Moved function definitions for _all functions in motors to their own …

### DIFF
--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -400,29 +400,6 @@ class Motor : public AbstractMotor, public Device {
 	double get_target_position(const std::uint8_t index = 0) const;
 
 	/**
-	 * Gets a vector containing the target position set for the motor by the user
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 *
-	 * \return A vector containing the target position in its encoder units or PROS_ERR_F if the
-	 * operation failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void autonomous() {
-	 *   pros::Motor motor (1);
-	 *   motor.move_absolute(100, 100);
-	 *   std::cout << "Motor Target: " << motor.get_target_position_all()[0];
-	 *   // Prints 100
-	 * }
-	 * \endcode
-	 */
-	std::vector<double> get_target_position_all(void) const;
-
-	/**
 	 * Gets the velocity commanded to the motor by the user at the index specified.
 	 *
 	 * \note This is one of many Motor functions that takes in an optional index parameter. 
@@ -456,32 +433,6 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	std::int32_t get_target_velocity(const std::uint8_t index = 0) const;
-
-	/**
-	 * Gets a vector containing the velocity commanded to the motor by the user
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \return A vector containing the commanded motor velocity from +-100, 
-	 * +-200, or +-600, or PROS_ERR if the operation failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     motor.move_velocity(master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y));
-	 *     std::cout << "Motor Velocity: " << motor.get_target_velocity_all()[0];
-	 *     // Prints the value of E_CONTROLLER_ANALOG_LEFT_Y
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::vector<std::int32_t> get_target_velocity_all(void) const;
 
 	///@}
 
@@ -522,33 +473,6 @@ class Motor : public AbstractMotor, public Device {
 	 */
 	double get_actual_velocity(const std::uint8_t index = 0) const;
 
-
-	/**
-	 * Gets a vector containing the actual velocity commanded of the motor
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \return A vector containing the motor's actual velocity in RPM or PROS_ERR_F
-	 * if the operation failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     motor.move_velocity(master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y));
-	 *     std::cout << "Motor Velocity: " << motor.get_actual_velocity_all()[0];
-	 *     // Prints the value of E_CONTROLLER_ANALOG_LEFT_Y
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */	
-	std::vector<double> get_actual_velocity_all(void) const;
-
 	/**
 	 * Gets the current drawn by the motor in mA.
 	 * 
@@ -585,34 +509,6 @@ class Motor : public AbstractMotor, public Device {
 	 */
 	std::int32_t get_current_draw(const std::uint8_t index = 0) const;
 
-
-	/**
-	 * Gets a vector containing the current drawn by the motor in mA.
-	 * 
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * 
-	 * ENODEV - The port cannot be configured as a motor
-	 * 
-	 * 
-	 * \return A vector conatining the motor's current in mA or PROS_ERR if the operation failed,
-	 * setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *     std::cout << "Motor Current Draw: " << motor.get_current_draw_all()[0];
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::vector<std::int32_t> get_current_draw_all(void) const;
-
 	/**
 	 * Gets the direction of movement for the motor.
 	 *
@@ -648,34 +544,6 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	std::int32_t get_direction(const std::uint8_t index = 0) const;
-
-	/**
-	 * Gets a vector containing the direction of movement for the motor.
-	 *
-	 * 
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * 
-	 * ENODEV - The port cannot be configured as a motor
-	 * 
-	 * 
-	 * \return A vecotr containing 1 for moving in the positive direction, -1 for moving in the
-	 * negative direction, and PROS_ERR if the operation failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *     std::cout << "Motor Direction: " << motor.get_direction_all()[0];
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::vector<std::int32_t> get_direction_all(void) const;
 
 	/**
 	 * Gets the efficiency of the motor in percent.
@@ -719,37 +587,6 @@ class Motor : public AbstractMotor, public Device {
 	double get_efficiency(const std::uint8_t index = 0) const;
 
 	/**
-	 * Gets a vector containing the efficiency of the motor in percent.
-	 *
-	 * An efficiency of 100% means that the motor is moving electrically while
-	 * drawing no electrical power, and an efficiency of 0% means that the motor
-	 * is drawing power but not moving.
-	 * 
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * 
-	 * ENODEV - The port cannot be configured as a motor
-	 * 
-	 *
-	 * \return A vector containing The motor's efficiency in percent or PROS_ERR_F if the operation
-	 * failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *     std::cout << "Motor Efficiency: " << motor.get_efficiency();
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::vector<double> get_efficiency_all(void) const;
-
-	/**
 	 * Gets the faults experienced by the motor.
 	 *
 	 * Compare this bitfield to the bitmasks in pros::motor_fault_e_t.
@@ -785,33 +622,6 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	std::uint32_t get_faults(const std::uint8_t index = 0) const;
-
-	/**
-	 * Gets a vector of the faults experienced by the motor.
-	 *
-	 * Compare this bitfield to the bitmasks in pros::motor_fault_e_t.
-	 * 
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * 
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \return A bitfield containing the motor's faults.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *     std::cout << "Motor Faults: " << motor.get_faults_all()[0];
-	 * 	   pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::vector<std::uint32_t> get_faults_all(void) const;
 	
 	/**
 	 * Gets the flags set by the motor's operation.
@@ -851,34 +661,6 @@ class Motor : public AbstractMotor, public Device {
 	std::uint32_t get_flags(const std::uint8_t index = 0) const;
 
 	/**
-	 * Gets a vector of the flags set by the motor's operation.
-	 *
-	 * Compare this bitfield to the bitmasks in pros::motor_flag_e_t.
-	 * 
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * 
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 *
-	 * \return A bitfield containing the motor's flags.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *     std::cout << "Motor Faults: " << motor.get_faults_all()[0];
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::vector<std::uint32_t> get_flags_all(void) const;
-
-	/**
 	 * Gets the absolute position of the motor in its encoder units.
 	 *
 	 * \note This is one of many Motor functions that takes in an optional index parameter. 
@@ -915,33 +697,6 @@ class Motor : public AbstractMotor, public Device {
 	double get_position(const std::uint8_t index = 0) const;
 
 	/**
-	 * Gets a vector containing the absolute position of the motor in its encoder units.
-	 * 
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * 
-	 * ENODEV - The port cannot be configured as a motor
-	 
-	 *
-	 * \return A vector containing the motor's absolute position in its encoder units or PROS_ERR_F
-	 * if the operation failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *     std::cout << "Motor Position: " << motor.get_position_all()[0];
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::vector<double> get_position_all(void) const;
-
-	/**
 	 * Gets the power drawn by the motor in Watts.
 	 *
 	 * \note This is one of many Motor functions that takes in an optional index parameter. 
@@ -976,32 +731,6 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	double get_power(const std::uint8_t index = 0) const;
-
-	/**
-	 * Gets a vector containing the power drawn by the motor in Watts.
-	 * 
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * 
-	 * ENODEV - The port cannot be configured as a motor
-	 * 
-	 * \return A vector containing the motor's power draw in Watts or PROS_ERR_F if the operation
-	 * failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *     std::cout << "Motor Power: " << motor.get_power_all()[0];
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::vector<double> get_power_all(void) const;
 
 	/**
 	 * Gets the raw encoder count of the motor at a given timestamp.
@@ -1047,38 +776,6 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	std::int32_t get_raw_position(std::uint32_t* const timestamp, const std::uint8_t index = 0) const;
-	/**
-	 * Gets a vector of the raw encoder count of the motor at a given timestamp.
-	 *
-	 * 
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * 
-	 * ENODEV - The port cannot be configured as a motor
-	 * 
-	 * \param timestamp
-	 *            A pointer to a time in milliseconds for which the encoder count
-	 *            will be returned. If NULL, the timestamp at which the encoder
-	 *            count was read will not be supplied
-	 * 
-	 * \return A vector containing the raw encoder count at the given timestamp or PROS_ERR if the
-	 * operation failed.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   std::uint32_t now = pros::millis();
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *     std::cout << "Motor Position: " << motor.get_raw_position(&now);
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::vector<std::int32_t> get_raw_position_all(std::uint32_t* const timestamp) const;
 
 	/**
 	 * Gets the temperature of the motor in degrees Celsius.
@@ -1115,31 +812,6 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	double get_temperature(const std::uint8_t index = 0) const;
-	
-	/**
-	 * Gets a vector of the temperature of the motor in degrees Celsius.
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \return A vector contaioning the motor's temperature in degrees Celsius 
-	 * or PROS_ERR_F if the operation failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *     std::cout << "Motor Temperature: " << motor.get_temperature_all()[0];
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::vector<double> get_temperature_all(void) const;
 
 	/**
 	 * Gets the torque generated by the motor in Newton Meters (Nm).
@@ -1178,31 +850,6 @@ class Motor : public AbstractMotor, public Device {
 	double get_torque(const std::uint8_t index = 0) const;
 
 	/**
-	 * Gets a vector of the torque generated by the motor in Newton Meters (Nm).
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 * 
-	 * \return A vector containing the motor's torque in Nm or PROS_ERR_F if the operation failed,
-	 * setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *     std::cout << "Motor Torque: " << motor.get_torque();
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::vector<double> get_torque_all(void) const;
-	
-	/**
 	 * Gets the voltage delivered to the motor in millivolts.
 	 *
 	 * \note This is one of many Motor functions that takes in an optional index parameter. 
@@ -1237,32 +884,6 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	std::int32_t get_voltage(const std::uint8_t index = 0) const;
-
-	/**
-	 * Gets a vector of the voltage delivered to the motor in millivolts.
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 * 
-	 *
-	 * \return A vector of the motor's voltage in mV or PROS_ERR_F if the operation failed,
-	 * setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *     std::cout << "Motor Voltage: " << motor.get_voltage_all()[0];
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::vector<std::int32_t> get_voltage_all(void) const;
 
 	/**
 	 * Checks if the motor is drawing over its current limit.
@@ -1302,32 +923,6 @@ class Motor : public AbstractMotor, public Device {
 	std::int32_t is_over_current(const std::uint8_t index = 0) const;
 
 	/**
-	 * Checks if the motor is drawing over its current limit.
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \return A vector containing 1 if the motor's current limit is being exceeded and 0 if the
-	 * current limit is not exceeded, or PROS_ERR if the operation failed, setting
-	 * errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *     std::cout << "Is the motor over its current limit?: " << motor.is_over_current_all()[0];
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::vector<std::int32_t> is_over_current_all(void) const;
-
-	/**
 	 * Gets the temperature limit flag for the motor.
 	 *
 	 * \note This is one of many Motor functions that takes in an optional index parameter. 
@@ -1362,31 +957,6 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	std::int32_t is_over_temp(const std::uint8_t index = 0) const;
-	
-	/**
-	 * Gets the temperature limit flag for the motor.
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor 
-	 * 
-	 * \return A vector containing 1 if the temperature limit is exceeded and 0 if the temperature is
-	 * below the limit, or PROS_ERR if the operation failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *     std::cout << "Is the motor over its temperature limit?: " << motor.is_over_temp_all();
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::vector<std::int32_t> is_over_temp_all(void) const;
 
 	///@}
 
@@ -1425,27 +995,6 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	MotorBrake get_brake_mode(const std::uint8_t index = 0) const;
-	
-	/**
-	 * Gets a vector containing the brake mode that was set for the motor.
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \return One of Motor_Brake, according to what was set for the
-	 * motor, or E_MOTOR_BRAKE_INVALID if the operation failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void initialize() {
-	 *   pros::Motor motor (1);
-	 *   motor.set_brake_mode(pros::E_MOTOR_BRAKE_HOLD);
-	 *   std::cout << "Brake Mode: " << motor.get_brake_mode();
-	 * }
-	 * \endcode
-	 */
-	std::vector<MotorBrake> get_brake_mode_all(void) const;
 
 	/**
 	 * Gets the current limit for the motor in mA.
@@ -1482,31 +1031,6 @@ class Motor : public AbstractMotor, public Device {
 	std::int32_t get_current_limit(const std::uint8_t index = 0) const;
 	
 	/**
-	 * Gets a vector containing the current limit for the motor in mA.
-	 *
-	 * The default value is 2500 mA.
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \return A vector containing the motor's current limit in mA or PROS_ERR if the operation failed,
-	 * setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1);
-	 *   while (true) {
-	 *     std::cout << "Motor Current Limit: " << motor.get_current_limit_all()[0];
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::vector<std::int32_t> get_current_limit_all(void) const;
-
-	/**
 	 * Gets the encoder units that were set for the motor.
 	 *
 	 * \note This is one of many Motor functions that takes in an optional index parameter. 
@@ -1538,26 +1062,6 @@ class Motor : public AbstractMotor, public Device {
 	MotorUnits get_encoder_units(const std::uint8_t index = 0) const;
 
 	/**
-	 * Gets a vector containing the encoder units that were set for the motor.
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \return A vector containing One of Motor_Units according to what is set for the
-	 * motor or E_MOTOR_ENCODER_INVALID if the operation failed.
-	 *
-	 * \b Example
-	 * \code
-	 * void initialize() {
-	 *   pros::Motor motor (1, E_MOTOR_GEARSET_06, E_MOTOR_ENCODER_COUNTS);
-	 *   std::cout << "Motor Encoder Units: " << motor.get_encoder_units_all()[0];
-	 * }
-	 * \endcode
-	 */
-	std::vector<MotorUnits> get_encoder_units_all(void) const;
-
-	/**
 	 * Gets the gearset that was set for the motor.
 	 *
 	 * \note This is one of many Motor functions that takes in an optional index parameter. 
@@ -1587,33 +1091,6 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	MotorGears get_gearing(const std::uint8_t index = 0) const;
-	
-	/**
-	 * Gets a vector containing the gearset that was set for the motor.
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \return A vector containing one of Motor_Gears according to what is set for the motor,
-	 * or pros::Motor_Gears::invalid if the operation failed.
-	 *
-	 * \b Example
-	 * \code
-	 * void initialize() {
-	 *   pros::Motor motor (1, E_MOTOR_GEARSET_06, E_MOTOR_ENCODER_COUNTS);
-	 *   std::cout << "Motor Gearing: " << motor.get_gearing_all()[0];
-	 * }
-	 * \endcode
-	 */
-	std::vector<MotorGears> get_gearing_all(void) const;
-
-	/**
-	 * Gets returns a vector with all the port numbers in the motor group.
-	 *
-	 * \return A vector containing the signed port of the motor. (negaitve if the motor is reversed) 
-	 */
-	std::vector<std::int8_t> get_port_all(void) const;
 
 	/**
 	 * Gets the voltage limit set by the user.
@@ -1645,29 +1122,6 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	std::int32_t get_voltage_limit(const std::uint8_t index = 0) const;
-	
-	/**
-	 * Gets a vector of the voltage limit set by the user.
-	 *
-	 * Default value is 0V, which means that there is no software limitation
-	 * imposed on the voltage.
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \return A vector containing the motor's voltage limit in V or PROS_ERR if the operation failed,
-	 * setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void initialize() {
-	 *   pros::Motor motor (1);
-	 *   std::cout << "Motor Voltage Limit: " << motor.get_voltage_limit_all()[0];
-	 * }
-	 * \endcode
-	 */
-	std::vector<std::int32_t> get_voltage_limit_all(void) const;
 
 	/**
 	 * Gets whether the motor is reversed or not
@@ -1700,23 +1154,6 @@ class Motor : public AbstractMotor, public Device {
 	std::int32_t is_reversed(const std::uint8_t index = 0) const;
 
 	/**
-	 * Gets a vector containg whether the motor is reversed or not
-	 *
-	 * \return A vector containing 1 if the motor has been reversed and 0 if the motor was not
-	 * reversed, or PROS_ERR if the operation failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void initialize() {
-	 *   pros::Motor motor (1);
-	 *   std::cout << "Is the motor reversed? " << motor.is_reversed_all()[0];
-	 *   // Prints "0"
-	 * }
-	 * \endcode
-	 */
-	std::vector<std::int32_t> is_reversed_all(void) const;
-
-	/**
 	 * Sets one of Motor_Brake to the motor.
 	 * \note This is one of many Motor functions that takes in an optional index parameter. 
 	 * 		 This parameter can be ignored by most users but exists to give a shared base class
@@ -1744,7 +1181,7 @@ class Motor : public AbstractMotor, public Device {
 	 * \code
 	 * void initialize() {
 	 *   pros::Motor motor (1);
-	 *   motor.set_brake_mode_all(pros::E_MOTOR_BRAKE_HOLD);
+	 *   motor.set_brake_mode(pros::E_MOTOR_BRAKE_HOLD);
 	 *   std::cout << "Brake Mode: " << motor.get_brake_mode();
 	 * }
 	 * \endcode
@@ -1778,59 +1215,13 @@ class Motor : public AbstractMotor, public Device {
 	 * \code
 	 * void initialize() {
 	 *   pros::Motor motor (1);
-	 *   motor.set_brake_mode_all(pros::E_MOTOR_BRAKE_HOLD);
+	 *   motor.set_brake_mode(pros::E_MOTOR_BRAKE_HOLD);
 	 *   std::cout << "Brake Mode: " << motor.get_brake_mode();
 	 * }
 	 * \endcode
 	 */
 	std::int32_t set_brake_mode(const pros::motor_brake_mode_e_t mode, const std::uint8_t index = 0) const;
-	
-	/**
-	 * Sets one of Motor_Brake to the motor. 
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \param mode
-	 *        The Motor_Brake to set for the motor
-	 *
-	 * \return 1 if the operation was successful or PROS_ERR if the operation
-	 * failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void initialize() {
-	 *   pros::Motor motor (1);
-	 *   motor.set_brake_mode_all(pros::E_MOTOR_BRAKE_HOLD);
-	 *   std::cout << "Brake Mode: " << motor.get_brake_mode();
-	 * }
-	 * \endcode
-	 */
-	std::int32_t set_brake_mode_all(const MotorBrake mode) const;
-	/**
-	 * Sets one of Motor_Brake to the motor. 
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \param mode
-	 *        The Motor_Brake to set for the motor
-	 *
-	 * \return 1 if the operation was successful or PROS_ERR if the operation
-	 * failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void initialize() {
-	 *   pros::Motor motor (1);
-	 *   motor.set_brake_mode_all(pros::E_MOTOR_BRAKE_HOLD);
-	 *   std::cout << "Brake Mode: " << motor.get_brake_mode();
-	 * }
-	 * \endcode
-	 */
-	std::int32_t set_brake_mode_all(const pros::motor_brake_mode_e_t mode) const;
+
 	/**
 	 * Sets the current limit for the motor in mA.
 	 *
@@ -1871,35 +1262,7 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	std::int32_t set_current_limit(const std::int32_t limit, const std::uint8_t index = 0) const;
-	/**
-	 * Sets the current limit for the motor in mA.
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \param limit
-	 *        The new current limit in mA
-	 *
-	 * \return 1 if the operation was successful or PROS_ERR if the operation
-	 * failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *
-	 * motor.set_current_limit(1000);
-	 * while (true) {
-	 *   motor = controller_get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *   // The motor will reduce its output at 1000 mA instead of the default 2500 mA
-	 *   pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::int32_t set_current_limit_all(const std::int32_t limit) const;
+
 	/**
 	 * Sets one of Motor_Units for the motor encoder. Works with the C
 	 * enum and the C++ enum class.
@@ -1959,67 +1322,7 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	std::int32_t set_encoder_units(const pros::motor_encoder_units_e_t units, const std::uint8_t index = 0) const;
-	/**
-	 * Sets one of Motor_Units for the motor encoder. Works with the C
-	 * enum and the C++ enum class.
-	 *
-	 * \note This is one of many Motor functions that takes in an optional index parameter. 
-	 * 		 This parameter can be ignored by most users but exists to give a shared base class
-	 * 		 for motors and motor groups
-	 * 
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * 
-	 * ENODEV - The port cannot be configured as a motor
-	 * 
-	 * EOVERFLOW - The index is non 0
-	 * 
-	 * * \param units
-	 *        The new motor encoder units
-	 * 
-	 * \param index Optional parameter. 
-	 * 		  The zero-indexed index of the motor to get the target position of.
-	 * 		  By default index is 0, and will return an error for a non-zero index
-	 *
-	 * \return 1 if the operation was successful or PROS_ERR if the operation
-	 * failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void initialize() {
-	 *   pros::Motor motor (1);
-	 *   motor.set_encoder_units(E_MOTOR_ENCODER_DEGREES);
-	 *   std::cout << "Encoder Units: " << motor.get_encoder_units();
-	 * }
-	 * \endcode
-	 */
-	std::int32_t set_encoder_units_all(const MotorUnits units) const;
-	
-	/**
-	 * Sets one of Motor_Units for the motor encoder. Works with the C
-	 * enum and the C++ enum class.
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \param units
-	 *        The new motor encoder units
-	 *
-	 * \return 1 if the operation was successful or PROS_ERR if the operation
-	 * failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void initialize() {
-	 *   pros::Motor motor (1);
-	 *   motor.set_encoder_units(E_MOTOR_ENCODER_DEGREES);
-	 *   std::cout << "Encoder Units: " << motor.get_encoder_units();
-	 * }
-	 * \endcode
-	 */
-	std::int32_t set_encoder_units_all(const pros::motor_encoder_units_e_t units) const;
-	
+
 	/**
 	 * Sets one of the gear cartridge (red, green, blue) for the motor. Usable with
 	 * the C++ enum class and the C enum.
@@ -2091,7 +1394,873 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	std::int32_t set_gearing(const pros::motor_gearset_e_t gearset, const std::uint8_t index = 0) const;
+
+	/**
+	 * Sets the reverse flag for the motor.
+	 *
+	 * This will invert its movements and the values returned for its position.
+	 *
+	 * \note This is one of many Motor functions that takes in an optional index parameter. 
+	 * 		 This parameter can be ignored by most users but exists to give a shared base class
+	 * 		 for motors and motor groups
+	 * 
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * 
+	 * EOVERFLOW - The index is non 0
+	 * 
+	 * \param reverse
+	 *        True reverses the motor, false is default direction
+	 * 
+	 * \param index Optional parameter. 
+	 * 		  The zero-indexed index of the motor to get the target position of.
+	 * 		  By default index is 0, and will return an error for a non-zero index
+	 *
+	 * \return 1 if the operation was successful or PROS_ERR if the operation
+	 * failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void initialize() {
+	 *   pros::Motor motor (1);
+	 *   motor.set_reversed(true);
+	 *   std::cout << "Is this motor reversed? " << motor.is_reversed();
+	 * }
+	 * \endcode
+	 */
+	std::int32_t set_reversed(const bool reverse, const std::uint8_t index = 0);
+
+	/**
+	 * Sets the voltage limit for the motor in Volts.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 * \param limit
+	 *        The new voltage limit in Volts
+	 *
+	 * \return 1 if the operation was successful or PROS_ERR if the operation
+	 * failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void autonomous() {
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *
+	 *   motor.set_voltage_limit(10000);
+	 *   while (true) {
+	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
+	 *     // The motor will not output more than 10 V
+	 *     pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::int32_t set_voltage_limit(const std::int32_t limit, const std::uint8_t index = 0) const;
+
+	/**
+	 * Sets the position for the motor in its encoder units.
+	 *
+	 * This will be the future reference point for the motor's "absolute"
+	 * position.
+	 *
+	 * \note This is one of many Motor functions that takes in an optional index parameter. 
+	 * 		 This parameter can be ignored by most users but exists to give a shared base class
+	 * 		 for motors and motor groups
+	 * 
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * 
+	 * ENODEV - The port cannot be configured as a motor
+	 * 
+	 * EOVERFLOW - The index is non 0
+	 * 
+	 * \param position
+	 *        The new reference position in its encoder units
+	 * 
+	 * \param index Optional parameter. 
+	 * 		  The zero-indexed index of the motor to get the target position of.
+	 * 		  By default index is 0, and will return an error for a non-zero index
+	 * 
+	 * 
+	 * \return 1 if the operation was successful or PROS_ERR if the operation
+	 * failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void autonomous() {
+	 *   pros::Motor motor (1);
+	 *   motor.move_absolute(100, 100); // Moves 100 units forward
+	 *   motor.move_absolute(100, 100); // This does not cause a movement
+	 *
+	 *   motor.set_zero_position(80);
+	 *   motor.move_absolute(100, 100); // Moves 80 units forward
+	 * }
+	 * \endcode
+	 *
+	 */
+	std::int32_t set_zero_position(const double position, const std::uint8_t index = 0) const;
+
+	/**
+	 * Sets the "absolute" zero position of the motor to its current position.
+	 *
+	 * \note This is one of many Motor functions that takes in an optional index parameter. 
+	 * 		 This parameter can be ignored by most users but exists to give a shared base class
+	 * 		 for motors and motor groups
+	 * 
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * 
+	 * ENODEV - The port cannot be configured as a motor
+	 * 
+	 * EOVERFLOW - The index is non 0
+	 * 
+	 * \param index Optional parameter. 
+	 * 		  The zero-indexed index of the motor to get the target position of.
+	 * 		  By default index is 0, and will return an error for a non-zero index
+	 * 
+	 * \return 1 if the operation was successful or PROS_ERR if the operation
+	 * failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void autonomous() {
+	 *   pros::Motor motor (1);
+	 *   motor.move_absolute(100, 100); // Moves 100 units forward
+	 *   motor.move_absolute(100, 100); // This does not cause a movement
+	 *
+	 *   motor.tare_position();
+	 *   motor.move_absolute(100, 100); // Moves 100 units forward
+	 * }
+	 * \endcode
+	 */
+	std::int32_t tare_position(const std::uint8_t index = 0) const;
+
+	/**
+	 * Gets the number of motors.
+	 * 
+	 * \return Always returns 1
+	 *  
+	 */
+	std::int8_t size(void) const;
+
+	/**
+	 * gets the port number of the motor
+	 *
+	 * \return A vector containing the signed port of the motor. (negative if the motor is reversed) 
+	 * 
+	*/
+	std::int8_t get_port(const std::uint8_t index = 0) const;
+
+	///@}
+
+	/// \name Additional motor functions
+	/// These functions allow for motors and motor groups to be used interchangeably
+	///@{
+	/**
+	 * Gets a vector containing the target position set for the motor by the user
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 *
+	 * \return A vector containing the target position in its encoder units or PROS_ERR_F if the
+	 * operation failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void autonomous() {
+	 *   pros::Motor motor (1);
+	 *   motor.move_absolute(100, 100);
+	 *   std::cout << "Motor Target: " << motor.get_target_position_all()[0];
+	 *   // Prints 100
+	 * }
+	 * \endcode
+	 */
+	std::vector<double> get_target_position_all(void) const;
+
+	/**
+	 * Gets a vector containing the velocity commanded to the motor by the user
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 * \return A vector containing the commanded motor velocity from +-100, 
+	 * +-200, or +-600, or PROS_ERR if the operation failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *   while (true) {
+	 *     motor.move_velocity(master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y));
+	 *     std::cout << "Motor Velocity: " << motor.get_target_velocity_all()[0];
+	 *     // Prints the value of E_CONTROLLER_ANALOG_LEFT_Y
+	 *     pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::vector<std::int32_t> get_target_velocity_all(void) const;
+
+	/**
+	 * Gets a vector containing the actual velocity commanded of the motor
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 * \return A vector containing the motor's actual velocity in RPM or PROS_ERR_F
+	 * if the operation failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *   while (true) {
+	 *     motor.move_velocity(master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y));
+	 *     std::cout << "Motor Velocity: " << motor.get_actual_velocity_all()[0];
+	 *     // Prints the value of E_CONTROLLER_ANALOG_LEFT_Y
+	 *     pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */	
+	std::vector<double> get_actual_velocity_all(void) const;
+
+	/**
+	 * Gets a vector containing the current drawn by the motor in mA.
+	 * 
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * 
+	 * ENODEV - The port cannot be configured as a motor
+	 * 
+	 * 
+	 * \return A vector containing the motor's current in mA or PROS_ERR if the operation failed,
+	 * setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *   while (true) {
+	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
+	 *     std::cout << "Motor Current Draw: " << motor.get_current_draw_all()[0];
+	 *     pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::vector<std::int32_t> get_current_draw_all(void) const;
+
+	/**
+	 * Gets a vector containing the direction of movement for the motor.
+	 *
+	 * 
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * 
+	 * ENODEV - The port cannot be configured as a motor
+	 * 
+	 * 
+	 * \return A vecotr containing 1 for moving in the positive direction, -1 for moving in the
+	 * negative direction, and PROS_ERR if the operation failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *   while (true) {
+	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
+	 *     std::cout << "Motor Direction: " << motor.get_direction_all()[0];
+	 *     pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::vector<std::int32_t> get_direction_all(void) const;
+
+	/**
+	 * Gets a vector containing the efficiency of the motor in percent.
+	 *
+	 * An efficiency of 100% means that the motor is moving electrically while
+	 * drawing no electrical power, and an efficiency of 0% means that the motor
+	 * is drawing power but not moving.
+	 * 
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * 
+	 * ENODEV - The port cannot be configured as a motor
+	 * 
+	 *
+	 * \return A vector containing The motor's efficiency in percent or PROS_ERR_F if the operation
+	 * failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *   while (true) {
+	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
+	 *     std::cout << "Motor Efficiency: " << motor.get_efficiency();
+	 *     pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::vector<double> get_efficiency_all(void) const;
 	
+	/**
+	 * Gets a vector of the faults experienced by the motor.
+	 *
+	 * Compare this bitfield to the bitmasks in pros::motor_fault_e_t.
+	 * 
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * 
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 * \return A bitfield containing the motor's faults.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *   while (true) {
+	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
+	 *     std::cout << "Motor Faults: " << motor.get_faults_all()[0];
+	 * 	   pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::vector<std::uint32_t> get_faults_all(void) const;
+
+	/**
+	 * Gets a vector of the flags set by the motor's operation.
+	 *
+	 * Compare this bitfield to the bitmasks in pros::motor_flag_e_t.
+	 * 
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * 
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 *
+	 * \return A bitfield containing the motor's flags.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *   while (true) {
+	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
+	 *     std::cout << "Motor Faults: " << motor.get_faults_all()[0];
+	 *     pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::vector<std::uint32_t> get_flags_all(void) const;
+	
+	/**
+	 * Gets a vector containing the absolute position of the motor in its encoder units.
+	 * 
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * 
+	 * ENODEV - The port cannot be configured as a motor
+	 
+	 *
+	 * \return A vector containing the motor's absolute position in its encoder units or PROS_ERR_F
+	 * if the operation failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *   while (true) {
+	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
+	 *     std::cout << "Motor Position: " << motor.get_position_all()[0];
+	 *     pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::vector<double> get_position_all(void) const;
+
+	/**
+	 * Gets a vector containing the power drawn by the motor in Watts.
+	 * 
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * 
+	 * ENODEV - The port cannot be configured as a motor
+	 * 
+	 * \return A vector containing the motor's power draw in Watts or PROS_ERR_F if the operation
+	 * failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *   while (true) {
+	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
+	 *     std::cout << "Motor Power: " << motor.get_power_all()[0];
+	 *     pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::vector<double> get_power_all(void) const;
+	
+	/**
+	 * Gets a vector of the raw encoder count of the motor at a given timestamp.
+	 *
+	 * 
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * 
+	 * ENODEV - The port cannot be configured as a motor
+	 * 
+	 * \param timestamp
+	 *            A pointer to a time in milliseconds for which the encoder count
+	 *            will be returned. If NULL, the timestamp at which the encoder
+	 *            count was read will not be supplied
+	 * 
+	 * \return A vector containing the raw encoder count at the given timestamp or PROS_ERR if the
+	 * operation failed.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   std::uint32_t now = pros::millis();
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *   while (true) {
+	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
+	 *     std::cout << "Motor Position: " << motor.get_raw_position(&now);
+	 *     pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::vector<std::int32_t> get_raw_position_all(std::uint32_t* const timestamp) const;
+	
+	/**
+	 * Gets a vector of the temperature of the motor in degrees Celsius.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 * \return A vector contaioning the motor's temperature in degrees Celsius 
+	 * or PROS_ERR_F if the operation failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *   while (true) {
+	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
+	 *     std::cout << "Motor Temperature: " << motor.get_temperature_all()[0];
+	 *     pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::vector<double> get_temperature_all(void) const;
+
+	/**
+	 * Gets a vector of the torque generated by the motor in Newton Meters (Nm).
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 * 
+	 * \return A vector containing the motor's torque in Nm or PROS_ERR_F if the operation failed,
+	 * setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *   while (true) {
+	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
+	 *     std::cout << "Motor Torque: " << motor.get_torque();
+	 *     pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::vector<double> get_torque_all(void) const;
+	
+	/**
+	 * Gets a vector of the voltage delivered to the motor in millivolts.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 * 
+	 *
+	 * \return A vector of the motor's voltage in mV or PROS_ERR_F if the operation failed,
+	 * setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *   while (true) {
+	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
+	 *     std::cout << "Motor Voltage: " << motor.get_voltage_all()[0];
+	 *     pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::vector<std::int32_t> get_voltage_all(void) const;
+
+	/**
+	 * Checks if the motor is drawing over its current limit.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 * \return A vector containing 1 if the motor's current limit is being exceeded and 0 if the
+	 * current limit is not exceeded, or PROS_ERR if the operation failed, setting
+	 * errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *   while (true) {
+	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
+	 *     std::cout << "Is the motor over its current limit?: " << motor.is_over_current_all()[0];
+	 *     pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::vector<std::int32_t> is_over_current_all(void) const;
+	
+	/**
+	 * Gets the temperature limit flag for the motor.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor 
+	 * 
+	 * \return A vector containing 1 if the temperature limit is exceeded and 0 if the temperature is
+	 * below the limit, or PROS_ERR if the operation failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *   while (true) {
+	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
+	 *     std::cout << "Is the motor over its temperature limit?: " << motor.is_over_temp_all();
+	 *     pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::vector<std::int32_t> is_over_temp_all(void) const;
+	
+	/**
+	 * Gets a vector containing the brake mode that was set for the motor.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 * \return One of Motor_Brake, according to what was set for the
+	 * motor, or E_MOTOR_BRAKE_INVALID if the operation failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void initialize() {
+	 *   pros::Motor motor (1);
+	 *   motor.set_brake_mode(pros::E_MOTOR_BRAKE_HOLD);
+	 *   std::cout << "Brake Mode: " << motor.get_brake_mode();
+	 * }
+	 * \endcode
+	 */
+	std::vector<MotorBrake> get_brake_mode_all(void) const;
+	
+	/**
+	 * Gets a vector containing the current limit for the motor in mA.
+	 *
+	 * The default value is 2500 mA.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 * \return A vector containing the motor's current limit in mA or PROS_ERR if the operation failed,
+	 * setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor (1);
+	 *   while (true) {
+	 *     std::cout << "Motor Current Limit: " << motor.get_current_limit_all()[0];
+	 *     pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::vector<std::int32_t> get_current_limit_all(void) const;
+
+	/**
+	 * Gets a vector containing the encoder units that were set for the motor.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 * \return A vector containing One of Motor_Units according to what is set for the
+	 * motor or E_MOTOR_ENCODER_INVALID if the operation failed.
+	 *
+	 * \b Example
+	 * \code
+	 * void initialize() {
+	 *   pros::Motor motor (1, E_MOTOR_GEARSET_06, E_MOTOR_ENCODER_COUNTS);
+	 *   std::cout << "Motor Encoder Units: " << motor.get_encoder_units_all()[0];
+	 * }
+	 * \endcode
+	 */
+	std::vector<MotorUnits> get_encoder_units_all(void) const;
+	
+	/**
+	 * Gets a vector containing the gearset that was set for the motor.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 * \return A vector containing one of Motor_Gears according to what is set for the motor,
+	 * or pros::Motor_Gears::invalid if the operation failed.
+	 *
+	 * \b Example
+	 * \code
+	 * void initialize() {
+	 *   pros::Motor motor (1, E_MOTOR_GEARSET_06, E_MOTOR_ENCODER_COUNTS);
+	 *   std::cout << "Motor Gearing: " << motor.get_gearing_all()[0];
+	 * }
+	 * \endcode
+	 */
+	std::vector<MotorGears> get_gearing_all(void) const;
+
+	/**
+	 * Gets returns a vector with all the port numbers in the motor group.
+	 *
+	 * \return A vector containing the signed port of the motor. (negative if the motor is reversed) 
+	 */
+	std::vector<std::int8_t> get_port_all(void) const;
+	
+	/**
+	 * Gets a vector of the voltage limit set by the user.
+	 *
+	 * Default value is 0V, which means that there is no software limitation
+	 * imposed on the voltage.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 * \return A vector containing the motor's voltage limit in V or PROS_ERR if the operation failed,
+	 * setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void initialize() {
+	 *   pros::Motor motor (1);
+	 *   std::cout << "Motor Voltage Limit: " << motor.get_voltage_limit_all()[0];
+	 * }
+	 * \endcode
+	 */
+	std::vector<std::int32_t> get_voltage_limit_all(void) const;
+
+	/**
+	 * Gets a vector containg whether the motor is reversed or not
+	 *
+	 * \return A vector containing 1 if the motor has been reversed and 0 if the motor was not
+	 * reversed, or PROS_ERR if the operation failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void initialize() {
+	 *   pros::Motor motor (1);
+	 *   std::cout << "Is the motor reversed? " << motor.is_reversed_all()[0];
+	 *   // Prints "0"
+	 * }
+	 * \endcode
+	 */
+	std::vector<std::int32_t> is_reversed_all(void) const;
+	
+	/**
+	 * Sets one of Motor_Brake to the motor. 
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 * \param mode
+	 *        The Motor_Brake to set for the motor
+	 *
+	 * \return 1 if the operation was successful or PROS_ERR if the operation
+	 * failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void initialize() {
+	 *   pros::Motor motor (1);
+	 *   motor.set_brake_mode_all(pros::E_MOTOR_BRAKE_HOLD);
+	 *   std::cout << "Brake Mode: " << motor.get_brake_mode();
+	 * }
+	 * \endcode
+	 */
+	std::int32_t set_brake_mode_all(const MotorBrake mode) const;
+	
+	/**
+	 * Sets one of Motor_Brake to the motor. 
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 * \param mode
+	 *        The Motor_Brake to set for the motor
+	 *
+	 * \return 1 if the operation was successful or PROS_ERR if the operation
+	 * failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void initialize() {
+	 *   pros::Motor motor (1);
+	 *   motor.set_brake_mode_all(pros::E_MOTOR_BRAKE_HOLD);
+	 *   std::cout << "Brake Mode: " << motor.get_brake_mode();
+	 * }
+	 * \endcode
+	 */
+	std::int32_t set_brake_mode_all(const pros::motor_brake_mode_e_t mode) const;
+
+	/**
+	 * Sets the current limit for the motor in mA.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 * \param limit
+	 *        The new current limit in mA
+	 *
+	 * \return 1 if the operation was successful or PROS_ERR if the operation
+	 * failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void opcontrol() {
+	 *   pros::Motor motor (1);
+	 *   pros::Controller master (E_CONTROLLER_MASTER);
+	 *
+	 * motor.set_current_limit_all(1000);
+	 * while (true) {
+	 *   motor = controller_get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
+	 *   // The motor will reduce its output at 1000 mA instead of the default 2500 mA
+	 *   pros::delay(2);
+	 *   }
+	 * }
+	 * \endcode
+	 */
+	std::int32_t set_current_limit_all(const std::int32_t limit) const;
+
+	/**
+	 * Sets one of Motor_Units for the motor encoder. Works with the C
+	 * enum and the C++ enum class.
+	 *
+	 * \note This is one of many Motor functions that takes in an optional index parameter. 
+	 * 		 This parameter can be ignored by most users but exists to give a shared base class
+	 * 		 for motors and motor groups
+	 * 
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * 
+	 * ENODEV - The port cannot be configured as a motor
+	 * 
+	 * EOVERFLOW - The index is non 0
+	 * 
+	 * * \param units
+	 *        The new motor encoder units
+	 * 
+	 * \param index Optional parameter. 
+	 * 		  The zero-indexed index of the motor to get the target position of.
+	 * 		  By default index is 0, and will return an error for a non-zero index
+	 *
+	 * \return 1 if the operation was successful or PROS_ERR if the operation
+	 * failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void initialize() {
+	 *   pros::Motor motor (1);
+	 *   motor.set_encoder_units_all(E_MOTOR_ENCODER_DEGREES);
+	 *   std::cout << "Encoder Units: " << motor.get_encoder_units();
+	 * }
+	 * \endcode
+	 */
+	std::int32_t set_encoder_units_all(const MotorUnits units) const;
+	
+	/**
+	 * Sets one of Motor_Units for the motor encoder. Works with the C
+	 * enum and the C++ enum class.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENODEV - The port cannot be configured as a motor
+	 *
+	 * \param units
+	 *        The new motor encoder units
+	 *
+	 * \return 1 if the operation was successful or PROS_ERR if the operation
+	 * failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 * void initialize() {
+	 *   pros::Motor motor (1);
+	 *   motor.set_encoder_units_all(E_MOTOR_ENCODER_DEGREES);
+	 *   std::cout << "Encoder Units: " << motor.get_encoder_units();
+	 * }
+	 * \endcode
+	 */
+	std::int32_t set_encoder_units_all(const pros::motor_encoder_units_e_t units) const;
+	
+		
 	/**
 	 * Sets one of the gear cartridge (red, green, blue) for the motor. Usable with
 	 * the C++ enum class and the C enum.
@@ -2141,42 +2310,7 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	std::int32_t set_gearing_all(const pros::motor_gearset_e_t gearset) const;
-
-
-	/**
-	 * Sets the reverse flag for the motor.
-	 *
-	 * This will invert its movements and the values returned for its position.
-	 *
-	 * \note This is one of many Motor functions that takes in an optional index parameter. 
-	 * 		 This parameter can be ignored by most users but exists to give a shared base class
-	 * 		 for motors and motor groups
-	 * 
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * 
-	 * EOVERFLOW - The index is non 0
-	 * 
-	 * \param reverse
-	 *        True reverses the motor, false is default direction
-	 * 
-	 * \param index Optional parameter. 
-	 * 		  The zero-indexed index of the motor to get the target position of.
-	 * 		  By default index is 0, and will return an error for a non-zero index
-	 *
-	 * \return 1 if the operation was successful or PROS_ERR if the operation
-	 * failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void initialize() {
-	 *   pros::Motor motor (1);
-	 *   motor.set_reversed(true);
-	 *   std::cout << "Is this motor reversed? " << motor.is_reversed();
-	 * }
-	 * \endcode
-	 */
-	std::int32_t set_reversed(const bool reverse, const std::uint8_t index = 0);
+	
 	/**
 	 * Sets the reverse flag for the motor.
 	 *
@@ -2198,36 +2332,6 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	std::int32_t set_reversed_all(const bool reverse);
-
-	/**
-	 * Sets the voltage limit for the motor in Volts.
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \param limit
-	 *        The new voltage limit in Volts
-	 *
-	 * \return 1 if the operation was successful or PROS_ERR if the operation
-	 * failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void autonomous() {
-	 *   pros::Motor motor (1);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *
-	 *   motor.set_voltage_limit(10000);
-	 *   while (true) {
-	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *     // The motor will not output more than 10 V
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::int32_t set_voltage_limit(const std::int32_t limit, const std::uint8_t index = 0) const;
 	
 	/**
 	 * Sets the voltage limit for the motor in Volts.
@@ -2269,49 +2373,6 @@ class Motor : public AbstractMotor, public Device {
 	 * \endcode
 	 */
 	std::int32_t set_voltage_limit_all(const std::int32_t limit) const;
-
-	/**
-	 * Sets the position for the motor in its encoder units.
-	 *
-	 * This will be the future reference point for the motor's "absolute"
-	 * position.
-	 *
-	 * \note This is one of many Motor functions that takes in an optional index parameter. 
-	 * 		 This parameter can be ignored by most users but exists to give a shared base class
-	 * 		 for motors and motor groups
-	 * 
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * 
-	 * ENODEV - The port cannot be configured as a motor
-	 * 
-	 * EOVERFLOW - The index is non 0
-	 * 
-	 * \param position
-	 *        The new reference position in its encoder units
-	 * 
-	 * \param index Optional parameter. 
-	 * 		  The zero-indexed index of the motor to get the target position of.
-	 * 		  By default index is 0, and will return an error for a non-zero index
-	 * 
-	 * 
-	 * \return 1 if the operation was successful or PROS_ERR if the operation
-	 * failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void autonomous() {
-	 *   pros::Motor motor (1);
-	 *   motor.move_absolute(100, 100); // Moves 100 units forward
-	 *   motor.move_absolute(100, 100); // This does not cause a movement
-	 *
-	 *   motor.set_zero_position(80);
-	 *   motor.move_absolute(100, 100); // Moves 80 units forward
-	 * }
-	 * \endcode
-	 *
-	 */
-	std::int32_t set_zero_position(const double position, const std::uint8_t index = 0) const;
 	
 	/**
 	 * Sets the position for the motor in its encoder units.
@@ -2347,41 +2408,6 @@ class Motor : public AbstractMotor, public Device {
 	/**
 	 * Sets the "absolute" zero position of the motor to its current position.
 	 *
-	 * \note This is one of many Motor functions that takes in an optional index parameter. 
-	 * 		 This parameter can be ignored by most users but exists to give a shared base class
-	 * 		 for motors and motor groups
-	 * 
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * 
-	 * ENODEV - The port cannot be configured as a motor
-	 * 
-	 * EOVERFLOW - The index is non 0
-	 * 
-	 * \param index Optional parameter. 
-	 * 		  The zero-indexed index of the motor to get the target position of.
-	 * 		  By default index is 0, and will return an error for a non-zero index
-	 * 
-	 * \return 1 if the operation was successful or PROS_ERR if the operation
-	 * failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void autonomous() {
-	 *   pros::Motor motor (1);
-	 *   motor.move_absolute(100, 100); // Moves 100 units forward
-	 *   motor.move_absolute(100, 100); // This does not cause a movement
-	 *
-	 *   motor.tare_position();
-	 *   motor.move_absolute(100, 100); // Moves 100 units forward
-	 * }
-	 * \endcode
-	 */
-	std::int32_t tare_position(const std::uint8_t index = 0) const;
-	
-	/**
-	 * Sets the "absolute" zero position of the motor to its current position.
-	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
@@ -2403,21 +2429,7 @@ class Motor : public AbstractMotor, public Device {
 	 */
 	std::int32_t tare_position_all(void) const;
 
-	/**
-	 * Gets the number of motors.
-	 * 
-	 * \return Always returns 1
-	 *  
-	 */
-	std::int8_t size(void) const;
-
-	/**
-	 * gets the port number of the motor
-	 *
-	 * \return A vector containing the signed port of the motor. (negaitve if the motor is reversed) 
-	 * 
-	*/
-	std::int8_t get_port(const std::uint8_t index = 0) const;
+	///@}
 
 	private:
 	std::int8_t _port;

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -1549,7 +1549,7 @@ class Motor : public AbstractMotor, public Device {
 	/**
 	 * gets the port number of the motor
 	 *
-	 * \return A vector containing the signed port of the motor. (negative if the motor is reversed) 
+	 * \return The signed port of the motor. (negative if the motor is reversed) 
 	 * 
 	*/
 	std::int8_t get_port(const std::uint8_t index = 0) const;


### PR DESCRIPTION
…category

#### Summary:
Moved function definitions for _all functions to the bottom of the file into their own category in doxygen

Also made a couple of typo corrections

#### Motivation:
Clean up documentation and move  *_all function definitions to their own category since they're less commonly used on standalone motors.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
N/A
