### PR TITLE
fix: :bug: Increase max text length for controller text setting

### DIFF
--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -19,6 +19,7 @@
 #include "vdml/vdml.h"
 
 #define CONTROLLER_MAX_COLS 15
+#define CONTROLLER_MAX_CHARS 31
 
 // From enum in misc.h
 #define NUM_BUTTONS 12
@@ -107,7 +108,7 @@ int32_t controller_set_text(controller_id_e_t id, uint8_t line, uint8_t col, con
 	else
 		col++;
 
-	char* buf = strndup(str, CONTROLLER_MAX_COLS + 1);
+	char* buf = strndup(str, CONTROLLER_MAX_CHARS + 1);
 
 	uint32_t rtn_val = vexControllerTextSet(id, line, col, buf);
 	free(buf);
@@ -131,8 +132,8 @@ int32_t controller_print(controller_id_e_t id, uint8_t line, uint8_t col, const 
 
 	va_list args;
 	va_start(args, fmt);
-	char* buf = (char*)malloc(CONTROLLER_MAX_COLS + 1);
-	vsnprintf(buf, CONTROLLER_MAX_COLS + 1, fmt, args);
+	char* buf = (char*)malloc(CONTROLLER_MAX_CHARS + 1);
+	vsnprintf(buf, CONTROLLER_MAX_CHARS + 1, fmt, args);
 
 	uint32_t rtn_val = vexControllerTextSet(id, line, col, buf);
 	free(buf);

--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -18,8 +18,8 @@
 #include "v5_api.h"
 #include "vdml/vdml.h"
 
-#define CONTROLLER_MAX_COLS 15
-#define CONTROLLER_MAX_CHARS 31
+#define CONTROLLER_MAX_COLS ( 20U )
+#define CONTROLLER_MAX_CHARS ( 31U )
 
 // From enum in misc.h
 #define NUM_BUTTONS 12


### PR DESCRIPTION
#### Summary:
Changes max length of controller text to 31 characters.

#### Motivation:
VEXCode allows users to set controller text with a maximum length of 31 characters, but PROS caps controller text at 15 characters.

##### References (optional):
Close #679

#### Test Plan:
- [x] Check it compiles
- [x] Check that controller text setting works with strings up to 31 characters long
- [x] Check that this doesn't break controller text clearing
