### PR TITLE
🐛Fixed Imu::is_calibrating function for PROS 3 #626

### DIFF
--- a/include/pros/imu.h
+++ b/include/pros/imu.h
@@ -29,8 +29,8 @@ namespace c {
 #endif
 
 typedef enum imu_status_e {
-	E_IMU_STATUS_READY = 0,
-	E_IMU_STATUS_CALIBRATING = 19,
+	E_IMU_STATUS_READY = 0, // IMU is connected but not currently calibrating
+	E_IMU_STATUS_CALIBRATING = 19, // IMU is calibrating
 	E_IMU_STATUS_ERROR = 0xFF,  // NOTE: used for returning an error from the get_status function, not that the IMU is
 	                            // necessarily in an error state
 } imu_status_e_t;

--- a/include/pros/imu.h
+++ b/include/pros/imu.h
@@ -29,7 +29,8 @@ namespace c {
 #endif
 
 typedef enum imu_status_e {
-	E_IMU_STATUS_CALIBRATING = 0x01,
+	E_IMU_STATUS_READY = 0,
+	E_IMU_STATUS_CALIBRATING = 19,
 	E_IMU_STATUS_ERROR = 0xFF,  // NOTE: used for returning an error from the get_status function, not that the IMU is
 	                            // necessarily in an error state
 } imu_status_e_t;

--- a/src/devices/vdml_imu.cpp
+++ b/src/devices/vdml_imu.cpp
@@ -62,7 +62,7 @@ pros::c::imu_status_e_t Imu::get_status() const {
 }
 
 bool Imu::is_calibrating() const {
-	return get_status() & pros::c::E_IMU_STATUS_CALIBRATING;
+	return get_status() == pros::c::E_IMU_STATUS_CALIBRATING;
 }
 
 std::int32_t Imu::tare_heading() const {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,21 +88,6 @@ void opcontrol() {
 		left_mtr = left;
 		right_mtr = right;
 
-		// Instantiate the IMU on port where is not connected
-		printf("Imu 1: \n");
-		pros::Imu imu(3);
-		// Call Imu::is_calibrating() to check if function is working
-		// Will return true if calibrating, false if not
-		printf("Imu::is_calibrating() = %d\n", imu.is_calibrating());
-		// Instantiate the IMU on port where is connected
-		printf("Imu 2: \n");
-		pros::Imu imu2(11);
-		// Calibrate the IMU, no blocking
-		imu2.reset();
-		// Call Imu::is_calibrating() to check if function is working
-		// Will return true if calibrating, false if not
-		printf("Imu::is_calibrating() = %d\n", imu2.is_calibrating());
-
 		pros::delay(20);
 	}
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,6 +88,21 @@ void opcontrol() {
 		left_mtr = left;
 		right_mtr = right;
 
+		// Instantiate the IMU on port where is not connected
+		printf("Imu 1: \n");
+		pros::Imu imu(3);
+		// Call Imu::is_calibrating() to check if function is working
+		// Will return true if calibrating, false if not
+		printf("Imu::is_calibrating() = %d\n", imu.is_calibrating());
+		// Instantiate the IMU on port where is connected
+		printf("Imu 2: \n");
+		pros::Imu imu2(11);
+		// Calibrate the IMU, no blocking
+		imu2.reset();
+		// Call Imu::is_calibrating() to check if function is working
+		// Will return true if calibrating, false if not
+		printf("Imu::is_calibrating() = %d\n", imu2.is_calibrating());
+
 		pros::delay(20);
 	}
 }


### PR DESCRIPTION
#### Summary:
Fixed Imu::is_calibrating function to return correct values.

#### Motivation:
Users can use this function to properly check if their connected imu is calibrating or not, and also get the proper return value of false if they call this function on an imu that is not connected.

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [x] Tested function on imu that is not connected
- [x] Tested function on connected imu but not calibrating
- [x] Tested function on connected imu that is calibrating
