### PR TITLE
feat: :sparkles: Get the state of the controller's power button

### DIFF
--- a/include/pros/misc.h
+++ b/include/pros/misc.h
@@ -223,7 +223,9 @@ typedef enum {
 	/// The ‘Y’ button on the right button pad of the controller.
 	E_CONTROLLER_DIGITAL_Y,
 	/// The ‘A’ button on the right button pad of the controller.
-	E_CONTROLLER_DIGITAL_A
+	E_CONTROLLER_DIGITAL_A,
+	/// The power button on the front of the controller.
+	E_CONTROLLER_DIGITAL_POWER
 } controller_digital_e_t;
 
 #ifdef PROS_USE_SIMPLE_NAMES
@@ -246,6 +248,7 @@ typedef enum {
 #define DIGITAL_B pros::E_CONTROLLER_DIGITAL_B
 #define DIGITAL_Y pros::E_CONTROLLER_DIGITAL_Y
 #define DIGITAL_A pros::E_CONTROLLER_DIGITAL_A
+#define DIGITAL_POWER pros::E_CONTROLLER_DIGITAL_POWER
 #else
 #define CONTROLLER_MASTER E_CONTROLLER_MASTER
 #define CONTROLLER_PARTNER E_CONTROLLER_PARTNER

--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -21,17 +21,17 @@
 #define CONTROLLER_MAX_COLS 15
 
 // From enum in misc.h
-#define NUM_BUTTONS 12
+#define NUM_BUTTONS 13
 
 typedef struct controller_data {
 	bool button_pressed[NUM_BUTTONS];
 } controller_data_s_t;
 
-bool get_button_pressed(int port, int button) {
+static bool get_button_pressed(int port, int button) {
 	return ((controller_data_s_t*)registry_get_device_internal(port)->pad)->button_pressed[button];
 }
 
-void set_button_pressed(int port, int button, bool state) {
+static void set_button_pressed(int port, int button, bool state) {
 	controller_data_s_t* data = (controller_data_s_t*)registry_get_device_internal(port)->pad;
 	data->button_pressed[button] = state;
 }
@@ -71,7 +71,7 @@ int32_t controller_get_battery_level(controller_id_e_t id) {
 int32_t controller_get_digital(controller_id_e_t id, controller_digital_e_t button) {
 	uint8_t port;
 	CONTROLLER_PORT_MUTEX_TAKE(id, port)
-	// the buttons enum starts at 4, the correct place for the libv5rts
+	// the buttons enum starts at 6, the correct place for the libv5rts
 	int32_t rtn = vexControllerGet(id, button);
 	internal_port_mutex_give(port);
 	return rtn;


### PR DESCRIPTION
#### Summary:
Allows accessing the state of the power button on the controller.

#### Motivation:
It can be useful occasionally to be able to use the controller power button as an input.

#### Test Plan:

- [x] Check it compiles
- [x] Check that `controller_get_digital` works with the power button
- [x] Check that `controller_get_digital_new_press` works with the power button
