### PR TITLE
✨ Added Motor Group Append/Erase Functions

### DIFF
--- a/include/pros/motor_group.hpp
+++ b/include/pros/motor_group.hpp
@@ -2357,6 +2357,15 @@ class MotorGroup : public virtual AbstractMotor {
 	 */
 	void append(AbstractMotor&);
 
+
+	/**
+	 * Appends all the motors on the port to this motor group
+	 *
+	 * \param port The port to append to the motor group
+	 *
+	 */
+	void append(std::int8_t port);
+
 	/**
 	 * Removes the all motors on the port (regardless of reversal) from the motor group
 	 *
@@ -2364,6 +2373,19 @@ class MotorGroup : public virtual AbstractMotor {
 	 *
 	 */
 	void erase_port(std::int8_t port);
+
+	/**
+	 * Removes all the motors in the other motor group reference from this motor group
+	 *
+	 * Maintains the order of the other motor group
+	 *
+	 */
+	void operator-=(AbstractMotor&);
+
+	/**
+	 * Removes all the motors in the other motor group reference from this motor group
+	 */
+	void erase_port(AbstractMotor&);
 
 	///@}
 	private:

--- a/src/devices/vdml_motorgroup.cpp
+++ b/src/devices/vdml_motorgroup.cpp
@@ -677,7 +677,6 @@ void MotorGroup::erase_port(std::int8_t port) {
 	}
 }
 
-// Question: Do we need to deal with port is already part of motor group?
 void MotorGroup::append(std::int8_t port) {
 	_ports.push_back(port);
 }

--- a/src/devices/vdml_motorgroup.cpp
+++ b/src/devices/vdml_motorgroup.cpp
@@ -676,5 +676,29 @@ void MotorGroup::erase_port(std::int8_t port) {
 		}
 	}
 }
+
+// Question: Do we need to deal with port is already part of motor group?
+void MotorGroup::append(std::int8_t port) {
+	_ports.push_back(port);
+}
+
+void MotorGroup::operator-=(AbstractMotor& other) {
+	auto ports = other.get_port_all();
+	for (auto it = ports.begin(); it < ports.end(); it++) {
+		auto port = *it;
+
+		// Locate port in _ports, remove if found
+		auto port_it = std::find(_ports.begin(), _ports.end(), port); 
+		if (port_it != _ports.end()) {
+			_ports.erase(port_it);
+		}
+	}
+}
+
+void MotorGroup::erase_port(AbstractMotor& other) {
+	(*this) -= other;
+}
+
+
 }  // namespace v5
 }  // namespace pros

--- a/src/devices/vdml_motorgroup.cpp
+++ b/src/devices/vdml_motorgroup.cpp
@@ -678,20 +678,24 @@ void MotorGroup::erase_port(std::int8_t port) {
 }
 
 void MotorGroup::append(std::int8_t port) {
-	_ports.push_back(port);
+	if (std::find_if(_ports.begin(), _ports.end(), 
+                     [port](std::int8_t p) { return std::abs(p) == std::abs(port); }) 
+        == _ports.end()) {
+        // If no matching absolute value is found, append the port
+        _ports.push_back(port);
+    }
 }
 
 void MotorGroup::operator-=(AbstractMotor& other) {
 	auto ports = other.get_port_all();
-	for (auto it = ports.begin(); it < ports.end(); it++) {
-		auto port = *it;
 
-		// Locate port in _ports, remove if found
-		auto port_it = std::find(_ports.begin(), _ports.end(), port); 
-		if (port_it != _ports.end()) {
-			_ports.erase(port_it);
-		}
-	}
+	// Iterate over the ports in 'other'
+    for (auto port : ports) {
+        // Remove ports that match the absolute value
+        _ports.erase(std::remove_if(_ports.begin(), _ports.end(),
+            [port](std::int8_t p) { return std::abs(p) == std::abs(port); }),
+            _ports.end());
+    }
 }
 
 void MotorGroup::erase_port(AbstractMotor& other) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,12 @@ void opcontrol() {
 	pros::MotorGroup left_mg({1, -2, 3});    // Creates a motor group with forwards ports 1 & 3 and reversed port 2
 	pros::MotorGroup right_mg({-4, 5, -6});  // Creates a motor group with forwards port 5 and reversed ports 4 & 6
 
+	// Create test motor group
+	pros::MotorGroup test({7, 8});
+	// Try to append port using new append function
+	left_mg.append(7);
+	// Try to erase ports using new erase function
+	left_mg.erase_port(test);
 
 	while (true) {
 		pros::lcd::print(0, "%d %d %d", (pros::lcd::read_buttons() & LCD_BTN_LEFT) >> 2,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,13 +78,6 @@ void opcontrol() {
 	pros::MotorGroup left_mg({1, -2, 3});    // Creates a motor group with forwards ports 1 & 3 and reversed port 2
 	pros::MotorGroup right_mg({-4, 5, -6});  // Creates a motor group with forwards port 5 and reversed ports 4 & 6
 
-	// Create test motor group
-	pros::MotorGroup test({7, 8});
-	// Try to append port using new append function
-	left_mg.append(7);
-	// Try to erase ports using new erase function
-	left_mg.erase_port(test);
-
 	while (true) {
 		pros::lcd::print(0, "%d %d %d", (pros::lcd::read_buttons() & LCD_BTN_LEFT) >> 2,
 		                 (pros::lcd::read_buttons() & LCD_BTN_CENTER) >> 1,


### PR DESCRIPTION
#### Summary:
Added append function that takes in port number and erase function that takes in reference to motor group.

#### Motivation:
The append function previously required a reference to the motor group, and the erase function required a port number. This update allows the append function to accept a port number, and the erase function to use a reference to the motor group.

#### Test Plan:

- [x] Try appending port via port number to motor group
- [x] Try erasing motors in motor group via reference to motor group
