### PR TITLE
chore: :page_facing_up: update copyright to 2024, update license to PROS 4

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
-PROS 3.0 contains modified or linked source code from the following packages:
+PROS 4.0 contains modified or linked source code from the following packages:
     - FreeRTOS (src/rtos/LICENSE)
 
-Unless otherwise specified, PROS 3.0 is distributed under the Mozilla Public
+Unless otherwise specified, PROS 4.0 is distributed under the Mozilla Public
 License Version 2.0, reproduced below:
 
 Mozilla Public License Version 2.0

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -46,7 +46,7 @@ These should be placed at the very start of a file.
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/api.h
+++ b/include/api.h
@@ -8,7 +8,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/common/cobs.h
+++ b/include/common/cobs.h
@@ -5,7 +5,7 @@
  *
  * See common/cobs.c for discussion
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/common/gid.h
+++ b/include/common/gid.h
@@ -5,7 +5,7 @@
  *
  * See common/gid.c for discussion
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/common/linkedlist.h
+++ b/include/common/linkedlist.h
@@ -6,7 +6,7 @@
  * This file defines a linked list implementation that operates on the FreeRTOS
  * heap, and is able to generically store function pointers and data
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/common/set.h
+++ b/include/common/set.h
@@ -5,7 +5,7 @@
  *
  * See common/set.c for discussion
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/common/string.h
+++ b/include/common/string.h
@@ -5,7 +5,7 @@
  *
  * See common/string.c for discussion
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/kapi.h
+++ b/include/kapi.h
@@ -8,7 +8,7 @@
  * creation of statically allocated FreeRTOS primitives like tasks, semaphores,
  * and queues.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/main.h
+++ b/include/main.h
@@ -4,7 +4,7 @@
  * Contains common definitions and header files used throughout your PROS
  * project.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/abstract_motor.hpp
+++ b/include/pros/abstract_motor.hpp
@@ -9,7 +9,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/adi.h
+++ b/include/pros/adi.h
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/apix.h
+++ b/include/pros/apix.h
@@ -11,7 +11,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/colors.h
+++ b/include/pros/colors.h
@@ -6,7 +6,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2020 Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/colors.hpp
+++ b/include/pros/colors.hpp
@@ -6,7 +6,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2022 Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/device.h
+++ b/include/pros/device.h
@@ -8,7 +8,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2021, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/device.hpp
+++ b/include/pros/device.hpp
@@ -6,7 +6,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2021, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/distance.h
+++ b/include/pros/distance.h
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/distance.hpp
+++ b/include/pros/distance.hpp
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/error.h
+++ b/include/pros/error.h
@@ -6,7 +6,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/ext_adi.h
+++ b/include/pros/ext_adi.h
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/gps.h
+++ b/include/pros/gps.h
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/gps.hpp
+++ b/include/pros/gps.hpp
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/imu.h
+++ b/include/pros/imu.h
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/imu.hpp
+++ b/include/pros/imu.hpp
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/link.h
+++ b/include/pros/link.h
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/link.hpp
+++ b/include/pros/link.hpp
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * Copyright (c) 2017-2021, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/llemu.hpp
+++ b/include/pros/llemu.hpp
@@ -11,7 +11,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/misc.h
+++ b/include/pros/misc.h
@@ -8,7 +8,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reservered.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/misc.hpp
+++ b/include/pros/misc.hpp
@@ -8,7 +8,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reservered.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/motor_group.hpp
+++ b/include/pros/motor_group.hpp
@@ -10,7 +10,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/motors.h
+++ b/include/pros/motors.h
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/motors.hpp
+++ b/include/pros/motors.hpp
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/optical.h
+++ b/include/pros/optical.h
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/optical.hpp
+++ b/include/pros/optical.hpp
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/rotation.h
+++ b/include/pros/rotation.h
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/rotation.hpp
+++ b/include/pros/rotation.hpp
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/rtos.h
+++ b/include/pros/rtos.h
@@ -8,7 +8,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/rtos.hpp
+++ b/include/pros/rtos.hpp
@@ -8,7 +8,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/screen.h
+++ b/include/pros/screen.h
@@ -6,7 +6,7 @@
  *
  * Contains user calls to the v5 screen for touching and displaying graphics.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/screen.hpp
+++ b/include/pros/screen.hpp
@@ -6,7 +6,7 @@
  *
  * Contains user calls to the v5 screen for touching and displaying graphics.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/serial.h
+++ b/include/pros/serial.h
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/serial.hpp
+++ b/include/pros/serial.hpp
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pros/version.h
+++ b/include/pros/version.h
@@ -6,7 +6,7 @@
 * Contains PROS kernel version information
 *
 *
-* \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+* \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
 * All rights reserved.
 *
 * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/vision.h
+++ b/include/pros/vision.h
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/pros/vision.hpp
+++ b/include/pros/vision.hpp
@@ -7,7 +7,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/system/dev/banners.h
+++ b/include/system/dev/banners.h
@@ -7,7 +7,7 @@
  *
  * See system/dev/serial_daemon.c for discussion
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/system/dev/dev.h
+++ b/include/system/dev/dev.h
@@ -3,7 +3,7 @@
  *
  * Generic Serial Device driver header
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/system/dev/ser.h
+++ b/include/system/dev/ser.h
@@ -5,7 +5,7 @@
  *
  * See system/dev/ser_driver.c and system/dev/ser_daemon.c for discussion
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/system/dev/usd.h
+++ b/include/system/dev/usd.h
@@ -5,7 +5,7 @@
  *
  * See system/dev/usd_driver.c for discussion
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/system/dev/vfs.h
+++ b/include/system/dev/vfs.h
@@ -5,7 +5,7 @@
  *
  * See system/dev/vfs.c for discussion
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/system/optimizers.h
+++ b/include/system/optimizers.h
@@ -5,7 +5,7 @@
  *
  * Probably shouldn't use anything from this header
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/vdml/port.h
+++ b/include/vdml/port.h
@@ -4,7 +4,7 @@
  * This file contains the standard header info for port macros and bit masks, 
  * used mostly for the adi expander.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/include/vdml/registry.h
+++ b/include/vdml/registry.h
@@ -4,7 +4,7 @@
  * This file contains the standard header info for the VDML (Vex Data Management
  * Layer) registry.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/vdml/vdml.h
+++ b/include/vdml/vdml.h
@@ -4,7 +4,7 @@
  * This file contains all types and functions used throughout multiple VDML
  * (Vex Data Management Layer) files.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/common/cobs.c
+++ b/src/common/cobs.c
@@ -6,7 +6,7 @@
  * Contains an implementation of Consistent Overhead Byte Stuffing, adapted from
  * https://github.com/jacquesf/COBS-Consistent-Overhead-Byte-Stuffing
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/common/gid.c
+++ b/src/common/gid.c
@@ -6,7 +6,7 @@
  * Contains an implementation to efficiently assign globally unique IDs
  * e.g. to assign entries in a global table
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/common/linkedlist.c
+++ b/src/common/linkedlist.c
@@ -6,7 +6,7 @@
  * This file defines a linked list implementation that operates on the FreeRTOS
  * heap, and is able to generically store function pointers and data
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/common/set.c
+++ b/src/common/set.c
@@ -5,7 +5,7 @@
  * It's used to check which streams are enabled in ser_driver for the moment,
  * but also has list_contains which may be useful in other contexts.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/common/string.c
+++ b/src/common/string.c
@@ -4,7 +4,7 @@
  * Contains extra string functions useful for PROS and kstrdup/kstrndup which
  * use the kernel heap instead of the user heap
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/devices/battery.c
+++ b/src/devices/battery.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 Battery.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/devices/battery.cpp
+++ b/src/devices/battery.cpp
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 Battery.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 Controller.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/devices/controller.cpp
+++ b/src/devices/controller.cpp
@@ -4,7 +4,7 @@
  * Contains functions for interacting with the V5 Controller, as well as the
  * competition control functions.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/devices/registry.c
+++ b/src/devices/registry.c
@@ -5,7 +5,7 @@
  * what devices are in use on the V5. Therefore, in order to use V5 devices with
  * PROS, they must be registered and deregistered using the registry.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/screen.c
+++ b/src/devices/screen.c
@@ -5,7 +5,7 @@
  *
  * Contains user calls to the v5 screen for touching and displaying graphics.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/screen.cpp
+++ b/src/devices/screen.cpp
@@ -5,7 +5,7 @@
  *
  * Contains user calls to the v5 screen for touching and displaying graphics.
  *
- * \copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml.c
+++ b/src/devices/vdml.c
@@ -6,7 +6,7 @@
  * VDML ensures thread saftey for operations on smart devices by maintaining
  * an array of RTOS Mutexes and implementing functions to take and give them.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_adi.c
+++ b/src/devices/vdml_adi.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 ADI.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_adi.cpp
+++ b/src/devices/vdml_adi.cpp
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 ADI.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_device.c
+++ b/src/devices/vdml_device.c
@@ -8,7 +8,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2021, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_device.cpp
+++ b/src/devices/vdml_device.cpp
@@ -8,7 +8,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright (c) 2017-2021, Purdue University ACM SIGBots.
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_distance.c
+++ b/src/devices/vdml_distance.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the VEX Distance sensor.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_distance.cpp
+++ b/src/devices/vdml_distance.cpp
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the VEX Distance sensor.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_ext_adi.c
+++ b/src/devices/vdml_ext_adi.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 3-Wire Expander.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_gps.c
+++ b/src/devices/vdml_gps.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the VEX GPS.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_gps.cpp
+++ b/src/devices/vdml_gps.cpp
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the VEX GPS.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_imu.c
+++ b/src/devices/vdml_imu.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the VEX Inertial sensor.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_imu.cpp
+++ b/src/devices/vdml_imu.cpp
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the VEX Inertial sensor.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_link.c
+++ b/src/devices/vdml_link.c
@@ -6,7 +6,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_link.cpp
+++ b/src/devices/vdml_link.cpp
@@ -6,7 +6,7 @@
  * This file should not be modified by users, since it gets replaced whenever
  * a kernel upgrade occurs.
  * 
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_motorgroup.cpp
+++ b/src/devices/vdml_motorgroup.cpp
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 Motors.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_motors.c
+++ b/src/devices/vdml_motors.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 Motors.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 Motors.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_optical.c
+++ b/src/devices/vdml_optical.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the VEX Optical sensor.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_optical.cpp
+++ b/src/devices/vdml_optical.cpp
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the VEX Optical sensor.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_rotation.c
+++ b/src/devices/vdml_rotation.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the VEX Rotation sensor.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_rotation.cpp
+++ b/src/devices/vdml_rotation.cpp
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the VEX Rotation sensor.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_serial.c
+++ b/src/devices/vdml_serial.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with V5 Generic Serial devices.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_serial.cpp
+++ b/src/devices/vdml_serial.cpp
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with V5 Generic Serial devices.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_usd.c
+++ b/src/devices/vdml_usd.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the SD card.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/devices/vdml_usd.cpp
+++ b/src/devices/vdml_usd.cpp
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the SD card.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/devices/vdml_vision.c
+++ b/src/devices/vdml_vision.c
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 Vision Sensor.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/devices/vdml_vision.cpp
+++ b/src/devices/vdml_vision.cpp
@@ -3,7 +3,7 @@
  *
  * Contains functions for interacting with the V5 Vision Sensor.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/rtos/rtos.cpp
+++ b/src/rtos/rtos.cpp
@@ -4,7 +4,7 @@
  * Contains functions for the PROS RTOS kernel for use by typical
  * VEX programmers.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/cpp_support.cpp
+++ b/src/system/cpp_support.cpp
@@ -3,7 +3,7 @@
  *
  * C++ support hooks
  *
- * Copyright (c) 2017-2021, Purdue University ACM SIGBots
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/dev/dev_driver.c
+++ b/src/system/dev/dev_driver.c
@@ -6,7 +6,7 @@
  * Contains the driver for writing to any smart port with no regard to the
  * device on the other end.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/dev/file_system_stubs.c
+++ b/src/system/dev/file_system_stubs.c
@@ -6,7 +6,7 @@
  * Contains temporary stubs for the file system to allow compilation under gcc 9.2
  * This is temporary and should be removed as part of #184
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/dev/ser_daemon.c
+++ b/src/system/dev/ser_daemon.c
@@ -7,7 +7,7 @@
  * characters and responding to any kernel commands (like printing the banner or
  * enabling COBS)
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/dev/ser_driver.c
+++ b/src/system/dev/ser_driver.c
@@ -6,7 +6,7 @@
  * Contains the driver for communicating over the serial line. The serial driver
  * is responsible for shipping out all data.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/dev/usd_driver.c
+++ b/src/system/dev/usd_driver.c
@@ -3,7 +3,7 @@
  *
  * Contains the driver for writing files to the microSD card.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/envlock.c
+++ b/src/system/envlock.c
@@ -5,7 +5,7 @@
  *
  * Contains implementations of environment-locking functions for newlib.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/mlock.c
+++ b/src/system/mlock.c
@@ -5,7 +5,7 @@
  *
  * Contains implementations of memory-locking functions for newlib.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/newlib_stubs.c
+++ b/src/system/newlib_stubs.c
@@ -6,7 +6,7 @@
  * Contains the various methods needed to enable standard C library support
  * through the use of the Arm-distributed implementation of newlib.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/rtos_hooks.c
+++ b/src/system/rtos_hooks.c
@@ -6,7 +6,7 @@
  * FreeRTOS requires some porting to each platform to handle certain tasks. This
  * file contains the various methods required to be implemented for FreeRTOS.
  *
- * Copyright (c) 2017-2021, Purdue University ACM SIGBots
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/startup.c
+++ b/src/system/startup.c
@@ -5,7 +5,7 @@
  * code. Our main() initializes data structures and starts the FreeRTOS
  * scheduler.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/system_daemon.c
+++ b/src/system/system_daemon.c
@@ -3,7 +3,7 @@
  *
  * Competition control daemon responsible for invoking the user tasks.
  *
- * Copyright (c) 2017-2021, Purdue University ACM SIGBots
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/system/unwind.c
+++ b/src/system/unwind.c
@@ -5,7 +5,7 @@
  * be arbitrarily stopped, requiring us to call all the destructors of the task
  * to be killed.
  *
- * Copyright (c) 2017-2021, Purdue University ACM SIGBots
+ * \copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/tests/adi.cpp
+++ b/src/tests/adi.cpp
@@ -6,7 +6,7 @@
  * NOTE: There should also be a call to the constructor for the gyroscope object
  * in initialize() for calibration to occur before the opcontrol code.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/tests/ext_adi.cpp
+++ b/src/tests/ext_adi.cpp
@@ -3,7 +3,7 @@
  *
  * Test code for various External ADI things
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/tests/generic_serial.cpp
+++ b/src/tests/generic_serial.cpp
@@ -6,7 +6,7 @@
  * NOTE: There should be a cable plugged into ports 1 and 2, connecting
  * them together
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/tests/generic_serial_file.cpp
+++ b/src/tests/generic_serial_file.cpp
@@ -6,7 +6,7 @@
  * NOTE: There should be a cable plugged into ports 1 and 2, connecting
  * them together
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/tests/gyro.c
+++ b/src/tests/gyro.c
@@ -6,7 +6,7 @@
  * NOTE: There should also be a call to the constructor for the gyroscope object
  * in initialize() for calibration to occur before the opcontrol code.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/tests/gyro.cpp
+++ b/src/tests/gyro.cpp
@@ -6,7 +6,7 @@
  * NOTE: There should also be a call to the constructor for the gyroscope object
  * in initialize() for calibration to occur before the opcontrol code.
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/tests/rtos_function_linking.c
+++ b/src/tests/rtos_function_linking.c
@@ -5,7 +5,7 @@
  *
  * Do not actually run this test - just make sure it compiles
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/tests/simple_names.c
+++ b/src/tests/simple_names.c
@@ -5,7 +5,7 @@
  *
  * Do not actually run this test - just make sure it compiles
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/src/tests/simple_names.cpp
+++ b/src/tests/simple_names.cpp
@@ -5,7 +5,7 @@
  *
  * Do not actually run this test - just make sure it compiles
  *
- * \copyright Copyright (c) 2017-2023, Purdue University ACM SIGBots.
+ * \copyright Copyright (c) 2017-2024, Purdue University ACM SIGBots.
  * All rights reserved.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public


### PR DESCRIPTION
#### Summary:
Self explanatory, updates the copyright year to 2024, and changes the license to refer to PROS 4, not PROS 3.

#### Motivation:
Detailed scientific examination reveals that it is currently 2024. (Also PROS 4 technically doesn't have a license right now)