### PR TITLE
Pros4/feature/get devices vector

### DIFF
--- a/include/pros/abstract_motor.hpp
+++ b/include/pros/abstract_motor.hpp
@@ -94,25 +94,6 @@ class AbstractMotor {
 	 *
 	 * This is designed to map easily to the input from the controller's analog
 	 * stick for simple opcontrol use. The actual behavior of the motor is
-	 * analogous to use of pros::Motor::move().
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \param voltage
-	 *        The new motor voltage from -127 to 127
-	 *
-	 * \return 1 if the operation was successful or PROS_ERR if the operation
-	 * failed, setting errno.
-	 */
-	virtual std::int32_t operator=(std::int32_t voltage) const = 0;
-
-	/**
-	 * Sets the voltage for the motor from -127 to 127.
-	 *
-	 * This is designed to map easily to the input from the controller's analog
-	 * stick for simple opcontrol use. The actual behavior of the motor is
 	 * analogous to use of motor_move(), or motorSet() from the PROS 2 API.
 	 *
 	 * This function uses the following values of errno when an error state is

--- a/include/pros/device.hpp
+++ b/include/pros/device.hpp
@@ -90,7 +90,7 @@ class Device {
  	 * }
  	 * \endcode
 	 */
-	std::uint8_t get_port(void);
+	std::uint8_t get_port(void) const;
 
 	/**
 	 * Checks if the device is installed.
@@ -136,6 +136,8 @@ class Device {
  	 * \endcode
 	 */
 	pros::DeviceType get_plugged_type() const;
+
+	static pros::DeviceType get_plugged_type(std::uint8_t port);
 
 	static std::vector<Device> get_all_devices(pros::DeviceType device_type = pros::DeviceType::undefined);
 

--- a/include/pros/device.hpp
+++ b/include/pros/device.hpp
@@ -137,6 +137,9 @@ class Device {
 	 */
 	pros::DeviceType get_plugged_type() const;
 
+	template <typename T>
+	static std::vector<T> get_all_devices();
+
 
 	protected:
 	/**

--- a/include/pros/device.hpp
+++ b/include/pros/device.hpp
@@ -137,9 +137,7 @@ class Device {
 	 */
 	pros::DeviceType get_plugged_type() const;
 
-	template <typename T>
-	static std::vector<T> get_all_devices();
-
+	static std::vector<Device> get_all_devices(pros::DeviceType device_type = pros::DeviceType::undefined);
 
 	protected:
 	/**

--- a/include/pros/distance.hpp
+++ b/include/pros/distance.hpp
@@ -56,7 +56,10 @@ class Distance : public Device {
 	 * }
 	 * \endcode
 	 */
-	explicit Distance(const std::uint8_t port);
+	Distance(const std::uint8_t port);
+
+	Distance(const Device& device)
+		: Distance(device.get_port()) {};
 
 	/**
 	 * Get the currently measured distance from the sensor in mm
@@ -83,6 +86,8 @@ class Distance : public Device {
 	 * \endcode
 	 */
 	virtual std::int32_t get();
+
+	static std::vector<Distance> get_all_devices();
 
 	/**
 	 * Get the confidence in the distance reading

--- a/include/pros/gps.hpp
+++ b/include/pros/gps.hpp
@@ -59,7 +59,10 @@ class Gps : public Device {
 	 * \endcode
 	 *
 	 */
-	explicit Gps(const std::uint8_t port) : Device(port, DeviceType::gps){};
+	Gps(const std::uint8_t port) : Device(port, DeviceType::gps){};
+
+	Gps(const Device& device)
+		: Gps(device.get_port()) {};
 
 	/**
 	 * Creates a GPS object for the given port.
@@ -219,6 +222,8 @@ class Gps : public Device {
 	 * \endcode
 	 */
 	virtual std::int32_t set_offset(double xOffset, double yOffset) const;
+
+	static std::vector<Gps> get_all_devices();
 
 	/**
 	* Get the GPS's cartesian location relative to the center of turning/origin in meters.

--- a/include/pros/imu.hpp
+++ b/include/pros/imu.hpp
@@ -82,7 +82,10 @@ class Imu : public Device {
 	 * }
 	 * \endcode
 	 */
-	explicit Imu(const std::uint8_t port) : Device(port, DeviceType::imu) {};
+	Imu(const std::uint8_t port) : Device(port, DeviceType::imu) {};
+
+	Imu(const Device& device)
+		: Imu(device.get_port()) {};
 
 	/**
 	 * Calibrate IMU
@@ -164,6 +167,9 @@ class Imu : public Device {
 	 * \endcode
 	 */
 	virtual std::int32_t set_data_rate(std::uint32_t rate) const;
+
+	static std::vector<Imu> get_all_devices();
+
 	/**
 	 * Get the total number of degrees the Inertial Sensor has spun about the z-axis
 	 *

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -74,45 +74,8 @@ class Motor : public AbstractMotor, public Device {
 	Motor(const std::int8_t port, const pros::v5::MotorGears gearset = pros::v5::MotorGears::invalid,
 	               const pros::v5::MotorUnits encoder_units = pros::v5::MotorUnits::invalid);
 
-	
-
-	
-
-
-	/// \name Motor movement functions
-	/// These functions allow programmers to make motors move
-	///@{
-
-	/**
-	 * Sets the voltage for the motor from -128 to 127.
-	 *
-	 * This is designed to map easily to the input from the controller's analog
-	 * stick for simple opcontrol use. The actual behavior of the motor is
-	 * analogous to use of pros::Motor::move().
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 *
-	 * \param voltage
-	 *        The new motor voltage from -127 to 127
-	 *
-	 * \return 1 if the operation was successful or PROS_ERR if the operation
-	 * failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::Motor motor (1, E_MOTOR_GEARSET_18);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     motor = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::int32_t operator=(std::int32_t voltage) const;
+	Motor(const Device& device)
+		: Motor(device.get_port()) {};
 
 	/**
 	 * Sets the voltage for the motor from -127 to 127.
@@ -1522,6 +1485,8 @@ class Motor : public AbstractMotor, public Device {
 	 *  
 	 */
 	std::int8_t size(void) const;
+
+	static std::vector<Motor> get_all_devices();
 
 	/**
 	 * gets the port number of the motor

--- a/include/pros/optical.hpp
+++ b/include/pros/optical.hpp
@@ -54,7 +54,12 @@ class Optical : public Device {
 	 * pros::Optical optical(1);
 	 * \endcode
 	 */
-	explicit Optical(const std::uint8_t port);
+	Optical(const std::uint8_t port);
+
+	Optical(const Device& device)
+		: Optical(device.get_port()) {};
+
+	static std::vector<Optical> get_all_devices();
 
 	/**
 	 * Get the detected color hue

--- a/include/pros/rotation.hpp
+++ b/include/pros/rotation.hpp
@@ -53,7 +53,10 @@ class Rotation : public Device {
  	 * }
  	 * \endcode
 	*/
-	explicit Rotation(const std::int8_t port);
+	Rotation(const std::int8_t port);
+
+	Rotation(const Device& device)
+		: Rotation(device.get_port()) {};
 
 	/**
 	 * Reset the Rotation Sensor

--- a/include/pros/vision.hpp
+++ b/include/pros/vision.hpp
@@ -56,7 +56,10 @@ class Vision : public Device {
 	 * }
 	 * \endcode
 	 */
-	explicit Vision(std::uint8_t port, vision_zero_e_t zero_point = E_VISION_ZERO_TOPLEFT);
+	Vision(std::uint8_t port, vision_zero_e_t zero_point = E_VISION_ZERO_TOPLEFT);
+
+	Vision(const Device& device)
+		: Vision(device.get_port()) {};
 
 	/**
 	 * Clears the vision sensor LED color, reseting it back to its default
@@ -167,6 +170,8 @@ class Vision : public Device {
 	vision_color_code_t create_color_code(const std::uint32_t sig_id1, const std::uint32_t sig_id2,
 	                                      const std::uint32_t sig_id3 = 0, const std::uint32_t sig_id4 = 0,
 	                                      const std::uint32_t sig_id5 = 0) const;
+
+	static std::vector<Vision> get_all_devices();
 
 	/**
 	 * Gets the nth largest object according to size_id.

--- a/src/devices/vdml_device.cpp
+++ b/src/devices/vdml_device.cpp
@@ -42,6 +42,48 @@ pros::DeviceType Device::get_plugged_type() const {
 	return_port(_port - 1, type);
 }
 
+template <typename T>
+std::vector<T> Device::get_all_devices() {
+	DeviceType device_type {};
+
+	if(std::is_same<T,Motor>::value)
+		device_type = DeviceType::motor;
+	else if (std::is_same<T,Rotation>::value)
+		device_type = DeviceType::motor;
+	else if (std::is_same<T,IMU>::value)
+		device_type = DeviceType::imu;
+	else if (std::is_same<T,Distance>::value)
+		device_type = DeviceType::distance;
+	else if (std::is_same<T,Vision>::value)
+		device_type = DeviceType::vision;
+	else if (std::is_same<T,Optical>::value)
+		device_type = DeviceType::optical;
+	else if (std::is_same<T,Gps>::value)
+		device_type = DeviceType::gps;
+	else if (std::is_same<T,Serial>::value)
+		device_type = DeviceType::serial;
+	else
+		device_type = DeviceType::undefined;
+
+	std::vector<T> device_list {};
+
+	for (std::uint8_t curr_port = 0; curr_port < 21; ++curr_port) {
+		if (!port_mutex_take(curr_port)) {                            
+			errno = EACCES;
+			continue;
+		}
+
+        DeviceType type = (DeviceType) c::registry_get_plugged_type(curr_port);
+		if (device_type == type) {
+			device_list.push_back(T {curr_port});
+		}
+
+		return_port(curr_port, type);
+	}
+
+	return device_list;
+}
+
 Device::Device(const std::uint8_t port) : _port(port) {}
 
 

--- a/src/devices/vdml_device.cpp
+++ b/src/devices/vdml_device.cpp
@@ -28,18 +28,22 @@ bool Device::is_installed() {
 	return_port(zero_indexed_port, _deviceType == plugged_device_type);
 }
 
-std::uint8_t Device::get_port(void) {
+std::uint8_t Device::get_port(void) const {
 	return _port;
 }
 
 pros::DeviceType Device::get_plugged_type() const {
-	if (!port_mutex_take(_port - 1)) {                            
+	return(get_plugged_type(_port));
+}
+
+pros::DeviceType Device::get_plugged_type(std::uint8_t port) {
+	if (!port_mutex_take(port - 1)) {                            
 		errno = EACCES; 
 		return DeviceType::undefined;                                                                           
 	}
-	DeviceType type = (DeviceType) pros::c::registry_get_plugged_type(_port - 1);
+	DeviceType type = (DeviceType) pros::c::registry_get_plugged_type(port - 1);
 	
-	return_port(_port - 1, type);
+	return_port(port - 1, type);
 }
 
 std::vector<Device> Device::get_all_devices(pros::DeviceType device_type) {
@@ -52,8 +56,8 @@ std::vector<Device> Device::get_all_devices(pros::DeviceType device_type) {
 		}
 
 		pros::DeviceType type = (DeviceType) pros::c::registry_get_plugged_type(curr_port);
-		if (device_type == type) {
-			device_list.push_back(Device {curr_port});
+		if (device_type == type) {;
+			device_list.push_back(Device {static_cast<std::uint8_t>(curr_port + 1)});
 		}
 		port_mutex_give(curr_port);
 	}

--- a/src/devices/vdml_device.cpp
+++ b/src/devices/vdml_device.cpp
@@ -42,30 +42,8 @@ pros::DeviceType Device::get_plugged_type() const {
 	return_port(_port - 1, type);
 }
 
-template <typename T>
-std::vector<T> Device::get_all_devices() {
-	DeviceType device_type {};
-
-	if(std::is_same<T,Motor>::value)
-		device_type = DeviceType::motor;
-	else if (std::is_same<T,Rotation>::value)
-		device_type = DeviceType::motor;
-	else if (std::is_same<T,IMU>::value)
-		device_type = DeviceType::imu;
-	else if (std::is_same<T,Distance>::value)
-		device_type = DeviceType::distance;
-	else if (std::is_same<T,Vision>::value)
-		device_type = DeviceType::vision;
-	else if (std::is_same<T,Optical>::value)
-		device_type = DeviceType::optical;
-	else if (std::is_same<T,Gps>::value)
-		device_type = DeviceType::gps;
-	else if (std::is_same<T,Serial>::value)
-		device_type = DeviceType::serial;
-	else
-		device_type = DeviceType::undefined;
-
-	std::vector<T> device_list {};
+std::vector<Device> Device::get_all_devices(pros::DeviceType device_type) {
+	std::vector<Device> device_list {};
 
 	for (std::uint8_t curr_port = 0; curr_port < 21; ++curr_port) {
 		if (!port_mutex_take(curr_port)) {                            
@@ -73,14 +51,12 @@ std::vector<T> Device::get_all_devices() {
 			continue;
 		}
 
-        DeviceType type = (DeviceType) c::registry_get_plugged_type(curr_port);
+		pros::DeviceType type = (DeviceType) pros::c::registry_get_plugged_type(curr_port);
 		if (device_type == type) {
-			device_list.push_back(T {curr_port});
+			device_list.push_back(Device {curr_port});
 		}
-
-		return_port(curr_port, type);
+		port_mutex_give(curr_port);
 	}
-
 	return device_list;
 }
 

--- a/src/devices/vdml_distance.cpp
+++ b/src/devices/vdml_distance.cpp
@@ -22,6 +22,15 @@ std::int32_t Distance::get() {
 	return pros::c::distance_get(_port);
 }
 
+std::vector<Distance> Distance::get_all_devices() {
+	std::vector<Device> matching_devices {Device::get_all_devices(DeviceType::distance)};
+	std::vector<Distance> return_vector;
+	for (auto device : matching_devices) {
+		return_vector.push_back(device);
+	}
+	return return_vector;
+}
+
 std::int32_t Distance::get_confidence() {
 	return pros::c::distance_get_confidence(_port);
 }

--- a/src/devices/vdml_gps.cpp
+++ b/src/devices/vdml_gps.cpp
@@ -37,6 +37,16 @@ std::int32_t Gps::set_data_rate(std::uint32_t rate) const {
 	return pros::c::gps_set_data_rate(_port, rate);
 }
 
+std::vector<Gps> Gps::get_all_devices() {
+	std::vector<Device> matching_devices {Device::get_all_devices(DeviceType::gps)};
+	std::vector<Gps> return_vector;
+	for (auto device : matching_devices) {
+		return_vector.push_back(device);
+	}
+	return return_vector;
+}
+
+
 double Gps::get_error() const {
 	return pros::c::gps_get_error(_port);
 }

--- a/src/devices/vdml_imu.cpp
+++ b/src/devices/vdml_imu.cpp
@@ -24,6 +24,15 @@ std::int32_t Imu::set_data_rate(std::uint32_t rate) const {
 	return pros::c::imu_set_data_rate(_port, rate);
 }
 
+std::vector<Imu> Imu::get_all_devices() {
+	std::vector<Device> matching_devices {Device::get_all_devices(DeviceType::gps)};
+	std::vector<Imu> return_vector;
+	for (auto device : matching_devices) {
+		return_vector.push_back(device);
+	}
+	return return_vector;
+}
+
 double Imu::get_rotation() const {
 	return pros::c::imu_get_rotation(_port);
 }

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -29,10 +29,6 @@ Motor::Motor(const std::int8_t port, const pros::v5::MotorGears gearset, const p
 	}
 }
 
-std::int32_t Motor::operator=(std::int32_t voltage) const {
-	return motor_move(_port, voltage);
-}
-
 std::int32_t Motor::move(std::int32_t voltage) const {
 	return motor_move(_port, voltage);
 
@@ -355,11 +351,22 @@ std::int32_t Motor::get_voltage_limit(const std::uint8_t index) const {
 	}
 	return motor_get_voltage_limit(_port);
 }
+
 std::vector<std::int32_t> Motor::get_voltage_limit_all(void) const {
 	std::vector<std::int32_t> return_vector;
 	return_vector.push_back(motor_get_voltage_limit(_port));
 	return return_vector;
 }
+
+std::vector<Motor> Motor::get_all_devices() {
+	std::vector<Device> matching_devices {Device::get_all_devices(DeviceType::motor)};
+	std::vector<Motor> return_vector;
+	for (auto device : matching_devices) {
+		return_vector.push_back(device);
+	}
+	return return_vector;
+}
+
 std::int8_t Motor::get_port(const std::uint8_t index) const {
 	if (index != 0) {
 		errno = EOVERFLOW;

--- a/src/devices/vdml_optical.cpp
+++ b/src/devices/vdml_optical.cpp
@@ -19,6 +19,15 @@ using namespace pros::c;
 
 Optical::Optical(std::uint8_t port) : Device(port, DeviceType::optical) {}
 
+std::vector<Optical> Optical::get_all_devices() {
+	std::vector<Device> matching_devices {Device::get_all_devices(DeviceType::optical)};
+	std::vector<Optical> return_vector;
+	for (auto device : matching_devices) {
+		return_vector.push_back(device);
+	}
+	return return_vector;
+}
+
 double Optical::get_hue(){
   return optical_get_hue(_port);
 }

--- a/src/devices/vdml_vision.cpp
+++ b/src/devices/vdml_vision.cpp
@@ -39,6 +39,15 @@ vision_color_code_t Vision::create_color_code(const std::uint32_t sig_id1, const
 	return vision_create_color_code(_port, sig_id1, sig_id2, sig_id3, sig_id4, sig_id5);
 }
 
+std::vector<Vision> Vision::get_all_devices() {
+	std::vector<Device> matching_devices {Device::get_all_devices(DeviceType::vision)};
+	std::vector<Vision> return_vector;
+	for (auto device : matching_devices) {
+		return_vector.push_back(device);
+	}
+	return return_vector;
+}
+
 vision_object_s_t Vision::get_by_size(const std::uint32_t size_id) const {
 	return vision_get_by_size(_port, size_id);
 }


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
- Gave critical device classes the get_all_devices() static class functions which returns a vector of that class' objects (e.g. Motor, Imu, etc.)
- Removed equals operator for motor movement assignment
- Removed explicit from device constructors
- Created static version of get_plugged_type() that takes in a port number

#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
- The function get_all_devices() can be used in the automatic setup of devices for users.
- get_plugged_type() having a static overload allows for the checking of device types before creating devices

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
Did lab testing for the new functions (but didn't get a chance to check for all devices)