### PR TITLE
🐛LVGL display update task at equal priority to user tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ EXTRA_LIB_DEPS=$(INCDIR)/api.h $(PATCHED_SDK)
 -include ./common.mk
 
 .PHONY: $(INCDIR)/api.h
-# $(INCDIR)/api.h: version.py
-# 	$(VV)python version.py
+$(INCDIR)/api.h: version.py
+	$(VV)python version.py
 
 $(PATCHED_SDK): $(FWDIR)/libv5rts/sdk/vexv5/libv5rts.a
 	$(call test_output_2,Stripping unwanted symbols from libv5rts.a ,$(STRIP) $^ @libv5rts-strip-options.txt -o $@, $(DONE_STRING))

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ EXTRA_LIB_DEPS=$(INCDIR)/api.h $(PATCHED_SDK)
 -include ./common.mk
 
 .PHONY: $(INCDIR)/api.h
-$(INCDIR)/api.h: version.py
-	$(VV)python version.py
+# $(INCDIR)/api.h: version.py
+# 	$(VV)python version.py
 
 $(PATCHED_SDK): $(FWDIR)/libv5rts/sdk/vexv5/libv5rts.a
 	$(call test_output_2,Stripping unwanted symbols from libv5rts.a ,$(STRIP) $^ @libv5rts-strip-options.txt -o $@, $(DONE_STRING))

--- a/src/display/display.c
+++ b/src/display/display.c
@@ -23,8 +23,8 @@ static void disp_daemon(void* ign) {
 	uint32_t time = millis();
 	while (true) {
 		lv_task_handler();
-		task_delay_until(&time, 16);
-		lv_tick_inc(16);
+		task_delay_until(&time, 8);
+		lv_tick_inc(8);
 	}
 }
 

--- a/src/display/display.c
+++ b/src/display/display.c
@@ -12,6 +12,7 @@
 
 #include "display/lvgl.h"
 #include "kapi.h"
+#include "pros/rtos.h"
 #include "v5_api.h"
 
 static task_stack_t disp_daemon_task_stack[TASK_STACK_DEPTH_DEFAULT];
@@ -22,8 +23,8 @@ static void disp_daemon(void* ign) {
 	uint32_t time = millis();
 	while (true) {
 		lv_task_handler();
-		task_delay_until(&time, 2);
-		lv_tick_inc(2);
+		task_delay_until(&time, 16);
+		lv_tick_inc(16);
 	}
 }
 
@@ -72,6 +73,6 @@ void display_initialize(void) {
 	lv_obj_set_size(page, 480, 240);
 	lv_scr_load(page);
 
-	disp_daemon_task = task_create_static(disp_daemon, NULL, TASK_PRIORITY_MIN + 2, TASK_STACK_DEPTH_DEFAULT,
+	disp_daemon_task = task_create_static(disp_daemon, NULL, TASK_PRIORITY_DEFAULT, TASK_STACK_DEPTH_DEFAULT,
 	                                      "Display Daemon (PROS)", disp_daemon_task_stack, &disp_daemon_task_buffer);
 }


### PR DESCRIPTION

#### Summary:
Changes the delay of the LVGL background daemon to be 8ms from 2 ms
Updates the priority of the LVGL background daemon to be equal priority to user tasks 

#### Motivation:
Currently the lvgl display daemon runs at a much lower priority than user tasks. Since PROS does not do priority upgrading when a task is starved, the lvgl daemon doesn't run if users don't have delays in their code. 
This PR upgrades the LVGL display daemon to equal priority to user tasks. In order to prevent LVGL from hogging the resources, the delay in the lvgl display daemon is upped from 2 ms to 8 ms. This still should give LVGL more resources when users don't have delays in their code, while slightly reducing the amount of cpu time LVGL uses when users use delays properly. LVGL should still have more than enough resources as the brain's refresh rate corresponds to a delay of 16.6ms in the display daemon.

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [x] Screen is kept up to date when a user task with delays is running. 
- [ ] Screen is kept up to date when a user task without delays is running. 

