### PR TITLE
🐛 Fix display when building a monolith

### DIFF
--- a/include/pros/llemu.h
+++ b/include/pros/llemu.h
@@ -15,7 +15,7 @@
 /******************************************************************************/
 #ifdef _PROS_INCLUDE_LIBLVGL_LLEMU_H
 #include "liblvgl/llemu.h"
-#endif
+#else
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,5 +50,7 @@ bool __attribute__((weak)) lcd_print(int16_t line, const char* fmt, ...)  {
 } // namespace pros
 } // extern "C"
 #endif//__cplusplus
+
+#endif // _PROS_INCLUDE_LIBLVGL_LLEMU_H
 
 #endif // _PROS_LLEMU_H_

--- a/include/pros/llemu.h
+++ b/include/pros/llemu.h
@@ -16,7 +16,7 @@
 /******************************************************************************/
 #ifdef _PROS_INCLUDE_LIBLVGL_LLEMU_H
 #include "liblvgl/llemu.h"
-#else
+#else // prevent lcd_print being resolved to definition below when liblvgl is present
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/pros/llemu.h
+++ b/include/pros/llemu.h
@@ -52,6 +52,6 @@ bool __attribute__((weak)) lcd_print(__attribute__((unused)) int16_t line, __att
 } // extern "C"
 #endif//__cplusplus
 
-#endif // _PROS_INCLUDE_LIBLVGL_LLEMU_H
+#endif // _PROS_INCLUDE_LIBLVGL_LLEMU_H not present
 
 #endif // _PROS_LLEMU_H_

--- a/include/pros/llemu.hpp
+++ b/include/pros/llemu.hpp
@@ -70,13 +70,14 @@ namespace lcd {
      * For documentation on these functions, please see the doxygen comments for
      * these functions in the libvgl llemu headers.
      */
-
+    #ifndef _PROS_INCLUDE_LIBLVGL_LLEMU_HPP
     extern __attribute__((weak)) bool set_text(std::int16_t line, std::string text);
     extern __attribute__((weak)) bool clear_line(std::int16_t line);
     extern __attribute__((weak)) bool initialize(void);
     extern __attribute__((weak)) std::uint8_t read_buttons(void);
     extern __attribute__((weak)) void register_btn1_cb(lcd_btn_cb_fn_t cb);
     extern __attribute__((weak)) bool is_initialized(void);
+    #endif // _PROS_INCLUDE_LIBLVGL_LLEMU_HPP
 
     /**
      * \addtogroup cpp-llemu

--- a/include/pros/screen.hpp
+++ b/include/pros/screen.hpp
@@ -712,6 +712,5 @@ const char* convert_args(const std::string& arg) {
 
 } // namespace pros
 
-extern __attribute__((weak)) void lvgl_init() {}
 ///@}
 #endif //header guard

--- a/src/system/startup.c
+++ b/src/system/startup.c
@@ -22,7 +22,6 @@ extern void rtos_initialize();
 extern void vfs_initialize();
 extern void system_daemon_initialize();
 extern void graphical_context_daemon_initialize(void);
-extern __attribute__((weak)) void display_initialize(void) {}
 extern void rtos_sched_start();
 extern void vdml_initialize();
 extern void invoke_install_hot_table();
@@ -33,7 +32,7 @@ extern void invoke_install_hot_table();
 // gives the compiler instructions on the priority of the constructor,
 // from 0-~65k. The first 0-100 priorities are reserved for language
 // implementation.
-__attribute__((constructor(101))) static void pros_init(void) {
+__attribute__((constructor(101))) static void pros_init_a(void) {
 	rtos_initialize();
 
 	vfs_initialize();
@@ -41,13 +40,16 @@ __attribute__((constructor(101))) static void pros_init(void) {
 	vdml_initialize();
 
 	graphical_context_daemon_initialize();
+}
 
-	display_initialize();
-
+__attribute__((constructor(103))) static void pros_init_b(void) {
 	// NOTE: this function should be called after all other initialize
 	// functions. for an example of what could happen if this is not
 	// the case, see
 	// https://github.com/purduesigbots/pros/pull/144/#issuecomment-496901942
+	// this is why this function is separate from pros_init_a
+	// this function has the "constructor(103)" attribute, because
+	// the display initialize function has the "constructor(102)" attribute
 	system_daemon_initialize();
 
 	invoke_install_hot_table();

--- a/src/system/startup.c
+++ b/src/system/startup.c
@@ -32,7 +32,7 @@ extern void invoke_install_hot_table();
 // gives the compiler instructions on the priority of the constructor,
 // from 0-~65k. The first 0-100 priorities are reserved for language
 // implementation.
-__attribute__((constructor(101))) static void pros_init_a(void) {
+__attribute__((constructor(101))) static void pros_init_stage_1(void) {
 	rtos_initialize();
 
 	vfs_initialize();
@@ -42,7 +42,7 @@ __attribute__((constructor(101))) static void pros_init_a(void) {
 	graphical_context_daemon_initialize();
 }
 
-__attribute__((constructor(103))) static void pros_init_b(void) {
+__attribute__((constructor(103))) static void pros_init_stage_2(void) {
 	// NOTE: this function should be called after all other initialize
 	// functions. for an example of what could happen if this is not
 	// the case, see


### PR DESCRIPTION
#### Summary:
Fix display when a project is built as a monolith

#### Motivation:
When you build a PROS project as a monolith, the display is unusable. This is because the weakly declared functions in `libpros.a` do not get overridden with the strongly declared functions in `liblvgl.a`, but only if building a monolith.

#### How does this fix work?
Weakly defined symbols are now only declared if LVGL is not present.
Except for one:
the `pros_initialize` function calls the weakly declared `display_initialize()` function. One solution would be to call this function after `pros_initialize`, in liblvgl.a. But alas, this won't work (see https://github.com/purduesigbots/pros/pull/144/#issuecomment-496901942). Instead, we initialize pros partially, then `display_initialize` is called as a constructor, then pros is initialized fully.

#### The underlying issue

The underlying issue is that weakly defined symbols do not get overridden, but only if building a monolith. Despite my best efforts, I was not able to identify the cause. It was not the order in which the libraries were linked, or the objects getting optimized out, since in my tests I eliminated both cases and the weakly declared functions still weren't overridden.

This PR does not fix this problem, it just treats the symptoms with a workaround.

#### Why does it work if using hot/cold linking?

Because all objects in every library are included in the cold package. When using a monolith, only the required objects are included. We could do the same when building a monolith, but this would cause the binary size to grow in size by an order of magnitude. Hence, this PR introduces a different workaround.

#### Incompatibilities

This PR requires a new version of liblvgl to be created. Current versions of liblvgl are not compatible with this version of pros. However, the new version of liblvgl will not be compatible with current versions of PROS. The new version of LVGL and the new version of PROS must be released simultaneously, and PROS would require, at minimum, a minor version increment (NOT a patch).

liblvgl pull request: https://github.com/purduesigbots/liblvgl/pull/51

See the related PR to liblvgl: 

#### Test Plan (pending on PROS team sharing a template zip):

This snippet works as expected when user code is built as
-[ ] hot/cold packages
-[ ] monolith

```c++
#include "main.h"

void initialize() {
    pros::lcd::initialize();
}
```