### PR TITLE
🚨 fix motorgroup compiler warnings

### DIFF
--- a/src/devices/vdml_motorgroup.cpp
+++ b/src/devices/vdml_motorgroup.cpp
@@ -562,7 +562,7 @@ std::int32_t MotorGroup::set_gearing(const motor_gearset_e_t gearset, const std:
 }
 std::int32_t MotorGroup::set_gearing(std::vector<motor_gearset_e_t> gearsets) const {
 	empty_MotorGroup_check(PROS_ERR);
-	for (size_t i = 0; i < gearsets.size(); i++) {
+	for (std::size_t i = 0; i < gearsets.size(); i++) {
 		this->set_gearing(gearsets[i], _ports[i]);
 	}
 	if (gearsets.size() != _ports.size()) {
@@ -573,7 +573,7 @@ std::int32_t MotorGroup::set_gearing(std::vector<motor_gearset_e_t> gearsets) co
 
 std::int32_t MotorGroup::set_gearing(std::vector<MotorGears> gearsets) const {
 	empty_MotorGroup_check(PROS_ERR);
-	for (size_t i = 0; i < gearsets.size(); i++) {
+	for (std::size_t i = 0; i < gearsets.size(); i++) {
 		this->set_gearing(gearsets[i], _ports[i]);
 	}
 	if (gearsets.size() != _ports.size()) {

--- a/src/devices/vdml_motorgroup.cpp
+++ b/src/devices/vdml_motorgroup.cpp
@@ -562,7 +562,7 @@ std::int32_t MotorGroup::set_gearing(const motor_gearset_e_t gearset, const std:
 }
 std::int32_t MotorGroup::set_gearing(std::vector<motor_gearset_e_t> gearsets) const {
 	empty_MotorGroup_check(PROS_ERR);
-	for (uint32_t i = 0; i < gearsets.size(); i++) {
+	for (size_t i = 0; i < gearsets.size(); i++) {
 		this->set_gearing(gearsets[i], _ports[i]);
 	}
 	if (gearsets.size() != _ports.size()) {

--- a/src/devices/vdml_motorgroup.cpp
+++ b/src/devices/vdml_motorgroup.cpp
@@ -10,6 +10,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <cstdint>
 #include "kapi.h"
 #include "pros/abstract_motor.hpp"
 #include "pros/motor_group.hpp"
@@ -561,7 +562,7 @@ std::int32_t MotorGroup::set_gearing(const motor_gearset_e_t gearset, const std:
 }
 std::int32_t MotorGroup::set_gearing(std::vector<motor_gearset_e_t> gearsets) const {
 	empty_MotorGroup_check(PROS_ERR);
-	for (int i = 0; i < gearsets.size(); i++) {
+	for (uint32_t i = 0; i < gearsets.size(); i++) {
 		this->set_gearing(gearsets[i], _ports[i]);
 	}
 	if (gearsets.size() != _ports.size()) {
@@ -572,7 +573,7 @@ std::int32_t MotorGroup::set_gearing(std::vector<motor_gearset_e_t> gearsets) co
 
 std::int32_t MotorGroup::set_gearing(std::vector<MotorGears> gearsets) const {
 	empty_MotorGroup_check(PROS_ERR);
-	for (int i = 0; i < gearsets.size(); i++) {
+	for (uint32_t i = 0; i < gearsets.size(); i++) {
 		this->set_gearing(gearsets[i], _ports[i]);
 	}
 	if (gearsets.size() != _ports.size()) {

--- a/src/devices/vdml_motorgroup.cpp
+++ b/src/devices/vdml_motorgroup.cpp
@@ -573,7 +573,7 @@ std::int32_t MotorGroup::set_gearing(std::vector<motor_gearset_e_t> gearsets) co
 
 std::int32_t MotorGroup::set_gearing(std::vector<MotorGears> gearsets) const {
 	empty_MotorGroup_check(PROS_ERR);
-	for (uint32_t i = 0; i < gearsets.size(); i++) {
+	for (size_t i = 0; i < gearsets.size(); i++) {
 		this->set_gearing(gearsets[i], _ports[i]);
 	}
 	if (gearsets.size() != _ports.size()) {


### PR DESCRIPTION
#### Summary:
fix motorgroup compiler warnings

#### Motivation:
Even though these specific warnings are harmless, it clutters the compiler output and may confuse new PROS developers.

#### Test Plan:
- [X] no warnings
