### PR TITLE
Fix motor groups not properly setting motor gearing/encoder units

### DIFF
--- a/src/devices/vdml_motorgroup.cpp
+++ b/src/devices/vdml_motorgroup.cpp
@@ -43,16 +43,16 @@ MotorGroup::MotorGroup(const std::initializer_list<std::int8_t> ports,
                        const pros::v5::MotorGears gearset,
                        const pros::v5::MotorUnits encoder_units)
     : _ports(ports) {
-	set_gearing(gearset);
-	set_encoder_units(encoder_units);
+	set_gearing_all(gearset);
+	set_encoder_units_all(encoder_units);
 }
 
 MotorGroup::MotorGroup(const std::vector<std::int8_t>& ports,
                        const pros::v5::MotorGears gearset,
                        const pros::v5::MotorUnits encoder_units)
     : _ports(ports) {
-	set_gearing(gearset);
-	set_encoder_units(encoder_units);
+	set_gearing_all(gearset);
+	set_encoder_units_all(encoder_units);
 }
 
 std::int32_t MotorGroup::operator=(std::int32_t voltage) const {


### PR DESCRIPTION
#### Summary:
Appended _all to the `set_gearing` and `set_encoder_units` calls in the motor group constructor.

#### Motivation:
After testing, it seems that when creating a motor group, the gearing you provide to the constructor only applies to the first motor in the group. Previously, the constructor would call `set_gearing` and pass in only the gearset, which would result in the `index` argument defaulting to 0 and therefore only applying to the first motor. The same is true with the existing `set_encoder_units` call. Changing these to their `_all` variants means all motors in the group will get the proper gearing and encoder units.

Example:

`pros::MotorGroup motors({1, 2}, pros::MotorGears::blue);` will only set the first motor to blue.

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- Create a motor group, being sure to specify a gearing and encoder units
- Call `get_gearing_all` on the motor group and print the values to verify the gearing is correct
- Similarly, call `get_encoder_units_all` on the motor group and print the values to verify the encoder units are correct
