### PR TITLE
Update common.mk to search all dependencies

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -12,7 +12,7 @@ COMMA := ,
 
 DEPDIR := .d
 $(shell mkdir -p $(DEPDIR))
-DEPFLAGS = -MT $$@ -MMD -MP -MF $(DEPDIR)/$$*.Td
+DEPFLAGS = -MT $$@ -MD -MP -MF $(DEPDIR)/$$*.Td
 MAKEDEPFOLDER = -$(VV)mkdir -p $(DEPDIR)/$$(dir $$(patsubst $(BINDIR)/%, %, $(ROOT)/$$@))
 RENAMEDEPENDENCYFILE = -$(VV)mv -f $(DEPDIR)/$$*.Td $$(patsubst $(SRCDIR)/%, $(DEPDIR)/%.d, $(ROOT)/$$<) && touch $$@
 


### PR DESCRIPTION
#### Summary:
Changed -MMD flag to -MD in common.mk

#### Motivation:
This is to make compiling more reliable at the cost of very little compile time. This will eliminate some rare errors.

##### References (optional):
Mesonbuild does this by [default](https://github.com/mesonbuild/meson/commit/8eaa0a27323e9fbee01b8aa0cf165cd499b78ee1).

#### Test Plan:

- [ ] Rebuild a typical project, modify a system header file (add a comment), then `pros make quick` to test if files which include that system header are recompiled.
