### PR TITLE
✨Allows for file open to default to the sd card.

### DIFF
--- a/src/system/dev/vfs.c
+++ b/src/system/dev/vfs.c
@@ -109,10 +109,9 @@ int _open(const char* file, int flags, int mode) {
 		return usd_open_r(r, file + strlen("/usd"), flags, mode);
 	} else if (strstr(file, "/dev") == file) {
 		return dev_open_r(r, file + strlen("/dev"), flags, mode);
+	} else {
+		return usd_open_r(r, file, flags, mode);
 	}
-
-	r->_errno = ENOENT;
-	return -1;
 }
 
 ssize_t _write(int file, const void* buf, size_t len) {


### PR DESCRIPTION
#### Summary:
Allows for open for the sd card to no longer need paths to start with "/usd/" UNLESS the path begins with "usd", "dev", or "ser".
TO access those folders you still need the usd prefix as before. 
Some examples: 
if there is a file called a.txt in the main folder of the sd card, it can be accessed via a path of "/usd/a.txt" or "a.txt" would work.
However, if there is a file called b.txt in a folder called dev, it must be accessed via the path of "/usd/dev/b.txt"

#### Motivation:
Makes file IO via the SD card way easier for users
##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [ ] tested opening a file without prefixed with "/usd/". Tested with both a leading / and without it
