### PR TITLE
feat: :sparkles: Allow disabling PROS banner

### DIFF
--- a/include/pros/apix.h
+++ b/include/pros/apix.h
@@ -690,11 +690,17 @@ void enable_banner(bool enabled);
  * \param enable
  *          Whether the banner should be enabled or disabled.
  */
+#ifdef __cplusplus
+#define ENABLE_BANNER(enabled) static_assert(!__builtin_strcmp(__FUNCTION__, "top level"),                            \
+                               "Cannot use ENABLE_BANNER inside a function!");                                        \
+                               __attribute__((constructor(PRE_PROS_INIT_PRIORITY))) static void _enable_banner_impl() \
+                               { pros::c::enable_banner(enabled); }
+#else
 #define ENABLE_BANNER(enabled) static_assert(!__builtin_strcmp(__FUNCTION__, "top level"),                            \
                                "Cannot use ENABLE_BANNER inside a function!");                                        \
                                __attribute__((constructor(PRE_PROS_INIT_PRIORITY))) static void _enable_banner_impl() \
                                { enable_banner(enabled); }
-
+#endif
 ///@}
 
 /// \name Filesystem

--- a/include/pros/apix.h
+++ b/include/pros/apix.h
@@ -661,6 +661,42 @@ v5_device_e_t registry_get_plugged_type(uint8_t port);
 
 ///@}
 
+/// \name Startup options
+///@{
+
+/**
+ * Enable/disable the PROS banner printed to the serial stream.
+ *
+ * \warning This function must be called BEFORE the PROS daemon starts.
+ * The easiest way to acheive this is to NOT call this function directly, 
+ * and instead use the BANNER_ENABLE macro.
+ *
+ * \param enable
+ *          Whether the banner should be enabled or disabled.
+ */
+void enable_banner(bool enabled);
+
+/**
+ * This priority value, when used with __attribute__((constructor( ))), is 
+ * guaranteed to run before PROS initializes.
+ */
+#define PRE_PROS_INIT_PRIORITY 101
+
+/**
+ * Enable/disable the PROS banner printed to the serial stream.
+ *
+ * \warning This macro must be used in global scope, outside of any function.
+ *
+ * \param enable
+ *          Whether the banner should be enabled or disabled.
+ */
+#define ENABLE_BANNER(enabled) static_assert(!__builtin_strcmp(__FUNCTION__, "top level"),                            \
+                               "Cannot use ENABLE_BANNER inside a function!");                                        \
+                               __attribute__((constructor(PRE_PROS_INIT_PRIORITY))) static void _enable_banner_impl() \
+                               { enable_banner(enabled); }
+
+///@}
+
 /// \name Filesystem
 ///@{
 

--- a/src/system/dev/ser_daemon.c
+++ b/src/system/dev/ser_daemon.c
@@ -30,7 +30,14 @@ __attribute__((weak)) char const* const _PROS_COMPILE_TIMESTAMP = "Unknown";
 __attribute__((weak)) char const* const _PROS_COMPILE_DIRECTORY = "Unknown";
 __attribute__((weak)) const int         _PROS_COMPILE_TIMESTAMP_INT = 0;
 
+static bool banner_is_enabled = true;
+
+void enable_banner(bool enabled) {
+	banner_is_enabled = enabled;
+}
+
 void print_small_banner(void) {
+	if (!banner_is_enabled) return;
 	uint32_t uptime = millis();
 	char const * const timestamp = (HOT_TABLE && HOT_TABLE->compile_timestamp) ? HOT_TABLE->compile_timestamp : _PROS_COMPILE_TIMESTAMP;
 	char const * const directory = (HOT_TABLE && HOT_TABLE->compile_directory) ? HOT_TABLE->compile_directory : _PROS_COMPILE_DIRECTORY;
@@ -39,6 +46,7 @@ void print_small_banner(void) {
 }
 
 void print_large_banner(void) {
+	if (!banner_is_enabled) return;
 	uint8_t version[4];
 	uint32_t* sys_ver = (uint32_t*)version;
 	*sys_ver = vexSystemVersion();

--- a/src/system/startup.c
+++ b/src/system/startup.c
@@ -29,11 +29,12 @@ extern void invoke_install_hot_table();
 
 // XXX: pros_init happens inside __libc_init_array, and before any global
 // C++ constructors are invoked. This is accomplished by instructing
-// GCC to include this function in the __init_array. The 101 argument
+// GCC to include this function in the __init_array. The 102 argument
 // gives the compiler instructions on the priority of the constructor,
 // from 0-~65k. The first 0-100 priorities are reserved for language
-// implementation.
-__attribute__((constructor(101))) static void pros_init(void) {
+// implementation. Priority 101 is not used to allow functions such as
+// banner_enable to run before PROS initializes.
+__attribute__((constructor(102))) static void pros_init(void) {
 	rtos_initialize();
 
 	vfs_initialize();


### PR DESCRIPTION
#### Summary:
This PR allows users to disable the PROS banner.

#### Motivation:
The banner can interfere with users who are doing serial comms through the USB port.

#### Test Plan:
- [x] test it compiles
- [x] test that ENABLE_BANNER(true) works with monolith
- [x] test that ENABLE_BANNER(false) works with monolith
- [x] test that ENABLE_BANNER(true) works with hot/cold
- [x] test that ENABLE_BANNER(false) works with hot/cold
- [x] test that ENABLE_BANNER does NOT compile inside a function, with a helpful error message
