### PR TITLE
🐛Imu Reset bugfix and IMU get orientation

### DIFF
--- a/include/pros/imu.h
+++ b/include/pros/imu.h
@@ -545,7 +545,7 @@ int32_t imu_set_roll(uint8_t port, double target);
 int32_t imu_set_yaw(uint8_t port, double target);
 
 /**
- * Returns the orientation of the IMU
+ * Returns the physical orientation of the IMU
  *
  * This function uses the following values of errno when an error state is
  * reached:
@@ -557,7 +557,7 @@ int32_t imu_set_yaw(uint8_t port, double target);
  * \returns The orientation of the Inertial Sensor or PROS_ERR if an error occured.
  *
  */
-imu_orientation_e_t imu_get_orientation(uint8_t port);
+imu_orientation_e_t imu_get_physical_orientation(uint8_t port);
 
 #ifdef __cplusplus
 }

--- a/include/pros/imu.h
+++ b/include/pros/imu.h
@@ -36,12 +36,12 @@ typedef enum imu_status_e {
 } imu_status_e_t;
 
 typedef enum imu_orientation_e {
-	E_IMU_Z_UP = 8,
-	E_IMU_Z_DOWN = 9,
-	E_IMU_X_UP = 10,
-	E_IMU_X_DOWN = 11,
-	E_IMU_Y_UP = 12,
-	E_IMU_Y_DOWN = 13,
+	E_IMU_Z_UP = 8,     // IMU has the Z axis UP (VEX Logo facing DOWN)
+	E_IMU_Z_DOWN = 9,   // IMU has the Z axis DOWN (VEX Logo facing UP)
+	E_IMU_X_UP = 10,    // IMU has the X axis UP
+	E_IMU_X_DOWN = 11,  // IMU has the X axis DOWN
+	E_IMU_Y_UP = 12,    // IMU has the Y axis UP
+	E_IMU_Y_DOWN = 13,  // IMU has the Y axis DOWN
 } imu_orientation_e_t;
 typedef struct __attribute__((__packed__)) quaternion_s {
 	double x;
@@ -305,7 +305,6 @@ imu_accel_s_t imu_get_accel(uint8_t port);
  * reached:
  * ENXIO - The given value is not within the range of V5 ports (1-21).
  * ENODEV - The port cannot be configured as an Inertial Sensor
- * EAGAIN - The sensor is still calibrating
  *
  * \param  port
  * 				 The V5 Inertial Sensor port number from 1-21
@@ -545,6 +544,19 @@ int32_t imu_set_roll(uint8_t port, double target);
  */
 int32_t imu_set_yaw(uint8_t port, double target);
 
+/**
+ * Returns the orientation of the IMU
+ *
+ * This function uses the following values of errno when an error state is
+ * reached:
+ * ENXIO - The given value is not within the range of V5 ports (1-21).
+ * ENODEV - The port cannot be configured as an Inertial Sensor
+ *
+ * \param  port
+ * 				 The V5 Inertial Sensor port number from 1-21
+ * \returns The orientation of the Inertial Sensor or PROS_ERR if an error occured.
+ *
+ */
 imu_orientation_e_t imu_get_orientation(uint8_t port);
 
 #ifdef __cplusplus

--- a/include/pros/imu.h
+++ b/include/pros/imu.h
@@ -36,12 +36,12 @@ typedef enum imu_status_e {
 } imu_status_e_t;
 
 typedef enum imu_orientation_e {
-	E_IMU_Z_UP = 8,     // IMU has the Z axis UP (VEX Logo facing DOWN)
-	E_IMU_Z_DOWN = 9,   // IMU has the Z axis DOWN (VEX Logo facing UP)
-	E_IMU_X_UP = 10,    // IMU has the X axis UP
-	E_IMU_X_DOWN = 11,  // IMU has the X axis DOWN
-	E_IMU_Y_UP = 12,    // IMU has the Y axis UP
-	E_IMU_Y_DOWN = 13,  // IMU has the Y axis DOWN
+	E_IMU_Z_UP = 0,    // IMU has the Z axis UP (VEX Logo facing DOWN)
+	E_IMU_Z_DOWN = 1,  // IMU has the Z axis DOWN (VEX Logo facing UP)
+	E_IMU_X_UP = 2,    // IMU has the X axis UP
+	E_IMU_X_DOWN = 3,  // IMU has the X axis DOWN
+	E_IMU_Y_UP = 4,    // IMU has the Y axis UP
+	E_IMU_Y_DOWN = 5,  // IMU has the Y axis DOWN
 } imu_orientation_e_t;
 typedef struct __attribute__((__packed__)) quaternion_s {
 	double x;

--- a/include/pros/imu.h
+++ b/include/pros/imu.h
@@ -29,12 +29,20 @@ namespace c {
 #endif
 
 typedef enum imu_status_e {
-	E_IMU_STATUS_READY = 0, // IMU is connected but not currently calibrating
-	E_IMU_STATUS_CALIBRATING = 19, // IMU is calibrating
-	E_IMU_STATUS_ERROR = 0xFF,  // NOTE: used for returning an error from the get_status function, not that the IMU is
-	                            // necessarily in an error state
+	E_IMU_STATUS_READY = 0,        // IMU is connected but not currently calibrating
+	E_IMU_STATUS_CALIBRATING = 1,  // IMU is calibrating
+	E_IMU_STATUS_ERROR = 0xFF,     // NOTE: used for returning an error from the get_status function, not that the IMU is
+	                               // necessarily in an error state
 } imu_status_e_t;
 
+typedef enum imu_orientation_e {
+	E_IMU_Z_UP = 8,
+	E_IMU_Z_DOWN = 9,
+	E_IMU_X_UP = 10,
+	E_IMU_X_DOWN = 11,
+	E_IMU_Y_UP = 12,
+	E_IMU_Y_DOWN = 13,
+} imu_orientation_e_t;
 typedef struct __attribute__((__packed__)) quaternion_s {
 	double x;
 	double y;
@@ -92,10 +100,10 @@ int32_t imu_reset(uint8_t port);
 /**
  * Calibrate IMU and Blocks while Calibrating
  *
- * Calibration takes approximately 2 seconds and blocks during this period, 
+ * Calibration takes approximately 2 seconds and blocks during this period,
  * with a timeout for this operation being set a 3 seconds as a safety margin.
- * Like the other reset function, this function also blocks until the IMU 
- * status flag is set properly to E_IMU_STATUS_CALIBRATING, with a minimum 
+ * Like the other reset function, this function also blocks until the IMU
+ * status flag is set properly to E_IMU_STATUS_CALIBRATING, with a minimum
  * blocking time of 5ms and a timeout of 1 second if it's never set.
  *
  * This function uses the following values of errno when an error state is
@@ -310,7 +318,7 @@ imu_status_e_t imu_get_status(uint8_t port);
 // void imu_set_mode(uint8_t port, uint32_t mode);
 // uint32_t imu_get_mode(uint8_t port);
 
-//Value reset functions:
+// Value reset functions:
 /**
  * Resets the current reading of the Inertial Sensor's heading to zero
  *
@@ -423,7 +431,7 @@ int32_t imu_tare_euler(uint8_t port);
  */
 int32_t imu_tare(uint8_t port);
 
-//Value set functions:
+// Value set functions:
 /**
  * Sets the current reading of the Inertial Sensor's euler values to
  * target euler values. Will default to +/- 180 if target exceeds +/- 180.
@@ -464,7 +472,7 @@ int32_t imu_set_rotation(uint8_t port, double target);
 /**
  * Sets the current reading of the Inertial Sensor's heading to target value
  * Target will default to 360 if above 360 and default to 0 if below 0.
- * 
+ *
  * This function uses the following values of errno when an error state is
  * reached:
  * ENXIO - The given value is not within the range of V5 ports (1-21).
@@ -483,7 +491,7 @@ int32_t imu_set_heading(uint8_t port, double target);
 /**
  * Sets the current reading of the Inertial Sensor's pitch to target value
  * Will default to +/- 180 if target exceeds +/- 180.
- * 
+ *
  * This function uses the following values of errno when an error state is
  * reached:
  * ENXIO - The given value is not within the range of V5 ports (1-21).
@@ -502,7 +510,7 @@ int32_t imu_set_pitch(uint8_t port, double target);
 /**
  * Sets the current reading of the Inertial Sensor's roll to target value
  * Will default to +/- 180 if target exceeds +/- 180.
- * 
+ *
  * This function uses the following values of errno when an error state is
  * reached:
  * ENXIO - The given value is not within the range of V5 ports (1-21).
@@ -521,7 +529,7 @@ int32_t imu_set_roll(uint8_t port, double target);
 /**
  * Sets the current reading of the Inertial Sensor's yaw to target value
  * Will default to +/- 180 if target exceeds +/- 180.
- * 
+ *
  * This function uses the following values of errno when an error state is
  * reached:
  * ENXIO - The given value is not within the range of V5 ports (1-21).
@@ -536,6 +544,8 @@ int32_t imu_set_roll(uint8_t port, double target);
  * failed, setting errno.
  */
 int32_t imu_set_yaw(uint8_t port, double target);
+
+imu_orientation_e_t imu_get_orientation(uint8_t port);
 
 #ifdef __cplusplus
 }

--- a/include/pros/imu.hpp
+++ b/include/pros/imu.hpp
@@ -452,7 +452,7 @@ class Imu {
 	virtual bool is_calibrating() const;
 
 	/**
-	 * Returns the orientation of the IMU
+	 * Returns the physical orientation of the IMU
 	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
@@ -461,10 +461,10 @@ class Imu {
 	 *
 	 * \param  port
 	 * 				 The V5 Inertial Sensor port number from 1-21
-	 * \returns The orientation of the Inertial Sensor or PROS_ERR if an error occured.
+	 * \returns The physical orientation of the Inertial Sensor or PROS_ERR if an error occured.
 	 *
 	 */
-	virtual pros::c::imu_orientation_e_t get_orientation() const;
+	virtual pros::c::imu_orientation_e_t get_physical_orientation() const;
 };
 
 using IMU = Imu;

--- a/include/pros/imu.hpp
+++ b/include/pros/imu.hpp
@@ -436,7 +436,6 @@ class Imu {
 	 * reached:
 	 * ENXIO - The given value is not within the range of V5 ports (1-21).
 	 * ENODEV - The port cannot be configured as an Inertial Sensor
-	 * EAGAIN - The sensor is still calibrating
 	 *
 	 * \param  port
 	 * 				 The V5 Inertial Sensor port number from 1-21
@@ -452,6 +451,19 @@ class Imu {
 	 */
 	virtual bool is_calibrating() const;
 
+	/**
+	 * Returns the orientation of the IMU
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENXIO - The given value is not within the range of V5 ports (1-21).
+	 * ENODEV - The port cannot be configured as an Inertial Sensor
+	 *
+	 * \param  port
+	 * 				 The V5 Inertial Sensor port number from 1-21
+	 * \returns The orientation of the Inertial Sensor or PROS_ERR if an error occured.
+	 *
+	 */
 	virtual pros::c::imu_orientation_e_t get_orientation() const;
 };
 

--- a/include/pros/imu.hpp
+++ b/include/pros/imu.hpp
@@ -19,6 +19,7 @@
 #define _PROS_IMU_HPP_
 
 #include <cstdint>
+
 #include "pros/imu.h"
 
 namespace pros {
@@ -31,47 +32,47 @@ class Imu {
 	/**
 	 * Calibrate IMU
 	 *
-	 * Calibration takes approximately 2 seconds and blocks during this period if 
-	 * the blocking param is true, with a timeout for this operation being set a 3 
-	 * seconds as a safety margin. This function also blocks until the IMU 
-	 * status flag is set properly to E_IMU_STATUS_CALIBRATING, with a minimum 
+	 * Calibration takes approximately 2 seconds and blocks during this period if
+	 * the blocking param is true, with a timeout for this operation being set a 3
+	 * seconds as a safety margin. This function also blocks until the IMU
+	 * status flag is set properly to E_IMU_STATUS_CALIBRATING, with a minimum
 	 * blocking time of 5ms and a timeout of 1 second if it's never set.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENXIO - The given value is not within the range of V5 ports (1-21).
 	 * ENODEV - The port cannot be configured as an Inertial Sensor
 	 * EAGAIN - The sensor is already calibrating, or time out setting the status flag.
 	 *
-	 * \param blocking 
+	 * \param blocking
 	 *			Whether this function blocks during calibration.
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 */
 	virtual std::int32_t reset(bool blocking = false) const;
 	/**
-	* Set the Inertial Sensor's refresh interval in milliseconds.
-	*
-	* The rate may be specified in increments of 5ms, and will be rounded down to
-	* the nearest increment. The minimum allowable refresh rate is 5ms. The default
-	* rate is 10ms.
-	*
-	* As values are copied into the shared memory buffer only at 10ms intervals,
-	* setting this value to less than 10ms does not mean that you can poll the
-	* sensor's values any faster. However, it will guarantee that the data is as
-	* recent as possible.
-	*
-	* This function uses the following values of errno when an error state is
-	* reached:
-	* ENXIO - The given value is not within the range of V5 ports (1-21).
-	* ENODEV - The port cannot be configured as an Inertial Sensor
-	* EAGAIN - The sensor is still calibrating
-	*
-	* \param rate 
-	*			The data refresh interval in milliseconds
-	* \return 1 if the operation was successful or PROS_ERR if the operation
-	* failed, setting errno.
-	*/
+	 * Set the Inertial Sensor's refresh interval in milliseconds.
+	 *
+	 * The rate may be specified in increments of 5ms, and will be rounded down to
+	 * the nearest increment. The minimum allowable refresh rate is 5ms. The default
+	 * rate is 10ms.
+	 *
+	 * As values are copied into the shared memory buffer only at 10ms intervals,
+	 * setting this value to less than 10ms does not mean that you can poll the
+	 * sensor's values any faster. However, it will guarantee that the data is as
+	 * recent as possible.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENXIO - The given value is not within the range of V5 ports (1-21).
+	 * ENODEV - The port cannot be configured as an Inertial Sensor
+	 * EAGAIN - The sensor is still calibrating
+	 *
+	 * \param rate
+	 *			The data refresh interval in milliseconds
+	 * \return 1 if the operation was successful or PROS_ERR if the operation
+	 * failed, setting errno.
+	 */
 	virtual std::int32_t set_data_rate(std::uint32_t rate) const;
 	/**
 	 * Get the total number of degrees the Inertial Sensor has spun about the z-axis
@@ -310,7 +311,7 @@ class Imu {
 	/**
 	 * Sets the current reading of the Inertial Sensor's heading to target value
 	 * Target will default to 360 if above 360 and default to 0 if below 0.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENXIO - The given value is not within the range of V5 ports (1-21).
@@ -345,7 +346,7 @@ class Imu {
 	/**
 	 * Sets the current reading of the Inertial Sensor's yaw to target value
 	 * Will default to +/- 180 if target exceeds +/- 180.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENXIO - The given value is not within the range of V5 ports (1-21).
@@ -380,7 +381,7 @@ class Imu {
 	/**
 	 * Sets the current reading of the Inertial Sensor's roll to target value
 	 * Will default to +/- 180 if target exceeds +/- 180.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENXIO - The given value is not within the range of V5 ports (1-21).
@@ -450,6 +451,8 @@ class Imu {
 	 * false if it is not.
 	 */
 	virtual bool is_calibrating() const;
+
+	virtual pros::c::imu_orientation_e_t get_orientation() const;
 };
 
 using IMU = Imu;

--- a/src/devices/vdml_imu.c
+++ b/src/devices/vdml_imu.c
@@ -409,5 +409,5 @@ int32_t imu_set_euler(uint8_t port, euler_s_t target) {
 }
 
 imu_orientation_e_t imu_get_orientation(uint8_t port) {
-	return imu_get_status(port) >> 1;
+	return (imu_get_status(port) >> 1) & 7;
 }

--- a/src/devices/vdml_imu.c
+++ b/src/devices/vdml_imu.c
@@ -11,6 +11,7 @@
  */
 
 #include <errno.h>
+
 #include "pros/imu.h"
 #include "v5_api.h"
 #include "vdml/registry.h"
@@ -28,9 +29,9 @@
 	}
 
 #define IMU_RESET_FLAG_SET_TIMEOUT 1000
-#define IMU_RESET_TIMEOUT 3000 // Canonically this should be 2s, but 3s for good margin
+#define IMU_RESET_TIMEOUT 3000  // Canonically this should be 2s, but 3s for good margin
 
-typedef struct __attribute__ ((packed)) imu_reset_data { 
+typedef struct __attribute__((packed)) imu_reset_data {
 	double heading_offset;
 	double rotation_offset;
 	double pitch_offset;
@@ -56,8 +57,8 @@ int32_t imu_reset(uint8_t port) {
 			errno = EAGAIN;
 			return PROS_ERR;
 		}
-		device = device; // suppressing compiler warning
-	} while(!(vexDeviceImuStatusGet(device->device_info) & E_IMU_STATUS_CALIBRATING));
+		device = device;  // suppressing compiler warning
+	} while (!(vexDeviceImuStatusGet(device->device_info) & E_IMU_STATUS_CALIBRATING));
 	port_mutex_give(port - 1);
 	return 1;
 }
@@ -80,8 +81,8 @@ int32_t imu_reset_blocking(uint8_t port) {
 			errno = EAGAIN;
 			return PROS_ERR;
 		}
-		device = device; // suppressing compiler warning
-	} while(!(vexDeviceImuStatusGet(device->device_info) & E_IMU_STATUS_CALIBRATING));
+		device = device;  // suppressing compiler warning
+	} while (!(vexDeviceImuStatusGet(device->device_info) & E_IMU_STATUS_CALIBRATING));
 	// same concept here, we add a blocking delay for the blocking version to wait
 	// until the IMU calibrating flag is cleared
 	do {
@@ -94,8 +95,8 @@ int32_t imu_reset_blocking(uint8_t port) {
 			errno = EAGAIN;
 			return PROS_ERR;
 		}
-		device = device; // suppressing compiler warning
-	} while(vexDeviceImuStatusGet(device->device_info) & E_IMU_STATUS_CALIBRATING);
+		device = device;  // suppressing compiler warning
+	} while (vexDeviceImuStatusGet(device->device_info) & E_IMU_STATUS_CALIBRATING);
 	port_mutex_give(port - 1);
 	return 1;
 }
@@ -118,16 +119,18 @@ int32_t imu_set_data_rate(uint8_t port, uint32_t rate) {
 double imu_get_rotation(uint8_t port) {
 	claim_port_f(port - 1, E_DEVICE_IMU);
 	ERROR_IMU_STILL_CALIBRATING(port, device, PROS_ERR_F);
-	double rtn = vexDeviceImuHeadingGet(device->device_info) + ((imu_data_s_t*)registry_get_device(port - 1)->pad)->rotation_offset;
+	double rtn = vexDeviceImuHeadingGet(device->device_info) +
+	             ((imu_data_s_t*)registry_get_device(port - 1)->pad)->rotation_offset;
 	return_port(port - 1, rtn);
 }
 
 double imu_get_heading(uint8_t port) {
 	claim_port_f(port - 1, E_DEVICE_IMU);
 	ERROR_IMU_STILL_CALIBRATING(port, device, PROS_ERR_F);
-	double rtn = vexDeviceImuDegreesGet(device->device_info) + ((imu_data_s_t*)registry_get_device(port - 1)->pad)->heading_offset;
+	double rtn =
+	    vexDeviceImuDegreesGet(device->device_info) + ((imu_data_s_t*)registry_get_device(port - 1)->pad)->heading_offset;
 	// Restricting value to raw boundaries
-	return_port(port - 1, fmod((rtn + IMU_HEADING_MAX), (double) IMU_HEADING_MAX));
+	return_port(port - 1, fmod((rtn + IMU_HEADING_MAX), (double)IMU_HEADING_MAX));
 }
 
 #define QUATERNION_ERR_INIT \
@@ -154,7 +157,7 @@ quaternion_s_t imu_get_quaternion(uint8_t port) {
 	double cp = cos(DEGTORAD * pitch * 0.5);
 	double sp = sin(DEGTORAD * pitch * 0.5);
 	double cr = cos(DEGTORAD * roll * 0.5);
-	double sr = sin(DEGTORAD * roll * 0.5); 
+	double sr = sin(DEGTORAD * roll * 0.5);
 
 	rtn.w = cr * cp * cy + sr * sp * sy;
 	rtn.x = sr * cp * cy - cr * sp * sy;
@@ -270,9 +273,9 @@ imu_status_e_t imu_get_status(uint8_t port) {
 	return_port(port - 1, rtn);
 }
 
-//Reset Functions:
-int32_t imu_tare(uint8_t port){
-    if (!claim_port_try(port - 1, E_DEVICE_IMU)) {
+// Reset Functions:
+int32_t imu_tare(uint8_t port) {
+	if (!claim_port_try(port - 1, E_DEVICE_IMU)) {
 		return PROS_ERR;
 	}
 	v5_smart_device_s_t* device = registry_get_device(port - 1);
@@ -287,33 +290,33 @@ int32_t imu_tare(uint8_t port){
 	return_port(port - 1, PROS_SUCCESS);
 }
 
-int32_t imu_tare_euler(uint8_t port){
-    return imu_set_euler(port, (euler_s_t){0,0,0});
+int32_t imu_tare_euler(uint8_t port) {
+	return imu_set_euler(port, (euler_s_t){0, 0, 0});
 }
 
-int32_t imu_tare_heading(uint8_t port){
-    return imu_set_heading(port, 0);
+int32_t imu_tare_heading(uint8_t port) {
+	return imu_set_heading(port, 0);
 }
 
-int32_t imu_tare_rotation(uint8_t port){
-    return imu_set_rotation(port, 0);
+int32_t imu_tare_rotation(uint8_t port) {
+	return imu_set_rotation(port, 0);
 }
 
-int32_t imu_tare_pitch(uint8_t port){
-    return imu_set_pitch(port, 0);
+int32_t imu_tare_pitch(uint8_t port) {
+	return imu_set_pitch(port, 0);
 }
 
-int32_t imu_tare_roll(uint8_t port){
-    return imu_set_roll(port, 0);
+int32_t imu_tare_roll(uint8_t port) {
+	return imu_set_roll(port, 0);
 }
 
-int32_t imu_tare_yaw(uint8_t port){
-    return imu_set_yaw(port, 0);
+int32_t imu_tare_yaw(uint8_t port) {
+	return imu_set_yaw(port, 0);
 }
 
-//Setter Functions:
-int32_t imu_set_rotation(uint8_t port, double target){
-    if (!claim_port_try(port - 1, E_DEVICE_IMU)) {
+// Setter Functions:
+int32_t imu_set_rotation(uint8_t port, double target) {
+	if (!claim_port_try(port - 1, E_DEVICE_IMU)) {
 		return PROS_ERR;
 	}
 	v5_smart_device_s_t* device = registry_get_device(port - 1);
@@ -325,8 +328,8 @@ int32_t imu_set_rotation(uint8_t port, double target){
 	return_port(port - 1, PROS_SUCCESS);
 }
 
-int32_t imu_set_heading(uint8_t port, double target){
-    if (!claim_port_try(port - 1, E_DEVICE_IMU)) {
+int32_t imu_set_heading(uint8_t port, double target) {
+	if (!claim_port_try(port - 1, E_DEVICE_IMU)) {
 		return PROS_ERR;
 	}
 	v5_smart_device_s_t* device = registry_get_device(port - 1);
@@ -340,8 +343,8 @@ int32_t imu_set_heading(uint8_t port, double target){
 	return_port(port - 1, PROS_SUCCESS);
 }
 
-int32_t imu_set_pitch(uint8_t port, double target){
-    if (!claim_port_try(port - 1, E_DEVICE_IMU)) {
+int32_t imu_set_pitch(uint8_t port, double target) {
+	if (!claim_port_try(port - 1, E_DEVICE_IMU)) {
 		return PROS_ERR;
 	}
 	v5_smart_device_s_t* device = registry_get_device(port - 1);
@@ -355,8 +358,8 @@ int32_t imu_set_pitch(uint8_t port, double target){
 	return_port(port - 1, PROS_SUCCESS);
 }
 
-int32_t imu_set_roll(uint8_t port, double target){
-    if (!claim_port_try(port - 1, E_DEVICE_IMU)) {
+int32_t imu_set_roll(uint8_t port, double target) {
+	if (!claim_port_try(port - 1, E_DEVICE_IMU)) {
 		return PROS_ERR;
 	}
 	v5_smart_device_s_t* device = registry_get_device(port - 1);
@@ -370,8 +373,8 @@ int32_t imu_set_roll(uint8_t port, double target){
 	return_port(port - 1, PROS_SUCCESS);
 }
 
-int32_t imu_set_yaw(uint8_t port, double target){
-    if (!claim_port_try(port - 1, E_DEVICE_IMU)) {
+int32_t imu_set_yaw(uint8_t port, double target) {
+	if (!claim_port_try(port - 1, E_DEVICE_IMU)) {
 		return PROS_ERR;
 	}
 	v5_smart_device_s_t* device = registry_get_device(port - 1);
@@ -385,7 +388,7 @@ int32_t imu_set_yaw(uint8_t port, double target){
 	return_port(port - 1, PROS_SUCCESS);
 }
 
-int32_t imu_set_euler(uint8_t port, euler_s_t target){
+int32_t imu_set_euler(uint8_t port, euler_s_t target) {
 	if (!claim_port_try(port - 1, E_DEVICE_IMU)) {
 		return PROS_ERR;
 	}
@@ -403,4 +406,8 @@ int32_t imu_set_euler(uint8_t port, euler_s_t target){
 	data->roll_offset = target.roll - euler_values.roll;
 	data->yaw_offset = target.yaw - euler_values.yaw;
 	return_port(port - 1, PROS_SUCCESS);
+}
+
+imu_orientation_e_t imu_get_orientation(uint8_t port) {
+	return imu_get_status(port) >> 1;
 }

--- a/src/devices/vdml_imu.c
+++ b/src/devices/vdml_imu.c
@@ -408,6 +408,6 @@ int32_t imu_set_euler(uint8_t port, euler_s_t target) {
 	return_port(port - 1, PROS_SUCCESS);
 }
 
-imu_orientation_e_t imu_get_orientation(uint8_t port) {
+imu_orientation_e_t imu_get_physical_orientation(uint8_t port) {
 	return (imu_get_status(port) >> 1) & 7;
 }

--- a/src/devices/vdml_imu.cpp
+++ b/src/devices/vdml_imu.cpp
@@ -117,8 +117,8 @@ std::int32_t Imu::set_euler(pros::c::euler_s_t target) const {
 std::int32_t Imu::tare() const {
 	return pros::c::imu_tare(_port);
 }
-pros::c::imu_orientation_e_t Imu::get_orientation() const {
-	return pros::c::imu_get_orientation(_port);
+pros::c::imu_orientation_e_t Imu::get_physical_orientation() const {
+	return pros::c::imu_get_physical_orientation(_port);
 }
 
 }  // namespace pros

--- a/src/devices/vdml_imu.cpp
+++ b/src/devices/vdml_imu.cpp
@@ -10,6 +10,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include "pros/imu.h"
 #include "pros/imu.hpp"
 
 namespace pros {
@@ -22,7 +23,7 @@ std::int32_t Imu::set_data_rate(std::uint32_t rate) const {
 }
 
 double Imu::get_rotation() const {
-    return pros::c::imu_get_rotation(_port);
+	return pros::c::imu_get_rotation(_port);
 }
 
 double Imu::get_heading() const {
@@ -62,7 +63,7 @@ pros::c::imu_status_e_t Imu::get_status() const {
 }
 
 bool Imu::is_calibrating() const {
-	return get_status() == pros::c::E_IMU_STATUS_CALIBRATING;
+	return get_status() & pros::c::E_IMU_STATUS_CALIBRATING;
 }
 
 std::int32_t Imu::tare_heading() const {
@@ -115,6 +116,9 @@ std::int32_t Imu::set_euler(pros::c::euler_s_t target) const {
 
 std::int32_t Imu::tare() const {
 	return pros::c::imu_tare(_port);
+}
+pros::c::imu_orientation_e_t Imu::get_orientation() const {
+	return pros::c::imu_get_orientation(_port);
 }
 
 }  // namespace pros


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
Fixes the issues with the IMU reset never returning
Adds functionality to get the Orientation of the IMU

#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
Currently on pros 3.8.2 IMU can only calibrate in the Z_DOWN orientation. The reset function is an infinite loop otherwise. 
Adds functionality to get the Physical Orientation of the IMU. 


#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [x] IMU can calibrate in all orientations
- [x] IMU can return the correct orientation from each orientation
