### PR TITLE
🐛Motor move operator fix

### DIFF
--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -71,7 +71,7 @@ class Motor : public AbstractMotor, public Device {
  	 * \endcode
 	 * 
 	 */
-	Motor(const std::int8_t port, const pros::v5::MotorGears gearset = pros::v5::MotorGears::invalid,
+	explicit Motor(const std::int8_t port, const pros::v5::MotorGears gearset = pros::v5::MotorGears::invalid,
 	               const pros::v5::MotorUnits encoder_units = pros::v5::MotorUnits::invalid);
 
 	


### PR DESCRIPTION
#### Summary:
Fixed an issue where users could not use the "=" operator to set a motor's voltage/speed 

#### Motivation:
Received an "Ambiguous overload for operator" error when attempting to set a motor's voltage with = operator. 

Ex. `my_motor = 127;  // Result in error`

#### Test Plan:

- [x] Test motor = [-127, 127]
- [x] Test with other methods
- [x] Test motor group operator