### PR TITLE
add serial.h/.hpp to api.h

### DIFF
--- a/include/api.h
+++ b/include/api.h
@@ -56,6 +56,7 @@
 #include "pros/rotation.h"
 #include "pros/rtos.h"
 #include "pros/screen.h"
+#include "pros/serial.h"
 #include "pros/vision.h"
 
 #ifdef __cplusplus
@@ -75,6 +76,7 @@
 #include "pros/rotation.hpp"
 #include "pros/rtos.hpp"
 #include "pros/screen.hpp"
+#include "pros/serial.hpp"
 #include "pros/vision.hpp"
 #endif
 


### PR DESCRIPTION
For some reason serial.h and serial.hpp was not included in api.h. 
Shout out to Renzhi for finding this mistake.
