### PR TITLE
🐛Fixed Imu::is_calibrating and Imu::get_physical_orientation for PROS 3

### DIFF
--- a/include/pros/imu.h
+++ b/include/pros/imu.h
@@ -36,12 +36,14 @@ typedef enum imu_status_e {
 } imu_status_e_t;
 
 typedef enum imu_orientation_e {
-	E_IMU_Z_UP = 0,    // IMU has the Z axis UP (VEX Logo facing DOWN)
-	E_IMU_Z_DOWN = 1,  // IMU has the Z axis DOWN (VEX Logo facing UP)
-	E_IMU_X_UP = 2,    // IMU has the X axis UP
-	E_IMU_X_DOWN = 3,  // IMU has the X axis DOWN
-	E_IMU_Y_UP = 4,    // IMU has the Y axis UP
-	E_IMU_Y_DOWN = 5,  // IMU has the Y axis DOWN
+	E_IMU_Z_UP = 0,                 // IMU has the Z axis UP (VEX Logo facing DOWN)
+	E_IMU_Z_DOWN = 1,               // IMU has the Z axis DOWN (VEX Logo facing UP)
+	E_IMU_X_UP = 2,                 // IMU has the X axis UP
+	E_IMU_X_DOWN = 3,               // IMU has the X axis DOWN
+	E_IMU_Y_UP = 4,                 // IMU has the Y axis UP
+	E_IMU_Y_DOWN = 5,               // IMU has the Y axis DOWN
+	E_IMU_ORIENTATION_ERROR = 0xFF  // NOTE: used for returning an error from the get_physical_orientation function, not
+	                                // that the IMU is necessarily in an error state
 } imu_orientation_e_t;
 typedef struct __attribute__((__packed__)) quaternion_s {
 	double x;

--- a/src/devices/vdml_imu.c
+++ b/src/devices/vdml_imu.c
@@ -409,5 +409,9 @@ int32_t imu_set_euler(uint8_t port, euler_s_t target) {
 }
 
 imu_orientation_e_t imu_get_physical_orientation(uint8_t port) {
-	return (imu_get_status(port) >> 1) & 7;
+	imu_status_e_t status = imu_get_status(port);
+	if (status == E_IMU_STATUS_ERROR) {
+		return E_IMU_ORIENTATION_ERROR;
+	}
+	return (status >> 1) & 7;
 }

--- a/src/devices/vdml_imu.cpp
+++ b/src/devices/vdml_imu.cpp
@@ -63,7 +63,11 @@ pros::c::imu_status_e_t Imu::get_status() const {
 }
 
 bool Imu::is_calibrating() const {
-	return get_status() & pros::c::E_IMU_STATUS_CALIBRATING;
+	pros::c::imu_status_e_t status = get_status();
+	if (status == pros::c::E_IMU_STATUS_ERROR) {
+		return false;
+	}
+	return status & pros::c::E_IMU_STATUS_CALIBRATING;
 }
 
 std::int32_t Imu::tare_heading() const {


### PR DESCRIPTION
#### Summary:
Fixed Imu is_calibrating and get_physical_orientation to return proper outputs when IMU is unplugged.

#### Motivation:
Prevents issues where code thinks the IMU is connected incorrectly.

##### References (optional):
Closes #626

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->
- [ ] Tested functions on IMU that is not connected
- [ ] Tested is_calibrating on connected IMU but not calibrating
- [ ] Tested is_calibrating on connected IMU that is calibrating

