### PR TITLE
feat: :technologist: Check device literal port numbers at compile time

### DIFF
--- a/include/pros/detail.hpp
+++ b/include/pros/detail.hpp
@@ -13,6 +13,8 @@
  * file You can obtain one at http://mozilla.org/MPL/2.0/.
  *
  */
+#ifndef _PROS_DETAIL_HPP_
+#define _PROS_DETAIL_HPP_
 
 #include <array>
 #include <charconv>
@@ -22,30 +24,9 @@ namespace pros::detail {
 template <char ...Chars>
 consteval uint8_t parse_port() {
     const std::array chars{Chars...};
-    const char* str = chars.begin();
-    int base = 10;
     uint8_t port_num{0};
-    if (chars.size() > 2 && chars[0] == '0') {
-        str += 2;
-        // from_chars doesn't seem to handle hex/binary/octal prefixes,
-        // so we handle them ourselves
-        switch (chars[1]) {
-            case 'X': case 'x':
-                // hex literal
-                base = 16;
-                break;
-            case 'B': case 'b':
-                // binary literal
-                base = 2;
-                break;
-            default:
-                // octal literal
-                str -= 1;
-                base = 8;
-        }
-    }
-    auto result = std::from_chars(str, chars.end(), port_num, base);
-    if (result.ptr != chars.end()) {
+    auto result = std::from_chars(chars.begin(), chars.end(), port_num, 0);
+    if (result.ptr != chars.end() || result.ec != std::errc{}) {
         return 0;
     }
     return port_num;
@@ -56,4 +37,23 @@ consteval bool is_valid_port() {
     auto port_num = parse_port<Chars...>();
     return port_num >= 1 && port_num <= 21;
 }
+
+// Tests:
+static_assert(is_valid_port<'1'>() == true, "Kernel test failed");
+static_assert(is_valid_port<'0'>() == false, "Kernel test failed");
+// 0x16 = 22
+static_assert(is_valid_port<'0','x','1','6'>() == false, "Kernel test failed");
+// 0x15 = 21
+static_assert(is_valid_port<'0','x','1','5'>() == true, "Kernel test failed");
+// 025 = 21
+static_assert(is_valid_port<'0','2','5'>() == true, "Kernel test failed");
+// 0b1 = 1
+static_assert(is_valid_port<'0','b','1'>() == true, "Kernel test failed");
+// 0x1 = 1
+static_assert(is_valid_port<'0','x','1'>() == true, "Kernel test failed");
+static_assert(is_valid_port<'-','1'>() == false, "Kernel test failed");
+static_assert(is_valid_port<'2','2'>() == false, "Kernel test failed");
+
 }
+
+#endif // _PROS_DETAIL_HPP_

--- a/include/pros/detail.hpp
+++ b/include/pros/detail.hpp
@@ -1,0 +1,59 @@
+/**
+ * \file pros/detail.hpp
+ *
+ * Contains PROS internal functions used in port literal functions.
+ *
+ * This file should not be modified by users, since it gets replaced whenever
+ * a kernel upgrade occurs.
+ *
+ * Copyright (c) 2017-2023 Purdue University ACM SIGBots.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License v. 2.0. If a copy of the MPL was not distributed with this
+ * file You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ */
+
+#include <array>
+#include <charconv>
+#include <cstdint>
+
+namespace pros::detail {
+template <char ...Chars>
+consteval uint8_t parse_port() {
+    const std::array chars{Chars...};
+    const char* str = chars.begin();
+    int base = 10;
+    uint8_t port_num{0};
+    if (chars.size() > 2 && chars[0] == '0') {
+        str += 2;
+        // from_chars doesn't seem to handle hex/binary/octal prefixes,
+        // so we handle them ourselves
+        switch (chars[1]) {
+            case 'X': case 'x':
+                // hex literal
+                base = 16;
+                break;
+            case 'B': case 'b':
+                // binary literal
+                base = 2;
+                break;
+            default:
+                // octal literal
+                str -= 1;
+                base = 8;
+        }
+    }
+    auto result = std::from_chars(str, chars.end(), port_num, base);
+    if (result.ptr != chars.end()) {
+        return 0;
+    }
+    return port_num;
+}
+
+template <char ...Chars>
+consteval bool is_valid_port() {
+    auto port_num = parse_port<Chars...>();
+    return port_num >= 1 && port_num <= 21;
+}
+}

--- a/include/pros/detail.hpp
+++ b/include/pros/detail.hpp
@@ -6,7 +6,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2023 Purdue University ACM SIGBots.
+ * Copyright (c) 2017-2024 Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License v. 2.0. If a copy of the MPL was not distributed with this
@@ -24,8 +24,29 @@ namespace pros::detail {
 template <char ...Chars>
 consteval uint8_t parse_port() {
     const std::array chars{Chars...};
+    const char* str = chars.begin();
+    int base = 10;
     uint8_t port_num{0};
-    auto result = std::from_chars(chars.begin(), chars.end(), port_num, 0);
+    if (chars.size() >= 2 && chars[0] == '0') {
+        str += 2;
+        // from_chars doesn't seem to handle hex/binary/octal prefixes,
+        // so we handle them ourselves
+        switch (chars[1]) {
+            case 'X': case 'x':
+                // hex literal
+                base = 16;
+                break;
+            case 'B': case 'b':
+                // binary literal
+                base = 2;
+                break;
+            default:
+                // octal literal
+                str -= 1;
+                base = 8;
+        }
+    }
+    auto result = std::from_chars(str, chars.end(), port_num, base);
     if (result.ptr != chars.end() || result.ec != std::errc{}) {
         return 0;
     }
@@ -51,7 +72,6 @@ static_assert(is_valid_port<'0','2','5'>() == true, "Kernel test failed");
 static_assert(is_valid_port<'0','b','1'>() == true, "Kernel test failed");
 // 0x1 = 1
 static_assert(is_valid_port<'0','x','1'>() == true, "Kernel test failed");
-static_assert(is_valid_port<'-','1'>() == false, "Kernel test failed");
 static_assert(is_valid_port<'2','2'>() == false, "Kernel test failed");
 
 }

--- a/include/pros/distance.hpp
+++ b/include/pros/distance.hpp
@@ -239,7 +239,23 @@ namespace literals {
  * }
  * \endcode
  */
-const pros::Distance operator"" _dist(const unsigned long long int d);
+template <char... Cs>
+const pros::Distance operator"" _dist() {
+    constexpr int num = ([] (auto a) consteval {
+        int num;
+        auto iter = a.begin();
+        for(; iter != a.end(); iter++) {
+            if (*iter != 0) {break;}
+        }
+        if (a.end()-iter > 2 || iter==a.end()) return 0;
+        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
+        else num = *iter;
+        if (num > 21 || num <= 0) return 0;
+        return num;
+    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
+    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    return pros::Distance(num);
+}
 }  // namespace literals
 }  // namespace v5
 }  // namespace pros

--- a/include/pros/distance.hpp
+++ b/include/pros/distance.hpp
@@ -24,6 +24,7 @@
 
 #include "pros/device.hpp"
 #include "pros/distance.h"
+#include "pros/detail.hpp"
 
 namespace pros {
 inline namespace v5 {
@@ -241,19 +242,8 @@ namespace literals {
  */
 template <char... Cs>
 const pros::Distance operator"" _dist() {
-    constexpr int num = ([] (auto a) consteval {
-        int num;
-        auto iter = a.begin();
-        for(; iter != a.end(); iter++) {
-            if (*iter != 0) {break;}
-        }
-        if (a.end()-iter > 2 || iter==a.end()) return 0;
-        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
-        else num = *iter;
-        if (num > 21 || num <= 0) return 0;
-        return num;
-    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
-    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+	static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Distance(num);
 }
 }  // namespace literals

--- a/include/pros/distance.hpp
+++ b/include/pros/distance.hpp
@@ -242,7 +242,7 @@ namespace literals {
  */
 template <char... Cs>
 const pros::Distance operator"" _dist() {
-	static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+	static_assert(pros::detail::is_valid_port<Cs...>(), "Invalid port number!");
     constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Distance(num);
 }

--- a/include/pros/gps.hpp
+++ b/include/pros/gps.hpp
@@ -924,7 +924,23 @@ namespace literals {
  * }
  * \endcode
  */
-const pros::Gps operator""_gps(const unsigned long long int g);
+template <char... Cs>
+const pros::Gps operator"" _gps() {
+    constexpr int num = ([] (auto a) consteval {
+        int num;
+        auto iter = a.begin();
+        for(; iter != a.end(); iter++) {
+            if (*iter != 0) {break;}
+        }
+        if (a.end()-iter > 2 || iter==a.end()) return 0;
+        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
+        else num = *iter;
+        if (num > 21 || num <= 0) return 0;
+        return num;
+    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
+    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    return pros::Gps(num);
+}
 }  // namespace literals
 
 /// @brief

--- a/include/pros/gps.hpp
+++ b/include/pros/gps.hpp
@@ -927,7 +927,7 @@ namespace literals {
  */
 template <char... Cs>
 const pros::Gps operator"" _gps() {
-    static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    static_assert(pros::detail::is_valid_port<Cs...>(), "Invalid port number!");
     constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Gps(num);
 }

--- a/include/pros/gps.hpp
+++ b/include/pros/gps.hpp
@@ -27,6 +27,7 @@
 
 #include "pros/device.hpp"
 #include "pros/gps.h"
+#include "pros/detail.hpp"
 
 namespace pros {
 inline namespace v5 {
@@ -926,19 +927,8 @@ namespace literals {
  */
 template <char... Cs>
 const pros::Gps operator"" _gps() {
-    constexpr int num = ([] (auto a) consteval {
-        int num;
-        auto iter = a.begin();
-        for(; iter != a.end(); iter++) {
-            if (*iter != 0) {break;}
-        }
-        if (a.end()-iter > 2 || iter==a.end()) return 0;
-        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
-        else num = *iter;
-        if (num > 21 || num <= 0) return 0;
-        return num;
-    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
-    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Gps(num);
 }
 }  // namespace literals

--- a/include/pros/imu.hpp
+++ b/include/pros/imu.hpp
@@ -1067,7 +1067,23 @@ namespace literals {
  * }
  * \endcode
  */
-const pros::Imu operator"" _imu(const unsigned long long int i);
+template <char... Cs>
+const pros::Imu operator"" _imu() {
+    constexpr int num = ([] (auto a) consteval {
+        int num;
+        auto iter = a.begin();
+        for(; iter != a.end(); iter++) {
+            if (*iter != 0) {break;}
+        }
+        if (a.end()-iter > 2 || iter==a.end()) return 0;
+        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
+        else num = *iter;
+        if (num > 21 || num <= 0) return 0;
+        return num;
+    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
+    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    return pros::Imu(num);
+}
 }  // namespace literals
 
 using IMU = Imu;

--- a/include/pros/imu.hpp
+++ b/include/pros/imu.hpp
@@ -1070,7 +1070,7 @@ namespace literals {
  */
 template <char... Cs>
 const pros::Imu operator"" _imu() {
-    static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    static_assert(pros::detail::is_valid_port<Cs...>(), "Invalid port number!");
     constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Imu(num);
 }

--- a/include/pros/imu.hpp
+++ b/include/pros/imu.hpp
@@ -23,6 +23,7 @@
 
 #include "pros/device.hpp"
 #include "pros/imu.h"
+#include "pros/detail.hpp"
 
 namespace pros {
 /**
@@ -1069,19 +1070,8 @@ namespace literals {
  */
 template <char... Cs>
 const pros::Imu operator"" _imu() {
-    constexpr int num = ([] (auto a) consteval {
-        int num;
-        auto iter = a.begin();
-        for(; iter != a.end(); iter++) {
-            if (*iter != 0) {break;}
-        }
-        if (a.end()-iter > 2 || iter==a.end()) return 0;
-        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
-        else num = *iter;
-        if (num > 21 || num <= 0) return 0;
-        return num;
-    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
-    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Imu(num);
 }
 }  // namespace literals

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -2405,7 +2405,24 @@ namespace literals {
  * }
  * \endcode
  */
-const pros::Motor operator"" _mtr(const unsigned long long int m);
+template <char... Cs>
+const pros::Motor operator"" _mtr() {
+    constexpr int num = ([] (auto a) consteval {
+        int num;
+        auto iter = a.begin();
+        for(; iter != a.end(); iter++) {
+            if (*iter != 0) {break;}
+        }
+        if (a.end()-iter > 2 || iter==a.end()) return 0;
+        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
+        else num = *iter;
+        if (num > 21 || num <= 0) return 0;
+        return num;
+    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
+    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    return pros::Motor(num);
+}
+
 /**
  * Constructs a reversed Motor from a literal ending in _rmtr
  *
@@ -2419,7 +2436,23 @@ const pros::Motor operator"" _mtr(const unsigned long long int m);
  * }
  * \endcode
  */
-const pros::Motor operator"" _rmtr(const unsigned long long int m);
+template <char... Cs>
+const pros::Motor operator"" _rmtr() {
+    constexpr int num = ([] (auto a) consteval {
+        int num;
+        auto iter = a.begin();
+        for(; iter != a.end(); iter++) {
+            if (*iter != 0) {break;}
+        }
+        if (a.end()-iter > 2 || iter==a.end()) return 0;
+        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
+        else num = *iter;
+        if (num > 21 || num <= 0) return 0;
+        return num;
+    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
+    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    return pros::Motor(-num);
+}
 }  // namespace literals
 }  // namespace v5
 }  // namespace pros

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -26,6 +26,7 @@
 #include "pros/abstract_motor.hpp"
 #include "pros/device.hpp"
 #include "pros/motors.h"
+#include "pros/detail.hpp"
 #include "rtos.hpp"
 
 namespace pros {
@@ -2407,19 +2408,8 @@ namespace literals {
  */
 template <char... Cs>
 const pros::Motor operator"" _mtr() {
-    constexpr int num = ([] (auto a) consteval {
-        int num;
-        auto iter = a.begin();
-        for(; iter != a.end(); iter++) {
-            if (*iter != 0) {break;}
-        }
-        if (a.end()-iter > 2 || iter==a.end()) return 0;
-        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
-        else num = *iter;
-        if (num > 21 || num <= 0) return 0;
-        return num;
-    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
-    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Motor(num);
 }
 
@@ -2438,19 +2428,8 @@ const pros::Motor operator"" _mtr() {
  */
 template <char... Cs>
 const pros::Motor operator"" _rmtr() {
-    constexpr int num = ([] (auto a) consteval {
-        int num;
-        auto iter = a.begin();
-        for(; iter != a.end(); iter++) {
-            if (*iter != 0) {break;}
-        }
-        if (a.end()-iter > 2 || iter==a.end()) return 0;
-        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
-        else num = *iter;
-        if (num > 21 || num <= 0) return 0;
-        return num;
-    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
-    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Motor(-num);
 }
 }  // namespace literals

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -2408,7 +2408,7 @@ namespace literals {
  */
 template <char... Cs>
 const pros::Motor operator"" _mtr() {
-    static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    static_assert(pros::detail::is_valid_port<Cs...>(), "Invalid port number!");
     constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Motor(num);
 }
@@ -2428,7 +2428,7 @@ const pros::Motor operator"" _mtr() {
  */
 template <char... Cs>
 const pros::Motor operator"" _rmtr() {
-    static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    static_assert(pros::detail::is_valid_port<Cs...>(), "Invalid port number!");
     constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Motor(-num);
 }

--- a/include/pros/optical.hpp
+++ b/include/pros/optical.hpp
@@ -431,7 +431,23 @@ namespace literals {
  * }
  * \endcode
  */
-const pros::Optical operator"" _opt(const unsigned long long int o);
+ template <char... Cs>
+const pros::Optical operator"" _opt() {
+    constexpr int num = ([] (auto a) consteval {
+        int num;
+        auto iter = a.begin();
+        for(; iter != a.end(); iter++) {
+            if (*iter != 0) {break;}
+        }
+        if (a.end()-iter > 2 || iter==a.end()) return 0;
+        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
+        else num = *iter;
+        if (num > 21 || num <= 0) return 0;
+        return num;
+    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
+    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    return pros::Optical(num);
+}
 }  // namespace literals
 }  // namespace v5
 }  // namespace pros

--- a/include/pros/optical.hpp
+++ b/include/pros/optical.hpp
@@ -26,6 +26,7 @@
 
 #include "pros/device.hpp"
 #include "pros/optical.h"
+#include "pros/detail.hpp"
 
 namespace pros {
 inline namespace v5 {
@@ -433,19 +434,8 @@ namespace literals {
  */
  template <char... Cs>
 const pros::Optical operator"" _opt() {
-    constexpr int num = ([] (auto a) consteval {
-        int num;
-        auto iter = a.begin();
-        for(; iter != a.end(); iter++) {
-            if (*iter != 0) {break;}
-        }
-        if (a.end()-iter > 2 || iter==a.end()) return 0;
-        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
-        else num = *iter;
-        if (num > 21 || num <= 0) return 0;
-        return num;
-    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
-    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Optical(num);
 }
 }  // namespace literals

--- a/include/pros/optical.hpp
+++ b/include/pros/optical.hpp
@@ -434,7 +434,7 @@ namespace literals {
  */
  template <char... Cs>
 const pros::Optical operator"" _opt() {
-    static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    static_assert(pros::detail::is_valid_port<Cs...>(), "Invalid port number!");
     constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Optical(num);
 }

--- a/include/pros/rotation.hpp
+++ b/include/pros/rotation.hpp
@@ -386,7 +386,23 @@ namespace literals {
  * }
  * \endcode
  */
-const pros::Rotation operator"" _rot(const unsigned long long int r);
+template <char... Cs>
+const pros::Rotation operator"" _rot() {
+    constexpr int num = ([] (auto a) consteval {
+        int num;
+        auto iter = a.begin();
+        for(; iter != a.end(); iter++) {
+            if (*iter != 0) {break;}
+        }
+        if (a.end()-iter > 2 || iter==a.end()) return 0;
+        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
+        else num = *iter;
+        if (num > 21 || num <= 0) return 0;
+        return num;
+    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
+    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    return pros::Rotation(num);
+}
 }  // namespace literals
 }  // namespace v5
 }  // namespace pros

--- a/include/pros/rotation.hpp
+++ b/include/pros/rotation.hpp
@@ -370,6 +370,23 @@ class Rotation : public Device {
 	 */
 	friend std::ostream& operator<<(std::ostream& os, const pros::Rotation& rotation);
 
+	/**
+	 * Returns a rotation sesnor that has the same port as the original, but reversed.
+	 *
+	 * This can only be used on a temporary object (such as a device literal).
+	 *
+	 * \b Example
+	 * \code
+	 * using namespace pros::literals;
+	 *
+	 * void opcontrol() {
+	 * 	pros::Rotation rotation_sensor = -1_rot;
+	 *  printf("Reversed: %d \n", rotation_sensor.get_reversed());
+	 * }
+	 * \endcode
+	 */
+	Rotation operator-() && { return Rotation(-this->get_port()); }
+
 	///@}
 };
 

--- a/include/pros/rotation.hpp
+++ b/include/pros/rotation.hpp
@@ -406,7 +406,7 @@ namespace literals {
  */
 template <char... Cs>
 const pros::Rotation operator"" _rot() {
-    static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    static_assert(pros::detail::is_valid_port<Cs...>(), "Invalid port number!");
     constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Rotation(num);
 }

--- a/include/pros/rotation.hpp
+++ b/include/pros/rotation.hpp
@@ -23,6 +23,7 @@
 
 #include "pros/device.hpp"
 #include "pros/rotation.h"
+#include "pros/detail.hpp"
 
 namespace pros {
 inline namespace v5 {
@@ -388,19 +389,8 @@ namespace literals {
  */
 template <char... Cs>
 const pros::Rotation operator"" _rot() {
-    constexpr int num = ([] (auto a) consteval {
-        int num;
-        auto iter = a.begin();
-        for(; iter != a.end(); iter++) {
-            if (*iter != 0) {break;}
-        }
-        if (a.end()-iter > 2 || iter==a.end()) return 0;
-        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
-        else num = *iter;
-        if (num > 21 || num <= 0) return 0;
-        return num;
-    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
-    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Rotation(num);
 }
 }  // namespace literals

--- a/include/pros/serial.hpp
+++ b/include/pros/serial.hpp
@@ -338,7 +338,23 @@ namespace literals {
  * }
  * \endcode
  */
-const pros::Serial operator"" _ser(const unsigned long long int m);
+template <char... Cs>
+const pros::Serial operator"" _ser() {
+    constexpr int num = ([] (auto a) consteval {
+        int num;
+        auto iter = a.begin();
+        for(; iter != a.end(); iter++) {
+            if (*iter != 0) {break;}
+        }
+        if (a.end()-iter > 2 || iter==a.end()) return 0;
+        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
+        else num = *iter;
+        if (num > 21 || num <= 0) return 0;
+        return num;
+    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
+    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    return pros::Serial(num);
+}
 }  // namespace literals
 }  // namespace pros
 #endif  // _PROS_SERIAL_HPP_

--- a/include/pros/serial.hpp
+++ b/include/pros/serial.hpp
@@ -340,19 +340,8 @@ namespace literals {
  */
 template <char... Cs>
 const pros::Serial operator"" _ser() {
-    constexpr int num = ([] (auto a) consteval {
-        int num;
-        auto iter = a.begin();
-        for(; iter != a.end(); iter++) {
-            if (*iter != 0) {break;}
-        }
-        if (a.end()-iter > 2 || iter==a.end()) return 0;
-        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
-        else num = *iter;
-        if (num > 21 || num <= 0) return 0;
-        return num;
-    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
-    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Serial(num);
 }
 }  // namespace literals

--- a/include/pros/serial.hpp
+++ b/include/pros/serial.hpp
@@ -340,7 +340,7 @@ namespace literals {
  */
 template <char... Cs>
 const pros::Serial operator"" _ser() {
-    static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    static_assert(pros::detail::is_valid_port<Cs...>(), "Invalid port number!");
     constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Serial(num);
 }

--- a/include/pros/vision.hpp
+++ b/include/pros/vision.hpp
@@ -781,7 +781,23 @@ namespace literals {
  * }
  * \endcode
  */
-const pros::Vision operator"" _vis(const unsigned long long int m);
+template<char... Cs>
+const pros::Vision operator"" _vis() {
+    constexpr int num = ([] (auto a) consteval {
+        int num;
+        auto iter = a.begin();
+        for(; iter != a.end(); iter++) {
+            if (*iter != 0) {break;}
+        }
+        if (a.end()-iter > 2 || iter==a.end()) return 0;
+        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
+        else num = *iter;
+        if (num > 21 || num <= 0) return 0;
+        return num;
+    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
+    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    return pros::Vision(num);
+}
 }  // namespace literals
 }  // namespace pros
 #endif  // _PROS_VISION_HPP_

--- a/include/pros/vision.hpp
+++ b/include/pros/vision.hpp
@@ -783,7 +783,7 @@ namespace literals {
  */
 template<char... Cs>
 const pros::Vision operator"" _vis() {
-    static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    static_assert(pros::detail::is_valid_port<Cs...>(), "Invalid port number!");
     constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Vision(num);
 }

--- a/include/pros/vision.hpp
+++ b/include/pros/vision.hpp
@@ -783,19 +783,8 @@ namespace literals {
  */
 template<char... Cs>
 const pros::Vision operator"" _vis() {
-    constexpr int num = ([] (auto a) consteval {
-        int num;
-        auto iter = a.begin();
-        for(; iter != a.end(); iter++) {
-            if (*iter != 0) {break;}
-        }
-        if (a.end()-iter > 2 || iter==a.end()) return 0;
-        if (a.end()-iter == 2) num = (*iter) * 10 + *(iter+1);
-        else num = *iter;
-        if (num > 21 || num <= 0) return 0;
-        return num;
-    })(std::initializer_list<unsigned char>{(static_cast<unsigned char>(Cs-'0'))...});
-    static_assert(num != 0, "\033[31;1;4m[!!!]\033[0m Port out of bounds");
+    static_assert(pros::detail::is_valid_port<Cs...>(), "Port is out of range!");
+    constexpr int num = pros::detail::parse_port<Cs...>();
     return pros::Vision(num);
 }
 }  // namespace literals

--- a/src/devices/vdml_distance.cpp
+++ b/src/devices/vdml_distance.cpp
@@ -59,10 +59,5 @@ std::ostream& operator<<(std::ostream& os, pros::Distance& distance) {
 	return os;
 }
 
-namespace literals {
-const pros::Distance operator"" _dist(const unsigned long long int d) {
-    return pros::Distance(d);
-}
-} // namespace literals
 } // namespace v5
 }  // namespace pros

--- a/src/devices/vdml_gps.cpp
+++ b/src/devices/vdml_gps.cpp
@@ -150,10 +150,5 @@ pros::Gps pros::Gps::get_gps() {
 	return Gps(PROS_ERR_BYTE);
 }
 
-namespace literals {
-const pros::Gps operator""_gps(const unsigned long long int g) {
-	return pros::Gps(g);
-}
-}  // namespace literals
 }  // namespace v5
 }  // namespace pros

--- a/src/devices/vdml_imu.cpp
+++ b/src/devices/vdml_imu.cpp
@@ -176,10 +176,5 @@ std::ostream& operator<<(std::ostream& os, const pros::Imu& imu) {
 	return os;
 }
 
-namespace literals {
-const pros::Imu operator"" _imu(const unsigned long long int i) {
-	return pros::Imu(i);
-}
-}  // namespace literals
 }  // namespace v5
 }  // namespace pros

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -551,12 +551,4 @@ std::ostream& operator<<(std::ostream& os, pros::Motor& motor) {
 }
 
 }  // namespace v5
-namespace literals {
-const pros::Motor operator"" _mtr(const unsigned long long int m) {
-	return pros::Motor(m);
-}
-const pros::Motor operator"" _rmtr(const unsigned long long int m) {
-	return pros::Motor(-m);
-}
-}  // namespace literals
 }  // namespace pros

--- a/src/devices/vdml_optical.cpp
+++ b/src/devices/vdml_optical.cpp
@@ -90,11 +90,5 @@ std::ostream& operator<<(std::ostream& os, pros::Optical& optical) {
   return os;
 }
 
-namespace literals {
-const pros::Optical operator"" _opt(const unsigned long long int o) {
-  return pros::Optical(o);
-}
-} //
-
 } // namespace v5
 } // namespace pros

--- a/src/devices/vdml_rotation.cpp
+++ b/src/devices/vdml_rotation.cpp
@@ -84,11 +84,5 @@ std::ostream& operator<<(std::ostream& os, const pros::Rotation& rotation) {
 	return os;
 }
 
-namespace literals {
-const pros::Rotation operator"" _rot(const unsigned long long int r) {
-	return pros::Rotation(r);
-}
-}  // namespace literals
-
 }  // namespace v5
 }  // namespace pros

--- a/src/devices/vdml_serial.cpp
+++ b/src/devices/vdml_serial.cpp
@@ -62,9 +62,4 @@ std::int32_t Serial::write(std::uint8_t* buffer, std::int32_t length) const {
 	return serial_write(_port, buffer, length);
 }
 
-namespace literals {
-const pros::Serial operator"" _ser(const unsigned long long int m) {
-	return pros::Serial(m);
-}
-}  // namespace literals
 }  // namespace pros

--- a/src/devices/vdml_vision.cpp
+++ b/src/devices/vdml_vision.cpp
@@ -140,10 +140,4 @@ Vision Vision::get_vision() {
 }
 
 }  // namespace v5
-namespace literals {
-const pros::Vision operator"" _vis(const unsigned long long int m) {
-	return Vision(m);
-}
-
-}  // namespace literals
 }  // namespace pros


### PR DESCRIPTION
#### Summary:
Checks port numbers for device literals at compile time rather than at runtime. (Thanks to @djava for giving me suggestions on refactoring my mess of templates into actually readable code)

#### Motivation:
If something can be checked at compile time, it should be checked at compile time.

#### Test Plan:
- [x] check it compiles
- [ ] check that port literals work as expected
- [ ] check that out of range port numbers give a compile time error that is readable

#### Note:
This is an ABI breaking change and therefore should be a minor version bump.