### PR TITLE
docs: :memo: Fix misleading example code for distance sensor api

### DIFF
--- a/include/pros/distance.hpp
+++ b/include/pros/distance.hpp
@@ -77,7 +77,7 @@ class Distance : public Device {
 	 * void opcontrol() {
 	  Distance distance(DISTANCE_PORT);
 	 *   while (true) {
-	 *     printf("Distance confidence: %d\n", distance.get());
+	 *     printf("Distance: %d\n", distance.get());
 	 *     delay(20);
 	 *   }
 	 * }
@@ -104,7 +104,7 @@ class Distance : public Device {
 	 * void opcontrol() {
 	  Distance distance(DISTANCE_PORT);
 	 *   while (true) {
-	 *     printf("Distance confidence: %d\n", distance.get_distance());
+	 *     printf("Distance: %d\n", distance.get_distance());
 	 *     delay(20);
 	 *   }
 	 * }
@@ -179,7 +179,7 @@ class Distance : public Device {
 	 * void opcontrol() {
 	  Distance distance(DISTANCE_PORT);
 	 *   while (true) {
-	 *     printf("Distance confidence: %d\n", distance.get_object_size());
+	 *     printf("Distance object size: %d\n", distance.get_object_size());
 	 *     delay(20);
 	 *   }
 	 * }
@@ -204,7 +204,7 @@ class Distance : public Device {
 	 * void opcontrol() {
 	 *	Distance distance(DISTANCE_PORT);
 	 *   while (true) {
-	 *     printf("Distance Object velocity: %f\n", distance.get_object_velocity());
+	 *     printf("Distance object velocity: %f\n", distance.get_object_velocity());
 	 *     delay(20);
 	 *   }
 	 * }


### PR DESCRIPTION
#### Summary:
This PR fixes some misleading example code for the distance sensor C++ API.

#### Motivation:
The example code is confusing right now, since it misrepresents the return values of several API functions.

##### References (optional):
Closes #744

#### Test Plan:
n/a
