### PR TITLE
Initial Commit. Changed default param.

### DIFF
--- a/include/pros/link.hpp
+++ b/include/pros/link.hpp
@@ -65,7 +65,7 @@ class Link : public Device {
 	 * pros::Link link(1, "my_link", pros::E_LINK_TX);
 	 * \endcode
 	 */
-	explicit Link(const std::uint8_t port, const std::string link_id, link_type_e_t type, bool ov = false);
+	explicit Link(const std::uint8_t port, const std::string link_id, link_type_e_t type, bool ov = true);
 
 	/**
 	 * Checks if a radio link on a port is active or not.


### PR DESCRIPTION
#### Summary:
Changed vex link (Link) override the default value

#### Motivation:
Radio port should be overridden to a transmitter/receiver by default

[https://discord.com/channels/1025259843763847229/1026010495523749990/1149147224647925810](url)



