### PR TITLE
feat: :sparkles: Make controller ctor constexpr

### DIFF
--- a/include/pros/misc.hpp
+++ b/include/pros/misc.hpp
@@ -45,7 +45,7 @@ class Controller {
 	 * 			  The ID of the controller (e.g. the master or partner controller).
 	 * 			  Must be one of CONTROLLER_MASTER or CONTROLLER_PARTNER
 	 */
-	explicit Controller(controller_id_e_t id);
+	explicit constexpr Controller(controller_id_e_t id): _id(id) {}
 
 	/**
 	 * Checks if the controller is connected.

--- a/src/devices/controller.cpp
+++ b/src/devices/controller.cpp
@@ -18,8 +18,6 @@ namespace pros {
 inline namespace v5 {
 using namespace pros::c;
 
-Controller::Controller(pros::controller_id_e_t id) : _id(id) {}
-
 std::int32_t Controller::is_connected(void) {
 	return controller_is_connected(_id);
 }


### PR DESCRIPTION
#### Summary:
Changes the `pros::Controller` constructor to be `constexpr`.

#### Motivation:
Allows `pros::Controller` instances to be declared `constinit`/`constexpr`.

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [x] Check it compiles
- [ ] Check that `Controller` instances can be declared as `constinit`/`constexpr`.
