### PR TITLE
:technologist: Deprecate LLEMU if liblvgl is not present

### DIFF
--- a/include/pros/llemu.h
+++ b/include/pros/llemu.h
@@ -41,7 +41,7 @@ namespace c {
  * \return True if the operation was successful, or false otherwise, setting
  * errno values as specified above.
  */
-bool __attribute__((weak)) lcd_print(int16_t line, const char* fmt, ...)  {
+bool __attribute__((weak)) lcd_print(__attribute__((unused)) int16_t line, __attribute__((unused)) const char* fmt, ...)  {
     return false;
 }
 

--- a/include/pros/llemu.h
+++ b/include/pros/llemu.h
@@ -3,6 +3,7 @@
 
 // TODO:? Should there be weak symbols for the C api in here as well?
 
+#include "stdbool.h"
 #include "stdint.h"
 
 /******************************************************************************/

--- a/include/pros/llemu.hpp
+++ b/include/pros/llemu.hpp
@@ -47,7 +47,11 @@ namespace pros {
 /**
  * \ingroup cpp-llemu 
  */
+#ifdef _PROS_INCLUDE_LIBLVGL_LLEMU_HPP
 namespace lcd {
+#else
+namespace [[deprecated("Without liblvgl, LLEMU functions will not display anything. To install liblvgl run \"pros c install liblvgl\" in the PROS terminal.")]] lcd {
+#endif
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wunused-function"
     namespace {


### PR DESCRIPTION
#### Summary:
Deprecates all LLEMU functions if liblvgl is not installed.

#### Motivation:
Helps users troubleshoot this issue easier.

#### Test Plan:

- [x] Check that using LLEMU without liblvgl creates a warning when compiling
- [x] Check that using LLEMU with liblvgl does not create a warning when compiling
