### PR TITLE
🚨 Fix make override warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ patch_sdk_headers: patch_headers.py
 	$(VV)python patch_headers.py
 
 # Override clean, necessary to remove patched sdk on clean
-clean:
+clean::
 	@echo "Cleaning patched SDK"
 	@rm -f $(PATCHED_SDK)
 	@rm -rf $(EXTRA_INCDIR)
@@ -75,7 +75,7 @@ CREATE_TEMPLATE_ARGS+=--user "src/main.{cpp,c,cc}" --user "include/main.{hpp,h,h
 CREATE_TEMPLATE_ARGS+=--target v5
 CREATE_TEMPLATE_ARGS+=--output bin/monolith.bin --cold_output bin/cold.package.bin --hot_output bin/hot.package.bin --cold_addr 58720256 --hot_addr 125829120
 
-template: patch_sdk_headers clean-template library
+template:: patch_sdk_headers clean-template library
 	$(VV)mkdir -p $(TEMPLATE_DIR)
 	@echo "Moving template files to $(TEMPLATE_DIR)"
 	$Dif [ $(shell uname -s) == "Darwin" ]; then \
@@ -91,7 +91,7 @@ template: patch_sdk_headers clean-template library
 	$Dpros c create-template $(TEMPLATE_DIR) kernel $(shell cat $(ROOT)/version) $(CREATE_TEMPLATE_ARGS)
 
 LIBV5RTS_EXTRACTION_DIR=$(BINDIR)/libv5rts
-$(LIBAR): patch_sdk_headers $(call GETALLOBJ,$(EXCLUDE_SRC_FROM_LIB)) $(EXTRA_LIB_DEPS)
+$(LIBAR):: patch_sdk_headers $(call GETALLOBJ,$(EXCLUDE_SRC_FROM_LIB)) $(EXTRA_LIB_DEPS)
 	$(VV)mkdir -p $(LIBV5RTS_EXTRACTION_DIR)
 	$(call test_output_2,Extracting libv5rts ,cd $(LIBV5RTS_EXTRACTION_DIR) && $(AR) x ../../$(PATCHED_SDK),$(DONE_STRING))
 	$(eval LIBV5RTS_OBJECTS := $(shell $(AR) t $(PATCHED_SDK)))

--- a/common.mk
+++ b/common.mk
@@ -188,7 +188,7 @@ quick: $(DEFAULT_BIN)
 
 all: clean $(DEFAULT_BIN)
 
-clean:
+clean::
 	@echo Cleaning project
 	-$Drm -rf $(BINDIR)
 	-$Drm -rf $(DEPDIR)
@@ -205,7 +205,7 @@ clean-template:
 	@echo Cleaning $(TEMPLATE_DIR)
 	-$Drm -rf $(TEMPLATE_DIR)
 
-$(LIBAR): $(call GETALLOBJ,$(EXCLUDE_SRC_FROM_LIB)) $(EXTRA_LIB_DEPS)
+$(LIBAR):: $(call GETALLOBJ,$(EXCLUDE_SRC_FROM_LIB)) $(EXTRA_LIB_DEPS)
 	-$Drm -f $@
 	$(call test_output_2,Creating $@ ,$(AR) rcs $@ $^, $(DONE_STRING))
 
@@ -213,7 +213,7 @@ $(LIBAR): $(call GETALLOBJ,$(EXCLUDE_SRC_FROM_LIB)) $(EXTRA_LIB_DEPS)
 library: $(LIBAR)
 
 .PHONY: template
-template: clean-template $(LIBAR)
+template:: clean-template $(LIBAR)
 	$Dpros c create-template . $(LIBNAME) $(VERSION) $(foreach file,$(TEMPLATE_FILES) $(LIBAR),--system "$(file)") --target v5 $(CREATE_TEMPLATE_FLAGS)
 endif
 


### PR DESCRIPTION
#### Summary:
Fix make target override warnings

#### Motivation:
This behavior has been well thought out and is intentional. These warnings are not required.

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [X] no warnings
