### PR TITLE
:sparkles: ADI Get Port

### DIFF
--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -190,6 +190,26 @@ class Port {
 	 */
 	std::int32_t set_value(std::int32_t value) const;
 
+	/**
+	 * Gets the port of the sensor.
+	 *
+	 * \return 1 if the operation was successful or PROS_ERR if the operation
+	 * failed, setting errno.
+	 * 
+	 * \b Example
+	 * \code
+	 * #define DIGITAL_SENSOR_PORT 1 // 'A'
+	 * 
+	 * void initialize() {
+	 *   pros::adi::AnalogIn sensor (DIGITAL_SENSOR_PORT);
+	 *   
+	 * 	 // Prints the second value from the port tuple (The Adi Port. The first value is the Smart Port)
+	 * 	 printf("Sensor Port: %d", std::get<1>(sensor.get_port()));
+	 * }
+	 * \endcode
+	 */
+	virtual ext_adi_port_tuple_t get_port() const;
+
 	protected:
 	std::uint8_t _smart_port;
 	std::uint8_t _adi_port;
@@ -396,6 +416,8 @@ class AnalogIn : protected Port {
 	 * value calibrated HR: (16 bit calibrated value), value: (12 bit value)]
 	 */
 	friend std::ostream& operator<<(std::ostream& os, pros::adi::AnalogIn& analog_in);
+
+	using Port::get_port;
 };
 
 ///@}
@@ -484,6 +506,8 @@ class AnalogOut : private Port {
 	 * \endcode
 	 */
 	using Port::set_value;
+	
+	using Port::get_port;
 
 	/**
 	 * This is the overload for the << operator for printing to streams
@@ -594,6 +618,8 @@ class DigitalOut : private Port {
 	 * \endcode
 	 */
 	using Port::set_value;
+
+	using Port::get_port;
 
 	/**
 	 * This is the overload for the << operator for printing to streams
@@ -731,6 +757,8 @@ class DigitalIn : private Port {
 	 * value: (value)]
 	 */
 	friend std::ostream& operator<<(std::ostream& os, pros::adi::DigitalIn& digital_in);
+
+	using Port::get_port;
 };
 
 ///@}
@@ -875,6 +903,8 @@ class Motor : private Port {
 	 * \endcode
 	 */
 	using Port::get_value;
+
+	using Port::get_port;
 };
 
 ///@}
@@ -1004,6 +1034,11 @@ class Encoder : private Port {
 	 * value: (value)]
 	 */ 
 	friend std::ostream& operator<<(std::ostream& os, pros::adi::Encoder& encoder);
+	ext_adi_port_tuple_t get_port() const override;
+
+	private:
+	ext_adi_port_pair_t _port_pair;
+
 };
 
 ///@}
@@ -1108,6 +1143,8 @@ class Ultrasonic : private Port {
 	 * \endcode
 	 */
 	std::int32_t get_value() const;
+
+	using Port::get_port;
 };
 
 ///@}
@@ -1259,6 +1296,8 @@ class Gyro : private Port {
 	 * \endcode
 	 */
 	std::int32_t reset() const;
+
+	using Port::get_port;
 };
 
 ///@}
@@ -1419,6 +1458,9 @@ class Potentiometer : public AnalogIn {
 	 * Prints in format(this below is all in one line with no new line):
 	 */ 
 	friend std::ostream& operator<<(std::ostream& os, pros::adi::Potentiometer& potentiometer);
+
+	using Port::get_port;
+	
 };
 
 ///@}
@@ -1709,6 +1751,8 @@ class Led : protected Port {
 	* \endcode
 	*/
 	std::int32_t length();
+
+	using Port::get_port;
 
 	protected:
 	std::vector<uint32_t> _buffer;

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -193,8 +193,10 @@ class Port {
 	/**
 	 * Gets the port of the sensor.
 	 *
-	 * \return 1 if the operation was successful or PROS_ERR if the operation
-	 * failed, setting errno.
+	 * \return returns a tuple of integer ports.
+	 * 
+	 * \note The parts of the tuple are {smart port, adi port, second adi port (when applicable)}. 
+	 * 
 	 * 
 	 * \b Example
 	 * \code
@@ -203,8 +205,13 @@ class Port {
 	 * void initialize() {
 	 *   pros::adi::AnalogIn sensor (DIGITAL_SENSOR_PORT);
 	 *   
-	 * 	 // Prints the second value from the port tuple (The Adi Port. The first value is the Smart Port)
-	 * 	 printf("Sensor Port: %d", std::get<1>(sensor.get_port()));
+	 * 	 // Getting values from the tuple using std::get<index> 
+	 * 	 int sensorSmartPort = std::get<0>(sensor.get_port()); // First value
+	 *   int sensorAdiPort = std::get<1>(sensor.get_port()); // Second value
+	 * 
+	 * 	 // Prints the first and second value from the port tuple (The Adi Port. The first value is the Smart Port)
+	 *   printf("Sensor Smart Port: %d\n", sensorSmartPort);
+	 *   printf("Sensor Adi Port: %d\n", sensorAdiPort);	
 	 * }
 	 * \endcode
 	 */

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -47,8 +47,7 @@ std::int32_t Port::get_value() const {
 }
 
 ext_adi_port_tuple_t Port::get_port() const {
-	ext_adi_port_pair_t _port_pair = std::make_pair(_adi_port, PROS_ERR_BYTE);
-	return std::make_tuple(+_smart_port, std::get<0>(_port_pair), std::get<1>(_port_pair));
+	return std::make_tuple(_smart_port, _adi_port, PROS_ERR_BYTE);
 }
 
 AnalogIn::AnalogIn(std::uint8_t adi_port) : Port(adi_port, E_ADI_ANALOG_IN) {}
@@ -147,7 +146,6 @@ Encoder::Encoder(ext_adi_port_tuple_t port_tuple, bool reversed) : Port(std::get
 	std::int32_t _port =
 	    ext_adi_encoder_init(std::get<0>(port_tuple), std::get<1>(port_tuple), std::get<2>(port_tuple), reversed);
 	get_ports(_port, _smart_port, _adi_port);
-
 }
 
 std::int32_t Encoder::reset() const {

--- a/src/devices/vdml_ext_adi.c
+++ b/src/devices/vdml_ext_adi.c
@@ -282,7 +282,7 @@ ext_adi_encoder_t ext_adi_encoder_init(uint8_t smart_port, uint8_t adi_port_top,
 	adi_data_s_t* const adi_data = &((adi_data_s_t*)(device->pad))[port];
 	adi_data->encoder_data.reversed = reverse;
 	vexDeviceAdiPortConfigSet(device->device_info, port, E_ADI_LEGACY_ENCODER);
-	return_port(smart_port - 1, merge_adi_ports(smart_port - 1, port + 1));
+	return_port(smart_port - 1, merge_adi_ports(smart_port, port + 1));
 }
 
 int32_t ext_adi_encoder_get(ext_adi_encoder_t enc) {
@@ -334,7 +334,7 @@ ext_adi_ultrasonic_t ext_adi_ultrasonic_init(uint8_t smart_port, uint8_t adi_por
 
 	claim_port_i(smart_port - 1, E_DEVICE_ADI);
 	vexDeviceAdiPortConfigSet(device->device_info, port, E_ADI_LEGACY_ULTRASONIC);
-	return_port(smart_port - 1, merge_adi_ports(smart_port - 1, port + 1));
+	return_port(smart_port - 1, merge_adi_ports(smart_port, port + 1));
 }
 
 int32_t ext_adi_ultrasonic_get(ext_adi_ultrasonic_t ult) {
@@ -371,7 +371,7 @@ ext_adi_gyro_t ext_adi_gyro_init(uint8_t smart_port, uint8_t adi_port, double mu
 	adi_port_config_e_t config = vexDeviceAdiPortConfigGet(device->device_info, adi_port);
 	if (config == E_ADI_LEGACY_GYRO) {
 		// Port has already been calibrated, no need to do that again
-		return_port(smart_port - 1, merge_adi_ports(smart_port - 1, adi_port + 1));
+		return_port(smart_port - 1, merge_adi_ports(smart_port, adi_port + 1));
 	}
 
 	vexDeviceAdiPortConfigSet(device->device_info, adi_port, E_ADI_LEGACY_GYRO);
@@ -381,7 +381,7 @@ ext_adi_gyro_t ext_adi_gyro_init(uint8_t smart_port, uint8_t adi_port, double mu
 		// the calibration time in VexOS.
 		delay(GYRO_CALIBRATION_TIME);
 	}
-	return_port(smart_port - 1, merge_adi_ports(smart_port - 1, adi_port + 1));
+	return_port(smart_port - 1, merge_adi_ports(smart_port, adi_port + 1));
 }
 
 double ext_adi_gyro_get(ext_adi_gyro_t gyro) {
@@ -430,7 +430,7 @@ ext_adi_potentiometer_t ext_adi_potentiometer_init(uint8_t smart_port, uint8_t a
 	adi_data->potentiometer_data.potentiometer_type = potentiometer_type;
 	vexDeviceAdiPortConfigSet(device->device_info, adi_port, E_ADI_ANALOG_IN);
 
-	return_port(smart_port - 1, merge_adi_ports(smart_port - 1, adi_port + 1));
+	return_port(smart_port - 1, merge_adi_ports(smart_port, adi_port + 1));
 }
 
 double ext_adi_potentiometer_get_angle(ext_adi_potentiometer_t potentiometer) {
@@ -461,7 +461,7 @@ ext_adi_led_t ext_adi_led_init(uint8_t smart_port, uint8_t adi_port) {
 	transform_adi_port(adi_port);
 	claim_port_i(smart_port - 1, E_DEVICE_ADI);
 	vexDeviceAdiPortConfigSet(device->device_info, adi_port, (V5_AdiPortConfiguration)E_ADI_DIGITAL_OUT); 
-	return_port(smart_port - 1, merge_adi_ports(smart_port - 1, adi_port + 1));
+	return_port(smart_port - 1, merge_adi_ports(smart_port, adi_port + 1));
 }
 
 int32_t ext_adi_led_set(ext_adi_led_t led, uint32_t* buffer, uint32_t buffer_length) {


### PR DESCRIPTION
#### Summary:
Added a get_port() method for all adi sesnors with functionality for adi extenders

#### Motivation:
Requested feature.

#### Test Plan:

- [x] AnalogIn
- [x] AnalogOut
- [x] DigitalIn
- [x] DigitalOut
- [x] Encoder (with extender)
- [x] Ultrasonic
- [x] Gyro
- [x] Potentiometer
- [x] Led

