### PR TITLE
fix: :bug: Fix is_installed when using negative port reversed motors

### DIFF
--- a/src/devices/vdml_motors.cpp
+++ b/src/devices/vdml_motors.cpp
@@ -13,6 +13,7 @@
 #include "kapi.h"
 #include "pros/motors.hpp"
 #include "vdml/vdml.h"
+#include <cmath>
 
 namespace pros {
 inline namespace v5 {
@@ -20,7 +21,7 @@ using namespace pros::c;
 
 
 Motor::Motor(const std::int8_t port, const pros::v5::MotorGears gearset, const pros::v5::MotorUnits encoder_units)
-    : Device(port, DeviceType::motor), _port(port) {
+    : Device(std::abs(port), DeviceType::motor), _port(port) {
 	if (gearset != pros::v5::MotorGears::invalid) {
 		set_gearing(gearset);
 	}


### PR DESCRIPTION
#### Summary:
Fixed an issue where `is_installed` would not work with `Motor`s initialized with a negative port number.

#### Motivation:
Self explanatory.

##### References (optional):
Closes #736 

#### Test Plan:
- [x] Check that `is_installed` works with positive motor ports
- [x] Check that `is_installed` works with negative motor ports
