### PR TITLE
🐛Remove = operator overload from motor groups

### DIFF
--- a/include/pros/motor_group.hpp
+++ b/include/pros/motor_group.hpp
@@ -40,141 +40,109 @@ class MotorGroup : public virtual AbstractMotor {
 	 *  @{
 	 */
 	public:
-
 	/**
 	 * Constructs a new MotorGroup object.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
- 	 * reached:
- 	 * ENXIO - The given value is not within the range of V5 ports |1-21|.
- 	 * ENODEV - The port cannot be configured as a motor
-	 * 
+	 * reached:
+	 * ENXIO - The given value is not within the range of V5 ports |1-21|.
+	 * ENODEV - The port cannot be configured as a motor
+	 *
 	 * \param port
- 	 *        A initializer list of V5 port numbers from 1 to 21, or from -21 to -1 for reversed motors. 
+	 *        A initializer list of V5 port numbers from 1 to 21, or from -21 to -1 for reversed motors.
 	 * 		  A reversed motor will reverse the input or output movement functions and movement related
 	 * 		  telemetry in order to produce consistant behavior with non-reversed motors
-	 * 
+	 *
 	 * \param gearset =  pros::v5::MotorGears::invalid
 	 * 		  Optional parameter for the gearset for the motor.
 	 * 		  Does not explicitly set the motor gearset if it is invalid or not specified
-	 * 
+	 *
 	 * \param encoder_units = pros::v5::MotorUnits::invalid
 	 * 		  Optional parameter for the encoder units of the motor
 	 * 		  Does not explicitly set the motor units if it is invalid or not specified
-	 * 
+	 *
 	 *  \b Example
- 	 * \code
- 	 * void opcontrol() {
-	 * 	MotorGroup first_mg({1, -2}); //Creates a motor on port 1  and a reversed motor on port 2 
+	 * \code
+	 * void opcontrol() {
+	 * 	MotorGroup first_mg({1, -2}); //Creates a motor on port 1  and a reversed motor on port 2
 	 *  MotorGroup rotations_mg({4, 5}, pros::v5::MotorGears::blue, pros::v5::MotorUnits::rotations);
- 	 *  //Creates a motor group on ports 4 and 5 with blue motors using rotaions as the encoder units
- 	 * }
+	 *  //Creates a motor group on ports 4 and 5 with blue motors using rotaions as the encoder units
+	 * }
 	 * \endcode
 	 */
-	MotorGroup(const std::initializer_list<std::int8_t>, const pros::v5::MotorGears gearset = pros::v5::MotorGears::invalid,
-	                    const pros::v5::MotorUnits encoder_units = pros::v5::MotorUnits::invalid);
+	MotorGroup(const std::initializer_list<std::int8_t>,
+	           const pros::v5::MotorGears gearset = pros::v5::MotorGears::invalid,
+	           const pros::v5::MotorUnits encoder_units = pros::v5::MotorUnits::invalid);
 	/**
 	 * Constructs a new MotorGroup object.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
- 	 * reached:
- 	 * 
+	 * reached:
+	 *
 	 * ENXIO - The given value is not within the range of V5 ports |1-21|.
- 	 * 
+	 *
 	 * ENODEV - The port cannot be configured as a motor
-	 * 
+	 *
 	 * EDOM - The motor group is empty
-	 * 
+	 *
 	 * \param port
- 	 *        A initializer list of V5 port numbers from 1 to 21, or from -21 to -1 for reversed motors. 
+	 *        A initializer list of V5 port numbers from 1 to 21, or from -21 to -1 for reversed motors.
 	 * 		  A reversed motor will reverse the input or output movement functions and movement related
 	 * 		  telemetry in order to produce consistant behavior with non-reversed motors
-	 * 
+	 *
 	 * \param gearset =  pros::v5::MotorGears::invalid
 	 * 		  Optional parameter for the gearset for the motor.
 	 * 		  Does not explicitly set the motor gearset if it is invalid or not specified
-	 * 
+	 *
 	 * \param encoder_units = pros::v5::MotorUnits::invalid
 	 * 		  Optional parameter for the encoder units of the motor
 	 * 		  Does not explicitly set the motor units if it is invalid or not specified
-	 * 
+	 *
 	 *  \b Example
- 	 * \code
- 	 * void opcontrol() {
-	 * 	MotorGroup first_mg({1, -2}); //Creates a motor on port 1  and a reversed motor on port 2 with 
+	 * \code
+	 * void opcontrol() {
+	 * 	MotorGroup first_mg({1, -2}); //Creates a motor on port 1  and a reversed motor on port 2 with
 	 *  with both motors using the green gearset and degrees as the encoder units
 	 *  MotorGroup rotations_mg({4, 5}, pros::v5::MotorGears::blue, pros::v5::MotorUnits::rotations);
- 	 *  //Creates a motor group on ports 4 and 5 with blue motors using rotaions as the encoder units
- 	 * }
+	 *  //Creates a motor group on ports 4 and 5 with blue motors using rotaions as the encoder units
+	 * }
 	 * \endcode
 	 */
 	MotorGroup(const std::vector<std::int8_t>& ports, const pros::v5::MotorGears gearset = pros::v5::MotorGears::invalid,
-	                    const pros::v5::MotorUnits encoder_units = pros::v5::MotorUnits::invalid);
+	           const pros::v5::MotorUnits encoder_units = pros::v5::MotorUnits::invalid);
 
-	 /**
+	/**
 	 * Constructs a new MotorGroup object from an abstract motor.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
- 	 * reached:
- 	 * 
+	 * reached:
+	 *
 	 * ENXIO - The given value is not within the range of V5 ports |1-21|.
- 	 * 
+	 *
 	 * ENODEV - The port cannot be configured as a motor
-	 * 
+	 *
 	 * EDOM - The motor group is empty
-	 * 
+	 *
 	 * \param abstract_motor
 	 * 		  THe abstract motor to turn into a motor group
 	 * 		  Uses abstract_motor.get_port_all() to get the vector of ports
-	 * 
-	 * 
+	 *
+	 *
 	 *  \b Example
- 	 * \code
- 	 * void opcontrol() {
-	 * 	MotorGroup first_mg({1, -2}); //Creates a motor on port 1  and a reversed motor on port 2 with 
+	 * \code
+	 * void opcontrol() {
+	 * 	MotorGroup first_mg({1, -2}); //Creates a motor on port 1  and a reversed motor on port 2 with
 	 *  with both motors using the green gearset and degrees as the encoder units
 	 * 	AbstractMotor abs_mtr_group = first_mg;
 	 * 	MotorGroup new_mg = (MotorGroup) abs_mtr_group;
- 	 * }
+	 * }
 	 * \endcode
 	 */
-	
+
 	MotorGroup(MotorGroup& motor_group);
 	/// \name Motor movement functions
 	/// These functions allow programmers to make motors move
 	///@{
-
-	/**
-	 * Sets the voltage for the motor group from -128 to 127.
-	 *
-	 * This is designed to map easily to the input from the controller's analog
-	 * stick for simple opcontrol use. The actual behavior of the motor is
-	 * analogous to use of pros::Motor::move()
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENODEV - The port cannot be configured as a motor
-	 * EDOM - the motor group is empty
-	 * 
-	 * \param voltage
-	 *        The new voltage from -127 to 127
-	 *
-	 * \return 1 if the operation was successful or PROS_ERR if the operation
-	 * failed, setting errno.
-	 *
-	 * \b Example
-	 * \code
-	 * void opcontrol() {
-	 *   pros::MotorGroup MotorGroup ({1,3}, E_MOTOR_GEARSET_18);
-	 *   pros::Controller master (E_CONTROLLER_MASTER);
-	 *   while (true) {
-	 *     mg = master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y);
-	 *     pros::delay(2);
-	 *   }
-	 * }
-	 * \endcode
-	 */
-	std::int32_t operator=(std::int32_t voltage) const;
 
 	/**
 	 * Sets the voltage for the motor group from -127 to 127.
@@ -353,10 +321,9 @@ class MotorGroup : public virtual AbstractMotor {
 	 */
 	std::int32_t move_voltage(const std::int32_t voltage) const;
 
-
 	/**
 	 * Stops the motor group using the currently configured brake mode.
-	 * 
+	 *
 	 * This function sets motor velocity to zero, which will cause it to act
 	 * according to the set brake mode. If brake mode is set to MOTOR_BRAKE_HOLD,
 	 * this function may behave differently than calling move_absolute(0)
@@ -365,22 +332,22 @@ class MotorGroup : public virtual AbstractMotor {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
-	 * 
+	 *
 	 * EDOM - The motor group is empty
-	* 
-	* \return 1 if the operation was successful or PROS_ERR if the operation
-	* failed, setting errno.
-	* 
-	* \b Example
-	* \code 
-	*  void autonomous() {
-	*	Motor motor(1);
-	*   mg.move_voltage(12000);
-	*   pros::delay(1000); // Move at max voltage for 1 second
-	*   motor.brake();
-	* }
-	* \endcode
-	*/
+	 *
+	 * \return 1 if the operation was successful or PROS_ERR if the operation
+	 * failed, setting errno.
+	 *
+	 * \b Example
+	 * \code
+	 *  void autonomous() {
+	 *	Motor motor(1);
+	 *   mg.move_voltage(12000);
+	 *   pros::delay(1000); // Move at max voltage for 1 second
+	 *   motor.brake();
+	 * }
+	 * \endcode
+	 */
 	std::int32_t brake(void) const;
 
 	/**
@@ -399,7 +366,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * void autonomous() {
@@ -411,7 +378,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * \endcode
 	 */
 	std::int32_t modify_profiled_velocity(const std::int32_t velocity) const;
-	
+
 	/**
 	 * Gets the target position set for a motor in the motor group, with a parameter
 	 * for the motor index.
@@ -421,7 +388,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
+	 *
 	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
@@ -467,16 +434,16 @@ class MotorGroup : public virtual AbstractMotor {
 
 	/**
 	 * Gets the velocity commanded to the motor by the user at the index specified.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
 	 * EDOM - The motor group was empty
-	 * 
-	 * \param index Optional parameter. 
+	 *
+	 * \param index Optional parameter.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
+	 *
 	 * \return The commanded motor velocity from +-100, +-200, or +-600, or
 	 * PROS_ERR if the operation failed, setting errno.
 	 *
@@ -488,7 +455,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 *   while (true) {
 	 *     mg.move_velocity(master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y));
 	 * 		// get the target velocity from motor at index 1. (port 3)
-	 *     std::cout << "Motor Velocity: " << mg.get_target_velocity(1); 
+	 *     std::cout << "Motor Velocity: " << mg.get_target_velocity(1);
 	 *     pros::delay(2);
 	 *   }
 	 * }
@@ -498,12 +465,12 @@ class MotorGroup : public virtual AbstractMotor {
 
 	/**
 	 * Gets a vector of the velocity commanded to the motor by the user
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - THe motor group is empty
-	 * 
+	 *
 	 * \return A vector of the commanded motor velocity from +-100, +-200, or +-600, or
 	 * PROS_ERR if the operation failed, setting errno.
 	 *
@@ -514,7 +481,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 *   pros::Controller master (E_CONTROLLER_MASTER);
 	 *   while (true) {
 	 *     mg.move_velocity(master.get_analog(E_CONTROLLER_ANALOG_LEFT_Y));
-	 *     std::cout << "Motor Velocity: " << mg.get_target_velocity_all(); 
+	 *     std::cout << "Motor Velocity: " << mg.get_target_velocity_all();
 	 *     pros::delay(2);
 	 *   }
 	 * }
@@ -534,13 +501,13 @@ class MotorGroup : public virtual AbstractMotor {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
-	 * 
+	 *
 	 * EDOM - THe motor group is empty
 	 *
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
-	 * \param index Optional parameter. 
-	 * 				The zero indexed index of the motor in the motor group 
+	 *
+	 * \param index Optional parameter.
+	 * 				The zero indexed index of the motor in the motor group
 	 *
 	 * \return The motor's actual velocity in RPM or PROS_ERR_F if the operation
 	 * failed, setting errno.
@@ -559,14 +526,14 @@ class MotorGroup : public virtual AbstractMotor {
 	 * \endcode
 	 */
 	double get_actual_velocity(const std::uint8_t index = 0) const;
-	
+
 	/**
 	 * Gets a vector of the the actual velocity of each motor the motor group.
 	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
-	 * 
+	 *
 	 * EDOM - THe motor group is empty
 	 *
 	 * \return A vector of the each motor's actual velocity in RPM or PROS_ERR_F if the operation
@@ -593,13 +560,13 @@ class MotorGroup : public virtual AbstractMotor {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
-	 *  
+	 *
 	 * EDOM - The motor group is empty
 	 *
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
-	 * \param index Optional parameter. 
-	 * 				The zero indexed index of the motor in the motor group 
+	 *
+	 * \param index Optional parameter.
+	 * 				The zero indexed index of the motor in the motor group
 	 *
 	 * \return The motor's current in mA or PROS_ERR if the operation failed,
 	 * setting errno.
@@ -625,7 +592,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
-	 *  
+	 *
 	 * EDOM - The motor group is empty
 	 *
 	 *
@@ -653,14 +620,14 @@ class MotorGroup : public virtual AbstractMotor {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
-	 * 
+	 *
 	 * EDOM - The motor group is empty
-	 * 
+	 *
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
+	 *
 	 * \return 1 for moving in the positive direction, -1 for moving in the
 	 * negative direction, and PROS_ERR if the operation failed, setting errno.
 	 *
@@ -687,7 +654,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 *
 	 * EDOM - The motor group is empty
-	 * 
+	 *
 	 * \return 1 for moving in the positive direction, -1 for moving in the
 	 * negative direction, and PROS_ERR if the operation failed, setting errno.
 	 *
@@ -716,12 +683,12 @@ class MotorGroup : public virtual AbstractMotor {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
-	 * 
+	 *
 	 * EDOM - The motor group is empty
-	 * 
+	 *
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
-	 * 
+	 *
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
 	 *
@@ -753,7 +720,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
-	 * 
+	 *
 	 * EDOM - THe motor group is empty
 	 *
 	 * \return A vector containing each motor's efficiency in percent or PROS_ERR_F if the operation
@@ -782,9 +749,9 @@ class MotorGroup : public virtual AbstractMotor {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
-	 * 
+	 *
 	 * EDOM - The motor group is empty
-	 * 
+	 *
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
 	 *
 	 * \param index Optional parameter, 0 by default.
@@ -814,9 +781,9 @@ class MotorGroup : public virtual AbstractMotor {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
-	 * 
+	 *
 	 * EDOM - The motor group is empty
-	 * 
+	 *
 	 *
 	 * \return A vector containing the bitfields containing each motor's faults.
 	 *
@@ -864,7 +831,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * \endcode
 	 */
 	std::uint32_t get_flags(const std::uint8_t index = 0) const;
-	
+
 	/**
 	 * Gets a vector of the flags set by each motor in the motor groups's operation.
 	 *
@@ -900,7 +867,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
 	 *
@@ -955,7 +922,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
 	 *
@@ -1009,13 +976,13 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
-	 * 
+	 *
+	 *
 	 * \param timestamp
 	 *            A pointer to a time in milliseconds for which the encoder count
 	 *            will be returned. If NULL, the timestamp at which the encoder
 	 *            count was read will not be supplied
-	 * 
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
 	 *
@@ -1079,7 +1046,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
+	 *
 	 * \return The motor's temperature in degrees Celsius or PROS_ERR_F if the
 	 * operation failed, setting errno.
 	 *
@@ -1133,7 +1100,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
+	 *
 	 * \return The motor's torque in Nm or PROS_ERR_F if the operation failed,
 	 * setting errno.
 	 *
@@ -1184,10 +1151,10 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
+	 *
 	 * \return The motor's voltage in mV or PROS_ERR_F if the operation failed,
 	 * setting errno.
 	 *
@@ -1239,10 +1206,10 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
+	 *
 	 * \return 1 if the motor's current limit is being exceeded and 0 if the
 	 * current limit is not exceeded, or PROS_ERR if the operation failed, setting
 	 * errno.
@@ -1269,9 +1236,8 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 *
-	 * \return A vector containing the following for each motor: 1 if the motor's current limit is being exceeded and 0 if the
-	 * current limit is not exceeded, or PROS_ERR if the operation failed, setting
-	 * errno.
+	 * \return A vector containing the following for each motor: 1 if the motor's current limit is being exceeded and 0 if
+	 * the current limit is not exceeded, or PROS_ERR if the operation failed, setting errno.
 	 *
 	 * \b Example
 	 * \code
@@ -1296,7 +1262,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
 	 *
@@ -1357,7 +1323,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
 	 *
@@ -1406,7 +1372,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
 	 *
@@ -1425,7 +1391,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * \endcode
 	 */
 	std::int32_t get_current_limit(const std::uint8_t index = 0) const;
-	
+
 	/**
 	 * Gets a vector of the current limit for each motor in the motor group in mA.
 	 *
@@ -1460,10 +1426,10 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
+	 *
 	 * \return One of Motor_Units according to what is set for the
 	 * motor or E_MOTOR_ENCODER_INVALID if the operation failed.
 	 *
@@ -1476,7 +1442,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * \endcode
 	 */
 	MotorUnits get_encoder_units(const std::uint8_t index = 0) const;
-	
+
 	/**
 	 * Gets a vector of the encoder units that were set for each motor in the motor group.
 	 *
@@ -1506,10 +1472,10 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
+	 *
 	 *\param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
+	 *
 	 * \return One of Motor_Gears according to what is set for the motor,
 	 * or pros::Motor_Gears::invalid if the operation failed.
 	 *
@@ -1530,7 +1496,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 *
-	 * 
+	 *
 	 * \return A vector with one of Motor_Gears according to what is set for the motor,
 	 * or pros::Motor_Gears::invalid if the operation failed for each motor.
 	 *
@@ -1547,7 +1513,7 @@ class MotorGroup : public virtual AbstractMotor {
 	/**
 	 * Gets a vector with all the port numbers in the motor group.
 	 * A port will be negative if the motor in the motor group is reversed
-	 * 
+	 *
 	 * @return a vector with all the port numbers for the motor group
 	 */
 	std::vector<std::int8_t> get_port_all(void) const;
@@ -1563,7 +1529,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
+	 *
 	 *\param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
 	 *
@@ -1581,7 +1547,7 @@ class MotorGroup : public virtual AbstractMotor {
 	std::int32_t get_voltage_limit(const std::uint8_t index = 0) const;
 
 	/**
-	 * Gets a vector of the voltage limit of each motor in the motor group 
+	 * Gets a vector of the voltage limit of each motor in the motor group
 	 *
 	 * Default value is 0V, which means that there is no software limitation
 	 * imposed on the voltage.
@@ -1609,10 +1575,10 @@ class MotorGroup : public virtual AbstractMotor {
 	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
-	 * 
+	 *
 	 * EDOM - The motor group is empty
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
+	 *
 	 *\param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
 	 *
@@ -1636,8 +1602,8 @@ class MotorGroup : public virtual AbstractMotor {
 	 * reached:
 	 * EDOM - The motor group is empty
 	 *
-	 * \return A vector conatining the following for each motor: 1 if the motor has been reversed and 0 if the motor was not
-	 * reversed, or PROS_ERR if the operation failed, setting errno.
+	 * \return A vector conatining the following for each motor: 1 if the motor has been reversed and 0 if the motor was
+	 * not reversed, or PROS_ERR if the operation failed, setting errno.
 	 *
 	 * \b Example
 	 * \code
@@ -1659,13 +1625,13 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
+	 *
 	 * \param mode
 	 *        The Motor_Brake to set for the motor
-	 * 
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
+	 *
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
@@ -1689,13 +1655,13 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
-	 * 
+	 *
 	 * \param mode
 	 *        The Motor_Brake to set for the motor
-	 * 
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
+	 *
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
@@ -1718,10 +1684,10 @@ class MotorGroup : public virtual AbstractMotor {
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
-	 * 
+	 *
 	 * \param mode
 	 *        The Motor_Brake to set for the motor
-	 * 
+	 *
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
@@ -1744,11 +1710,11 @@ class MotorGroup : public virtual AbstractMotor {
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
-	 * 
+	 *
 	 * \param mode
 	 *        The Motor_Brake to set for the motor
 	 *
-	 * 
+	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 *
@@ -1773,11 +1739,11 @@ class MotorGroup : public virtual AbstractMotor {
 	 *
 	 * \param limit
 	 *        The new current limit in mA
-	 * 
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
-	 * 
+	 *
+	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 *
@@ -1835,13 +1801,13 @@ class MotorGroup : public virtual AbstractMotor {
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
-	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size() 
+	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
 	 *
 	 * \param units
 	 *        The new motor encoder units
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
+	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 *
@@ -1863,13 +1829,13 @@ class MotorGroup : public virtual AbstractMotor {
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
-	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size() 
+	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
 	 *
 	 * \param units
 	 *        The new motor encoder units
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
+	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 *
@@ -1890,11 +1856,11 @@ class MotorGroup : public virtual AbstractMotor {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
-	 * EDOM - The motor group is empty 
+	 * EDOM - The motor group is empty
 	 *
 	 * \param units
 	 *        The new motor encoder units
-	 * 
+	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 *
@@ -1915,11 +1881,11 @@ class MotorGroup : public virtual AbstractMotor {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
-	 * EDOM - The motor group is empty 
+	 * EDOM - The motor group is empty
 	 *
 	 * \param units
 	 *        The new motor encoder units
-	 * 
+	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 *
@@ -1933,7 +1899,6 @@ class MotorGroup : public virtual AbstractMotor {
 	 * \endcode
 	 */
 	std::int32_t set_encoder_units_all(const pros::motor_encoder_units_e_t units) const;
-	
 
 	/**
 	 * Sets one of the gear cartridge (red, green, blue) for one motor in the motor group. Usable with
@@ -1944,19 +1909,19 @@ class MotorGroup : public virtual AbstractMotor {
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
 	 * E2BIG - The size of the vector mismatches the number of motors in the motor group
-	 * 
-	 * \note If there are more motors than gearsets passed in, 
+	 *
+	 * \note If there are more motors than gearsets passed in,
 	 * 	only the first n motors will have their gearsets changed where n is the number of gearsets passed in.
-	 *  If there are more gearsets passed in than motors, then the only the first m gearsets will be used, 
-	 *  where m is the number of motors. In either case, errno will be set to E2BIG, but the operation still occurs 
+	 *  If there are more gearsets passed in than motors, then the only the first m gearsets will be used,
+	 *  where m is the number of motors. In either case, errno will be set to E2BIG, but the operation still occurs
 	 *
 	 *
 	 * \param gearset
 	 *        The new geatset of the motor
-	 * 
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
+	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 *
@@ -1978,14 +1943,14 @@ class MotorGroup : public virtual AbstractMotor {
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
-	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size() 
+	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
 	 *
 	 * \param gearset
 	 *        The new geatset of the motor
-	 * 
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
+	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 *
@@ -1999,10 +1964,10 @@ class MotorGroup : public virtual AbstractMotor {
 	 * \endcode
 	 */
 	std::int32_t set_gearing(const pros::motor_gearset_e_t gearset, const std::uint8_t index = 0) const;
-	
+
 	/**
-	 * Sets the gear cartridge (red, green, blue) for each motor in the motor group by taking in a vector of the cartridges. 
-	 * Usable with the C++ enum class and the C enum.
+	 * Sets the gear cartridge (red, green, blue) for each motor in the motor group by taking in a vector of the
+	 * cartridges. Usable with the C++ enum class and the C enum.
 	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
@@ -2010,14 +1975,14 @@ class MotorGroup : public virtual AbstractMotor {
 	 * EDOM - The motor group is empty
 	 * E2BIG - The size of the vector mismatches the number of motors in the motor group
 	 *
-	 * \note If there are more motors than gearsets passed in, 
+	 * \note If there are more motors than gearsets passed in,
 	 * 	only the first n motors will have their gearsets changed where n is the number of gearsets passed in.
-	 *  If there are more gearsets passed in than motors, then the only the first m gearsets will be used, 
-	 *  where m is the number of motors. In either case, errno will be set to E2BIG, but the operation still occurs 
-	 * 
+	 *  If there are more gearsets passed in than motors, then the only the first m gearsets will be used,
+	 *  where m is the number of motors. In either case, errno will be set to E2BIG, but the operation still occurs
+	 *
 	 * \param gearset
 	 *        The a vector containing the new geatsets of the motors
-	 * 
+	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 *
@@ -2039,14 +2004,14 @@ class MotorGroup : public virtual AbstractMotor {
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
-	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size() 
+	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
 	 *
 	 * \param gearset
 	 *        The new geatset of the motor
-	 * 
+	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
+	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 *
@@ -2071,7 +2036,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 *
 	 * \param gearset
 	 *        The new geatset of the motor
-	 * 
+	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 *
@@ -2096,7 +2061,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 *
 	 * \param gearset
 	 *        The new geatset of the motor
-	 * 
+	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 *
@@ -2119,8 +2084,8 @@ class MotorGroup : public virtual AbstractMotor {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * EDOM - The motor group is empty
-	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()  
-	 * 
+	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
+	 *
 	 * \param reverse
 	 *        True reverses the motor, false is default
 	 *
@@ -2150,7 +2115,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * EDOM - The motor group is empty
-	 * 
+	 *
 	 * \param reverse
 	 *        True reverses the motor, false is default
 	 *
@@ -2175,11 +2140,11 @@ class MotorGroup : public virtual AbstractMotor {
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
-	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size() 
+	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
 	 *
 	 * \param limit
 	 *        The new voltage limit in Volts
-	 * 
+	 *
 	 * 	\param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
 	 *
@@ -2244,8 +2209,8 @@ class MotorGroup : public virtual AbstractMotor {
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
-	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size() 
-	 * 
+	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
+	 *
 	 * \param position
 	 *        The new reference position in its encoder units
 	 * \param index Optional parameter, 0 by default.
@@ -2307,11 +2272,11 @@ class MotorGroup : public virtual AbstractMotor {
 	 * reached:
 	 * ENODEV - The port cannot be configured as a motor
 	 * EDOM - The motor group is empty
-	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size() 
+	 * EOVERFLOW - The index is greater than or equal to MotorGroup::size()
 	 *
 	 * \param index Optional parameter, 0 by default.
 	 * 		The zero indexed index of the motor in the motor group
-	 * 
+	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
 	 *
@@ -2323,14 +2288,14 @@ class MotorGroup : public virtual AbstractMotor {
 	 *   mg.move_absolute(100, 100); // This does not cause a movement
 	 *
 	 *   mg.tare_position();
-	 *   mg.tare_position(1); 
-	 * 
+	 *   mg.tare_position(1);
+	 *
 	 *   mg.move_absolute(100, 100); // Moves 100 units forward
 	 * }
 	 * \endcode
 	 */
 	std::int32_t tare_position(const std::uint8_t index = 0) const;
-	
+
 	/**
 	 * Sets the "absolute" zero position of every motor in the motor group to its current position.
 	 *
@@ -2363,18 +2328,18 @@ class MotorGroup : public virtual AbstractMotor {
 
 	/**
 	 * Gets the port of a motor in the motor group
-	 * 
+	 *
 	 * 	 * \param index Optional parameter, 0 by default.
 	 * 				The zero indexed index of the motor in the motor group
-	 * 
-	 * \return The port of the motor at the specified index. 
+	 *
+	 * \return The port of the motor at the specified index.
 	 * The return value is negative if the corresponding motor is reversed
-	*/
+	 */
 	std::int8_t get_port(const std::uint8_t index = 0) const;
 
 	/**
 	 * Appends all the motors in the other motor group reference to this motor group
-	 * 
+	 *
 	 * Maintains the order of the other motor group
 	 *
 	 */
@@ -2382,7 +2347,7 @@ class MotorGroup : public virtual AbstractMotor {
 
 	/**
 	 * Appends all the motors in the other motor group reference to this motor group
-	 * 
+	 *
 	 * Maintains the order of the other motor group
 	 *
 	 */
@@ -2392,7 +2357,7 @@ class MotorGroup : public virtual AbstractMotor {
 	 * Removes the all motors on the port (regardless of reversal) from the motor group
 	 *
 	 * \param port The port to remove from the motor group
-	 * 
+	 *
 	 */
 	void erase_port(std::int8_t port);
 
@@ -2400,7 +2365,7 @@ class MotorGroup : public virtual AbstractMotor {
 	private:
 	/**
 	 * The ordered vector of ports used by the motor group
-	*/
+	 */
 	std::vector<std::int8_t> _ports;
 	mutable pros::Mutex _MotorGroup_mutex;
 };

--- a/src/devices/vdml_motorgroup.cpp
+++ b/src/devices/vdml_motorgroup.cpp
@@ -31,16 +31,13 @@ using namespace pros::c;
 #define empty_MotorGroup_check_vector(error, vector) \
 	if (_ports.size() <= 0) {                          \
 		errno = EDOM;                                    \
-		vector.push_back(error);                      \
+		vector.push_back(error);                         \
 		return vector;                                   \
 	}
 
+MotorGroup::MotorGroup(MotorGroup& motor_group) : MotorGroup(motor_group.get_port_all()) {}
 
-MotorGroup::MotorGroup(MotorGroup& motor_group) : MotorGroup(motor_group.get_port_all()) {
-}
-
-MotorGroup::MotorGroup(const std::initializer_list<std::int8_t> ports,
-                       const pros::v5::MotorGears gearset,
+MotorGroup::MotorGroup(const std::initializer_list<std::int8_t> ports, const pros::v5::MotorGears gearset,
                        const pros::v5::MotorUnits encoder_units)
     : _ports(ports) {
 	if (gearset != pros::v5::MotorGears::invalid) {
@@ -51,8 +48,7 @@ MotorGroup::MotorGroup(const std::initializer_list<std::int8_t> ports,
 	}
 }
 
-MotorGroup::MotorGroup(const std::vector<std::int8_t>& ports,
-                       const pros::v5::MotorGears gearset,
+MotorGroup::MotorGroup(const std::vector<std::int8_t>& ports, const pros::v5::MotorGears gearset,
                        const pros::v5::MotorUnits encoder_units)
     : _ports(ports) {
 	if (gearset != pros::v5::MotorGears::invalid) {
@@ -61,14 +57,6 @@ MotorGroup::MotorGroup(const std::vector<std::int8_t>& ports,
 	if (encoder_units != pros::v5::MotorUnits::invalid) {
 		set_encoder_units_all(encoder_units);
 	}
-}
-
-std::int32_t MotorGroup::operator=(std::int32_t voltage) const {
-	empty_MotorGroup_check(PROS_ERR);
-	for (auto it = _ports.begin() + 1; it < _ports.end(); it++) {
-		motor_move(*it, voltage);
-	}
-	return motor_move(_ports[0], voltage);
 }
 
 std::int32_t MotorGroup::move(std::int32_t voltage) const {
@@ -571,7 +559,7 @@ std::int32_t MotorGroup::set_gearing(const motor_gearset_e_t gearset, const std:
 }
 std::int32_t MotorGroup::set_gearing(std::vector<motor_gearset_e_t> gearsets) const {
 	empty_MotorGroup_check(PROS_ERR);
-	for (int i = 0; i < gearsets.size(); i++){
+	for (int i = 0; i < gearsets.size(); i++) {
 		this->set_gearing(gearsets[i], _ports[i]);
 	}
 	if (gearsets.size() != _ports.size()) {
@@ -582,7 +570,7 @@ std::int32_t MotorGroup::set_gearing(std::vector<motor_gearset_e_t> gearsets) co
 
 std::int32_t MotorGroup::set_gearing(std::vector<MotorGears> gearsets) const {
 	empty_MotorGroup_check(PROS_ERR);
-	for (int i = 0; i < gearsets.size(); i++){
+	for (int i = 0; i < gearsets.size(); i++) {
 		this->set_gearing(gearsets[i], _ports[i]);
 	}
 	if (gearsets.size() != _ports.size()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,8 +87,8 @@ void opcontrol() {
 		// Arcade control scheme
 		int dir = master.get_analog(ANALOG_LEFT_Y);    // Gets amount forward/backward from left joystick
 		int turn = master.get_analog(ANALOG_RIGHT_X);  // Gets the turn left/right from right joystick
-		left_mg = dir - turn;                          // Sets left motor voltage
-		right_mg = dir + turn;                         // Sets right motor voltage
+		left_mg.move(dir - turn);                      // Sets left motor voltage
+		right_mg.move(dir + turn);                     // Sets right motor voltage
 		pros::delay(20);                               // Run for 20 ms then update
 	}
 }


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
Removes the = overload from motor groups as motors don't have them either
#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [x] compiles
- [x] Doesn't compile if you use the = overload
