### PR TITLE
Fixed "make all" failing when IS_LIBRARY:=1

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -193,6 +193,7 @@ clean-template:
 	-$Drm -rf $(TEMPLATE_DIR)
 
 $(LIBAR): $(call GETALLOBJ,$(EXCLUDE_SRC_FROM_LIB)) $(EXTRA_LIB_DEPS)
+	-$Dmkdir $(BINDIR)
 	-$Drm -f $@
 	$(call test_output_2,Creating $@ ,$(AR) rcs $@ $^, $(DONE_STRING))
 


### PR DESCRIPTION
#### Summary:
Created the "bin" directory at the start when compiling a library

#### Motivation:
Not sure if this is the right place to modify this but currently, on a fresh project, changing to `IS_LIBRARY:=1` in the Makefile and running `pros make all` will fail to compile. The issue is caused by not being able to find the "bin" folder.

#### Test Plan:

1. Create a new project
2. Change  `IS_LIBRARY:=1` in the Makefile
3. Run `pros make all`
4. Failure expected
5. Update common.mk with changes
6. Run `pros make all`
7. Success expected
