### PR TITLE
:sparkles: Add rotation constructor with reversed flag

### DIFF
--- a/include/pros/rotation.hpp
+++ b/include/pros/rotation.hpp
@@ -55,6 +55,27 @@ class Rotation : public Device {
 	 */
 	Rotation(const std::int8_t port);
 
+	/**
+	 * Constructs a new Rotation Sensor object
+	 *
+	 * ENXIO - The given value is not within the range of V5 ports |1-21|.
+	 * ENODEV - The port cannot be configured as a Rotation Sensor
+	 *
+	 * \param port
+	 *        The V5 port number from 1 to 21.
+	 * \param reversed
+	 *        Whether or not the rotation sensor is reversed.
+	 *
+	 * 	\b Example
+	 * \code
+	 * void opcontrol() {
+	 * 	 pros::Rotation rotation_sensor(1, false); //Creates a Rotation Sensor on port 1
+	 *   pros::Rotation reversed_rotation_sensor(2, true); //Creates a reversed Rotation Sensor on port 2
+	 * }
+	 * \endcode
+	 */
+	Rotation(const std::uint8_t port, const bool reversed);
+
 	Rotation(const Device& device) : Rotation(device.get_port()){};
 
 

--- a/src/devices/vdml_rotation.cpp
+++ b/src/devices/vdml_rotation.cpp
@@ -16,12 +16,10 @@
 namespace pros {
 inline namespace v5 {
 
-Rotation::Rotation(const std::int8_t port) : Device(abs(port), DeviceType::rotation) {
-	if (port < 0) {
-		pros::c::rotation_set_reversed(abs(port), true);
-	} else {
-		pros::c::rotation_set_reversed(port, false);
-	}
+Rotation::Rotation(const std::int8_t port) : Rotation(abs(port), port < 0) {}
+
+Rotation::Rotation(const std::uint8_t port, const bool reversed): Device(port, DeviceType::rotation) {
+	pros::c::rotation_set_reversed(port, reversed);
 }
 
 std::int32_t Rotation::reset() {


### PR DESCRIPTION
#### Summary:
Add a rotation sensor constructor that takes a reversed flag.

#### Motivation:
Some people prefer using a reversed flag instead of negative port numbers.

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [ ] Check it compiles
- [ ] Check that both constructors work as expected
