### PR TITLE
Docs + implementation forgotten for rotation sensor

### DIFF
--- a/include/pros/device.hpp
+++ b/include/pros/device.hpp
@@ -137,8 +137,46 @@ class Device {
 	 */
 	pros::DeviceType get_plugged_type() const;
 
+	/**
+	 * Gets the type of device on a given port.
+	 * 
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * EACCES - Mutex of port cannot be taken (access denied).
+	 * 
+	 * \param port The V5 port number from 1-21
+	 * 
+	 * \return The device type as an enum.
+	 *
+	 * \b Example
+ 	 * \code
+	 * #define DEVICE_PORT 1
+	 *
+	 * void opcontrol() {
+	 *   while (true) { 
+	 *     DeviceType dt = pros::Device::get_plugged_type(DEVICE_PORT);
+	 *     printf("device plugged type: {plugged type: %d}\n", dt);
+	 *     delay(20);
+	 *   }
+	 * }
+ 	 * \endcode
+	 */
 	static pros::DeviceType get_plugged_type(std::uint8_t port);
 
+	/**
+	 * Gets all devices of a given device type.
+	 * 
+	 * \param device_type The pros::DeviceType enum that matches the type of device desired.
+	 * 
+	 * \return A vector of Device objects for the given device type.
+	 *
+	 * \b Example
+ 	 * \code
+	 * void opcontrol() {
+	 *   std::vector<Device> motor_devices = pros::Device::get_all_devices(pros::DeviceType::motor);  // All Device objects are motors
+	 * }
+ 	 * \endcode
+	 */
 	static std::vector<Device> get_all_devices(pros::DeviceType device_type = pros::DeviceType::undefined);
 
 	protected:

--- a/include/pros/distance.hpp
+++ b/include/pros/distance.hpp
@@ -87,6 +87,18 @@ class Distance : public Device {
 	 */
 	virtual std::int32_t get();
 
+	/**
+	 * Gets all distance sensors.
+	 * 
+	 * \return A vector of Distance sensor objects.
+	 *
+	 * \b Example
+ 	 * \code
+	 * void opcontrol() {
+	 *   std::vector<Distance> distance_all = pros::Distance::get_all_devices();  // All distance sensors that are connected
+	 * }
+ 	 * \endcode
+	 */
 	static std::vector<Distance> get_all_devices();
 
 	/**

--- a/include/pros/gps.hpp
+++ b/include/pros/gps.hpp
@@ -223,6 +223,18 @@ class Gps : public Device {
 	 */
 	virtual std::int32_t set_offset(double xOffset, double yOffset) const;
 
+	/**
+	 * Gets all GPS sensors.
+	 * 
+	 * \return A vector of Gps sensor objects.
+	 *
+	 * \b Example
+ 	 * \code
+	 * void opcontrol() {
+	 *   std::vector<Gps> gps_all = pros::Gps::get_all_devices();  // All GPS sensors that are connected
+	 * }
+ 	 * \endcode
+	 */
 	static std::vector<Gps> get_all_devices();
 
 	/**

--- a/include/pros/imu.hpp
+++ b/include/pros/imu.hpp
@@ -190,6 +190,18 @@ class Imu : public Device {
 	 */
 	virtual std::int32_t set_data_rate(std::uint32_t rate) const;
 
+	/**
+	 * Gets all IMU sensors.
+	 * 
+	 * \return A vector of Imu sensor objects.
+	 *
+	 * \b Example
+ 	 * \code
+	 * void opcontrol() {
+	 *   std::vector<Imu> imu_all = pros::Imu::get_all_devices();  // All IMU sensors that are connected
+	 * }
+ 	 * \endcode
+	 */
 	static std::vector<Imu> get_all_devices();
 
 	/**

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -1484,6 +1484,18 @@ class Motor : public AbstractMotor, public Device {
 	 */
 	std::int8_t size(void) const;
 
+	/**
+	 * Gets all motors.
+	 * 
+	 * \return A vector of Motor objects.
+	 *
+	 * \b Example
+ 	 * \code
+	 * void opcontrol() {
+	 *   std::vector<Motor> motor_all = pros::Motor::get_all_devices();  // All motors that are connected
+	 * }
+ 	 * \endcode
+	 */
 	static std::vector<Motor> get_all_devices();
 
 	/**

--- a/include/pros/optical.hpp
+++ b/include/pros/optical.hpp
@@ -59,6 +59,19 @@ class Optical : public Device {
 	Optical(const Device& device)
 		: Optical(device.get_port()) {};
 
+
+	/**
+	 * Gets all optical sensors.
+	 * 
+	 * \return A vector of Optical sensor objects.
+	 *
+	 * \b Example
+ 	 * \code
+	 * void opcontrol() {
+	 *   std::vector<Optical> optical_all = pros::Optical::get_all_devices();  // All optical sensors that are connected
+	 * }
+ 	 * \endcode
+	 */
 	static std::vector<Optical> get_all_devices();
 
 	/**

--- a/include/pros/rotation.hpp
+++ b/include/pros/rotation.hpp
@@ -178,6 +178,20 @@ class Rotation : public Device {
 	virtual std::int32_t reset_position(void) const;
 
 	/**
+	 * Gets all rotation sensors.
+	 * 
+	 * \return A vector of Rotation sensor objects.
+	 *
+	 * \b Example
+ 	 * \code
+	 * void opcontrol() {
+	 *   std::vector<Rotation> rotation_all = pros::Rotation::get_all_devices();  // All rotation sensors that are connected
+	 * }
+ 	 * \endcode
+	 */
+	static std::vector<Rotation> get_all_devices();
+
+	/**
 	 * Get the Rotation Sensor's current position in centidegrees
 	 *
 	 * This function uses the following values of errno when an error state is

--- a/include/pros/vision.hpp
+++ b/include/pros/vision.hpp
@@ -172,6 +172,18 @@ class Vision : public Device {
 	                                      const std::uint32_t sig_id3 = 0, const std::uint32_t sig_id4 = 0,
 	                                      const std::uint32_t sig_id5 = 0) const;
 
+	/**
+	 * Gets all vision sensors.
+	 * 
+	 * \return A vector of Vision sensor objects.
+	 *
+	 * \b Example
+ 	 * \code
+	 * void opcontrol() {
+	 *   std::vector<Vision> vision_all = pros::Vision::get_all_devices();  // All vision sensors that are connected
+	 * }
+ 	 * \endcode
+	 */
 	static std::vector<Vision> get_all_devices();
 
 	/**

--- a/src/devices/vdml_rotation.cpp
+++ b/src/devices/vdml_rotation.cpp
@@ -40,6 +40,15 @@ std::int32_t Rotation::reset_position(void) const {
 	return pros::c::rotation_reset_position(_port);
 }
 
+std::vector<Rotation> Rotation::get_all_devices() {
+	std::vector<Device> matching_devices {Device::get_all_devices(DeviceType::rotation)};
+	std::vector<Rotation> return_vector;
+	for (auto device : matching_devices) {
+		return_vector.push_back(device);
+	}
+	return return_vector;
+}
+
 std::int32_t Rotation::get_position(void) const {
 	return pros::c::rotation_get_position(_port);
 }


### PR DESCRIPTION
#### Summary:
Added docs for get_all_devices() member functions on applicable devices. Also implemented get_all_devices() for rotation sensors which was originally forgotten.

#### Motivation:
Documentation for users.

##### References (optional):
N/A

#### Test Plan:
N/A
