### PR TITLE
🐛 Fix _exit implementation

### DIFF
--- a/src/system/newlib_stubs.c
+++ b/src/system/newlib_stubs.c
@@ -33,7 +33,9 @@
 void _exit(int status) {
 	taskDISABLE_INTERRUPTS();
 	if(status != 0) dprintf(3, "Error %d\n", status); // kprintf
-	while (vexSerialWriteFree(1) != 2048) {
+	uint32_t start_time = millis();
+	static const uint32_t max_flush_time = 50;
+	while (vexSerialWriteFree(1) != 2048 || millis() - start_time > max_flush_time) {
 		vexBackgroundProcessing();
 		extern void ser_output_flush();
 		ser_output_flush();

--- a/src/system/newlib_stubs.c
+++ b/src/system/newlib_stubs.c
@@ -33,7 +33,7 @@
 void _exit(int status) {
 	taskDISABLE_INTERRUPTS();
 	if(status != 0) dprintf(3, "Error %d\n", status); // kprintf
-	while (vexSerialWriteFree() != 2048) {
+	while (vexSerialWriteFree(1) != 2048) {
 		vexBackgroundProcessing();
 		extern void ser_output_flush();
 		ser_output_flush();

--- a/src/system/newlib_stubs.c
+++ b/src/system/newlib_stubs.c
@@ -31,8 +31,15 @@
 #define MICRO_TO_NANO 1000
 
 void _exit(int status) {
+	taskDISABLE_INTERRUPTS();
 	if(status != 0) dprintf(3, "Error %d\n", status); // kprintf
+	while (vexSerialWriteFree() != 2048) {
+		vexBackgroundProcessing();
+		extern void ser_output_flush();
+		ser_output_flush();
+	}
 	vexSystemExitRequest();
+	while (1) asm("YIELD");
 }
 
 int usleep( useconds_t period ) {

--- a/src/system/newlib_stubs.c
+++ b/src/system/newlib_stubs.c
@@ -31,6 +31,8 @@
 #define MICRO_TO_NANO 1000
 
 void _exit(int status) {
+	extern void flush_output_streams();
+	flush_output_streams();
 	extern void ser_output_flush();
 	ser_output_flush();
 	rtos_suspend_all();

--- a/src/system/newlib_stubs.c
+++ b/src/system/newlib_stubs.c
@@ -31,17 +31,17 @@
 #define MICRO_TO_NANO 1000
 
 void _exit(int status) {
-	taskDISABLE_INTERRUPTS();
+	extern void ser_output_flush();
+	ser_output_flush();
+	rtos_suspend_all();
 	if(status != 0) dprintf(3, "Error %d\n", status); // kprintf
 	uint32_t start_time = millis();
 	static const uint32_t max_flush_time = 50;
 	while (vexSerialWriteFree(1) != 2048 || millis() - start_time > max_flush_time) {
 		vexBackgroundProcessing();
-		extern void ser_output_flush();
-		ser_output_flush();
 	}
 	vexSystemExitRequest();
-	while (1) asm("YIELD");
+	while (1) vexBackgroundProcessing();
 }
 
 int usleep( useconds_t period ) {

--- a/src/system/newlib_stubs_support.cpp
+++ b/src/system/newlib_stubs_support.cpp
@@ -1,0 +1,8 @@
+#include <cstdio>
+#include <iostream>
+
+// called by _exit in newlib_stubs.c
+extern "C" void flush_output_streams() {
+    fflush(stdout);
+    std::cout.flush();
+}


### PR DESCRIPTION
#### Summary:
Changes the `_exit` function to flush the serial buffer and indefinitely block. 

#### Motivation:
The `_exit` function is supposed to never return, but right now it does.

#### Test Plan:
- [x] Check it compiles
- [ ] Test that `_exit` exits the code
- [ ] Test that `_exit` always flushes the serial buffer

##### Test Code:

```cpp
printf("hi");
std::exit(0);
asm volatile("mov r0, #0 \n\tSTR sp, [r0]\n\t"); // if exit does not immediately, there will be a data abort
```