### PR TITLE
fix adi expander docs... lmao

### DIFF
--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -101,7 +101,7 @@ class Port {
 	 * #define EXT_ADI_SMART_PORT 1
 	 * 
 	 * void initialize() {
-	 *   pros::adi::Port sensor ({ EXT_ADI_SMART_PORT , ANALOG_SENSOR_PORT }, E_ADI_ANALOG_IN);
+	 *   pros::adi::Port sensor ({EXT_ADI_SMART_PORT, ANALOG_SENSOR_PORT}, E_ADI_ANALOG_IN);
 	 *   // Displays the value of E_ADI_ANALOG_IN
 	 *   std::cout << "Port Type: " << sensor.get_config();
 	 * }
@@ -277,7 +277,7 @@ class AnalogIn : protected Port {
 	 * #define ADI_PORT 'a'
 	 * 
 	 * void opcontrol() {
-	 *   pros::ADIAnalogIn sensor ({{EXT_ADI_SMART_PORT, ADI_PORT}});
+	 *   pros::ADIAnalogIn sensor ({EXT_ADI_SMART_PORT, ADI_PORT});
 	 *   while (true) {
 	 *     // Use the sensor
 	 *   }
@@ -301,20 +301,20 @@ class AnalogIn : protected Port {
 	 *
 	 * Do not use this function when the sensor value might be unstable (gyro
 	 * rotation, accelerometer movement).
-	 * 
+	 *
 	 * \note The ADI currently returns data at 10ms intervals, in contrast to the
-	 * calibrate function’s 1ms sample rate. 
+	 * calibrate function’s 1ms sample rate.
 	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port is not configured as an analog input
 	 *
 	 * \return The average sensor value computed by this function
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 1
-	 * 
+	 *
 	 * void initialize() {
 	 *   pros::adi::AnalogIn sensor (ANALOG_SENSOR_PORT);
 	 *   sensor.calibrate(ANALOG_SENSOR_PORT);
@@ -339,11 +339,11 @@ class AnalogIn : protected Port {
 	 *
 	 * \return The difference of the sensor value from its calibrated default from
 	 * -4095 to 4095
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 1
-	 * 
+	 *
 	 * void initialize() {
 	 *   pros::adi::AnalogIn sensor (ANALOG_SENSOR_PORT);
 	 *   sensor.calibrate(ANALOG_SENSOR_PORT);
@@ -373,11 +373,11 @@ class AnalogIn : protected Port {
 	 *
 	 * \return The difference of the sensor value from its calibrated default from
 	 * -16384 to 16384
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 1
-	 * 
+	 *
 	 * void initialize() {
 	 *   pros::adi::AnalogIn sensor (ANALOG_SENSOR_PORT);
 	 *   sensor.calibrate(ANALOG_SENSOR_PORT);
@@ -390,22 +390,22 @@ class AnalogIn : protected Port {
 
 	/**
 	 * Reads an analog input channel and returns the 12-bit value.
-	 * 
+	 *
 	 * The value returned is undefined if the analog pin has been switched to a different mode. The meaning of the returned value varies depending on the sensor attached.
-	 * 
+	 *
 	 * Inherited from ADIPort::get_value.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is reached:
 	 * EADDRINUSE - The port is not configured as an analog input (e.g. the port has been reconfigured)
-	 * 
+	 *
 	 * \return The analog sensor value, where a value of 0 reflects an input
 	 * voltage of nearly 0 V and a value of 4095 reflects an input voltage of
 	 * nearly 5 V
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 1
-	 * 
+	 *
 	 * void initialize() {
 	 *   pros::adi::AnalogIn sensor (ANALOG_SENSOR_PORT);
 	 *   std::cout << "Sensor Reading:" << sensor.get_value();
@@ -419,7 +419,7 @@ class AnalogIn : protected Port {
      *
      * Prints in format(this below is all in one line with no new line):
 	 * AnalogIn [smart_port: analog_in._smart_port, adi_port: analog_in._adi_port,
-	 * value calibrated: (12 bit calibrated value), 
+	 * value calibrated: (12 bit calibrated value),
 	 * value calibrated HR: (16 bit calibrated value), value: (12 bit value)]
 	 */
 	friend std::ostream& operator<<(std::ostream& os, pros::adi::AnalogIn& analog_in);
@@ -450,11 +450,11 @@ class AnalogOut : private Port {
 	 *
 	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::AnalogOut sensor (ANALOG_SENSOR_PORT);
 	 *   // Use the sensor
@@ -474,14 +474,14 @@ class AnalogOut : private Port {
 	 * \param port_pair
 	 *        The pair of the smart port number (from 1-22) and the
 	 * 		  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define EXT_ADI_SMART_PORT 1
 	 * #define ADI_PORT 'a'
-	 * 
+	 *
 	 * void opcontrol() {
-	 *   pros::AnalogOut sensor ({{EXT_ADI_SMART_PORT, ADI_PORT}});
+	 *   pros::AnalogOut sensor ({EXT_ADI_SMART_PORT, ADI_PORT});
 	 *   // Use the sensor
 	 * }
 	 * \endcode
@@ -492,7 +492,7 @@ class AnalogOut : private Port {
 	 * Sets the output for the Analog Output from 0 (0V) to 4095 (5V).
 	 *
 	 * Inherited from ADIPort::set_value.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is reached:
 	 * EACCES - Another resource is currently trying to access the ADI.
 	 *
@@ -501,11 +501,11 @@ class AnalogOut : private Port {
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::AnalogOut sensor (ANALOG_SENSOR_PORT);
 	 *   sensor.set_value(4095); // Set the port to 5V
@@ -513,7 +513,7 @@ class AnalogOut : private Port {
 	 * \endcode
 	 */
 	using Port::set_value;
-	
+
 	using Port::get_port;
 
 	/**
@@ -545,11 +545,11 @@ class DigitalOut : private Port {
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param init_state
 	 *        The initial state for the port
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * 	#define DIGITAL_SENSOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   bool state = LOW;
 	 *   pros::adi::DigitalOut sensor (DIGITAL_SENSOR_PORT, state);
@@ -576,15 +576,15 @@ class DigitalOut : private Port {
 	 * 		  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param init_state
 	 *        The initial state for the port
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define EXT_ADI_SMART_PORT 1
 	 * #define ADI_PORT 'a'
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   bool state = LOW;
-	 *   pros::adi::DigitalOut sensor ( {{ EXT_ADI_SMART_PORT , ADI_PORT }});
+	 *   pros::adi::DigitalOut sensor ({EXT_ADI_SMART_PORT , ADI_PORT});
 	 *   while (true) {
 	 *     state != state;
 	 *     sensor.set_value(state);
@@ -599,7 +599,7 @@ class DigitalOut : private Port {
 	 * Sets the digital value (1 or 0) of a pin.
 	 *
 	 * Inherited from ADIPort::set_value.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * EADDRINUSE - The port is not configured as a digital output (e.g. the port has been reconfigured)
@@ -608,11 +608,11 @@ class DigitalOut : private Port {
 	 *        The value to set the ADI port to
 	 *
 	 * \return if the operation was successful or PROS_ERR if the operation failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define DIGITAL_SENSOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   bool state = LOW;
 	 *   pros::adi::DigitalOut sensor (DIGITAL_SENSOR_PORT);
@@ -634,7 +634,7 @@ class DigitalOut : private Port {
 	 * Prints in format(this below is all in one line with no new line):
 	 * DigitalOut [smart_port: digital_out._smart_port, adi_port: digital_out._adi_port,
 	 * value: (value)]
-	 */  
+	 */
 	friend std::ostream& operator<<(std::ostream& os, pros::adi::DigitalOut& digital_out);
 };
 ///@}
@@ -643,7 +643,7 @@ class DigitalIn : private Port {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{
-	 */	
+	 */
 	public:
 	/**
 	 * Configures an ADI port to act as a Digital Input.
@@ -655,11 +655,11 @@ class DigitalIn : private Port {
 	 *
 	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define DIGITAL_SENSOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::DigitalIn sensor (ANALOG_SENSOR_PORT);
 	 *   // Use the sensor
@@ -679,14 +679,14 @@ class DigitalIn : private Port {
 	 * \param port_pair
 	 *        The pair of the smart port number (from 1-22) and the
 	 *  	  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define EXT_ADI_SMART_PORT 1
 	 * #define ADI_PORT 'a'
-	 * 
+	 *
 	 * void opcontrol() {
-	 *   pros::adi::DigitalIn sensor ({{EXT_ADI_SMART_PORT, ADI_PORT}});
+	 *   pros::adi::DigitalIn sensor ({EXT_ADI_SMART_PORT, ADI_PORT});
 	 *   // Use the sensor
 	 * }
 	 * \endcode
@@ -710,11 +710,11 @@ class DigitalIn : private Port {
 	 *
 	 * \return 1 if the button is pressed and had not been pressed the last time
 	 * this function was called, 0 otherwise.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define DIGITAL_SENSOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::DigitalIn sensor (DIGITAL_SENSOR_PORT);
 	 *   while (true) {
@@ -730,21 +730,21 @@ class DigitalIn : private Port {
 
 	/**
 	 * Gets the digital value (1 or 0) of a pin.
-	 * 
+	 *
 	 * Inherited from ADIPort::get_value.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is reached:
-	 * 
+	 *
 	 * EADDRINUSE - The port is not configured as a digital input (e.g. the port has been reconfigured)
-	 * 
+	 *
 	 * Analogous to adi_digital_read.
 	 *
 	 * \return The value stored for the given port
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define DIGITAL_SENSOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::DigitalIn sensor (DIGITAL_SENSOR_PORT);
 	 *   while (true) {
@@ -777,7 +777,7 @@ class Motor : private Port {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{
-	 */	
+	 */
 	public:
 	/**
 	 * Configures an ADI port to act as a Motor.
@@ -789,11 +789,11 @@ class Motor : private Port {
 	 *
 	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define MOTOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Motor motor (MOTOR_PORT);
 	 *   motor.set_value(127); // Go full speed forward
@@ -816,14 +816,14 @@ class Motor : private Port {
 	 * \param port_pair
 	 *        The pair of the smart port number (from 1-22) and the
 	 *  	  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define EXT_ADI_SMART_PORT 1
 	 * #define ADI_MOTOR_PORT 'a'
-	 * 
+	 *
 	 * void opcontrol() {
-	 *   pros::adi::Motor motor ( {{ EXT_ADI_SMART_PORT ,  ADI_MOTOR_PORT}} );
+	 *   pros::adi::Motor motor ({EXT_ADI_SMART_PORT, ADI_MOTOR_PORT});
 	 *   motor.set_value(127); // Go full speed forward
 	 *   std::cout << "Commanded Motor Power: " << motor.get_value(); // Will display 127
 	 *   delay(1000);
@@ -842,11 +842,11 @@ class Motor : private Port {
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define MOTOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Motor motor (MOTOR_PORT);
 	 *   motor.set_value(127); // Go full speed forward
@@ -871,11 +871,11 @@ class Motor : private Port {
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define MOTOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Motor motor (MOTOR_PORT);
 	 *   motor.set_value(127); // Go full speed forward
@@ -894,13 +894,13 @@ class Motor : private Port {
 	 * reached:
 	 * ENODEV - The port is not configured as a motor
 	 *
-	 * \return The last set speed of the motor on the given 
-	 * 
+	 * \return The last set speed of the motor on the given
+	 *
 	 * \b Example
 	 * \code
 	 * #define MOTOR_PORT 1
-	 * 
-	 * void opcontrol() { 
+	 *
+	 * void opcontrol() {
 	 *   pros::adi::Motor motor (MOTOR_PORT);
 	 *   motor.set_value(127); // Go full speed forward
 	 *   std::cout << "Commanded Motor Power: " << motor.get_value(); // Will display 127
@@ -920,7 +920,7 @@ class Encoder : private Port {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{
-	 */	
+	 */
 	public:
 	/**
 	 * Configures a set of ADI ports to act as an Encoder.
@@ -936,12 +936,12 @@ class Encoder : private Port {
 	 *       The "bottom" wire from the encoder sensor
 	 * \param reverse
 	 *        If "true", the sensor will count in the opposite direction
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define PORT_TOP 1
 	 * #define PORT_BOTTOM 2
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Encoder sensor (PORT_TOP, PORT_BOTTOM, false);
 	 *   // Use the sensor
@@ -964,13 +964,13 @@ class Encoder : private Port {
 	 * 		  the encoder sensor
 	 * \param reverse
 	 *        If "true", the sensor will count in theopposite direction
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define PORT_TOP 'A'
 	 * #define PORT_BOTTOM 'B'
 	 * #define SMART_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Encoder sensor ({ SMART_PORT, PORT_TOP, PORT_BOTTOM }, false);
 	 *   // Use the sensor
@@ -991,12 +991,12 @@ class Encoder : private Port {
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define PORT_TOP 1
 	 * #define PORT_BOTTOM 2
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Encoder sensor (PORT_TOP, PORT_BOTTOM, false);
 	 *   delay(1000); // Move the encoder around in this time
@@ -1016,12 +1016,12 @@ class Encoder : private Port {
 	 * ENODEV - The port is not configured as a motor
 	 *
 	 * \return The signed and cumulative number of counts since the last start or
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define PORT_TOP 1
 	 * #define PORT_BOTTOM 2
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Encoder sensor (PORT_TOP, PORT_BOTTOM, false);
 	 *   while (true) {
@@ -1039,7 +1039,7 @@ class Encoder : private Port {
 	 * Prints in format(this below is all in one line with no new line):
 	 * Encoder [smart_port: encoder._smart_port, adi_port: encoder._adi_port,
 	 * value: (value)]
-	 */ 
+	 */
 	friend std::ostream& operator<<(std::ostream& os, pros::adi::Encoder& encoder);
 	ext_adi_port_tuple_t get_port() const override;
 
@@ -1054,7 +1054,7 @@ class Ultrasonic : private Port {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{
-	 */	
+	 */
 	public:
 	/**
 	 * Configures a set of ADI ports to act as an Ultrasonic sensor.
@@ -1070,12 +1070,12 @@ class Ultrasonic : private Port {
 	 * \param port_echo
 	 *        The port connected to the yellow INPUT cable. This should be in the
 	 *        next highest port following port_ping.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define PORT_PING 1
 	 * #define PORT_ECHO 2
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Ultrasonic sensor (PORT_PING, PORT_ECHO);
 	 *   while (true) {
@@ -1101,13 +1101,13 @@ class Ultrasonic : private Port {
 	 * 		  OUTPUT cable (1, 3, 5, 7 or 'A', 'C', 'E', 'G'), and the port
 	 * 		  connected to the yellow INPUT cable (the next) highest port
 	 * 		  following port_ping).
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define PORT_PING 'A'
 	 * #define PORT_ECHO 'B'
 	 * #define SMART_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Ultrasonic sensor ( {{ SMART_PORT, PORT_PING, PORT_ECHO }} );
 	 *   while (true) {
@@ -1133,12 +1133,12 @@ class Ultrasonic : private Port {
 	 *
 	 * \return The distance to the nearest object in m^-4 (10000 indicates 1
 	 * meter), measured from the sensor's mounting points.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define PORT_PING 1
 	 * #define PORT_ECHO 2
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Ultrasonic sensor (PORT_PING, PORT_ECHO);
 	 *   while (true) {
@@ -1160,7 +1160,7 @@ class Gyro : private Port {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{
-	 */	
+	 */
 	public:
 	/**
 	 * Initializes a gyroscope on the given port. If the given port has not
@@ -1182,12 +1182,12 @@ class Gyro : private Port {
 	 *        The ADI port to initialize as a gyro (from 1-8, 'a'-'h', 'A'-'H')
 	 * \param multiplier
 	 *        A scalar value that will be multiplied by the gyro heading value
-	 *        supplied by the 
-	 * 
+	 *        supplied by the
+	 *
 	 * \b Example
 	 * \code
 	 * #define GYRO_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Gyro gyro (GYRO_PORT);
 	 *   while (true) {
@@ -1221,15 +1221,15 @@ class Gyro : private Port {
 	 *  	  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param multiplier
 	 *        A scalar value that will be multiplied by the gyro heading value
-	 *        supplied by the 
-	 * 
+	 *        supplied by the
+	 *
 	 * \b Example
 	 * \code
 	 * #define ADI_GYRO_PORT 'a'
 	 * #define SMART_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
-	 *   pros::adi::Gyro gyro ({{ SMART_PORT , ADI_GYRO_PORT }});
+	 *   pros::adi::Gyro gyro ({SMART_PORT ,ADI_GYRO_PORT});
 	 *   while (true) {
 	 *     // Get the gyro heading
 	 *   std::cout << "Distance: " << gyro.get_value();
@@ -1239,7 +1239,7 @@ class Gyro : private Port {
 	 * \endcode
 	 */
 	explicit Gyro(ext_adi_port_pair_t port_pair, double multiplier = 1);
-  
+
 	/**
 	 * Gets the current gyro angle in tenths of a degree. Unless a multiplier is
 	 * applied to the gyro, the return value will be a whole number representing
@@ -1253,11 +1253,11 @@ class Gyro : private Port {
 	 * ENODEV - The port is not configured as a gyro
 	 *
 	 * \return The gyro angle in degrees.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define GYRO_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Gyro gyro (GYRO_PORT);
 	 *   while (true) {
@@ -1279,24 +1279,24 @@ class Gyro : private Port {
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define GYRO_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Gyro gyro (GYRO_PORT);
 	 *   std::uint32_t now = pros::millis();
 	 *   while (true) {
 	 *     // Get the gyro heading
 	 *     std::cout << "Distance: " << gyro.get_value();
-	 * 
+	 *
 	 *   if (pros::millis() - now > 2000) {
 	 *     // Reset the gyro every 2 seconds
 	 *     gyro.reset();
 	 *     now = pros::millis();
 	 *   }
-	 * 
+	 *
 	 *   pros::delay(10);
 	 *   }
 	 * }
@@ -1313,7 +1313,7 @@ class Potentiometer : public AnalogIn {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{
-	 */	
+	 */
 	public:
 	/**
 	 * Configures an ADI port to act as a Potentiometer.
@@ -1327,12 +1327,12 @@ class Potentiometer : public AnalogIn {
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param potentiometer_type
  	 *        An adi_potentiometer_type_e_t enum value specifying the potentiometer version type
-	  * 
+	  *
 	  * \b Example
 	  * \code
 	  * #define POTENTIOMETER_PORT 1
 	  * #define POTENTIOMETER_TYPE pros::E_ADI_POT_EDR
-	  * 
+	  *
 	  * void opcontrol() {
 	  *   pros::adi::Potentiometer potentiometer (POTENTIOMETER_PORT, POTENTIOMETER_TYPE);
 	  *   while (true) {
@@ -1358,14 +1358,14 @@ class Potentiometer : public AnalogIn {
 	 *  	  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param potentiometer_type
  	 *        An adi_potentiometer_type_e_t enum value specifying the potentiometer version type
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ADI_POTENTIOMETER_PORT 'a'
 	 * #define SMART_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
-	 *   pros::adi::Potentiometer potentiometer ({{ SMART_PORT , ADI_POTENTIOMETER_PORT }});
+	 *   pros::adi::Potentiometer potentiometer ({SMART_PORT, ADI_POTENTIOMETER_PORT});
 	 *   while (true) {
 	 *     // Get the potentiometer angle
 	 *     std::cout << "Angle: " << potentiometer.get_angle();
@@ -1386,14 +1386,14 @@ class Potentiometer : public AnalogIn {
 	 * reached:
 	 * ENXIO - The given value is not within the range of ADI Ports
 	 * EADDRINUSE - The port is not configured as a potentiometer
-	 * 
+	 *
 	 * \return The potentiometer angle in degrees.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ADI_POTENTIOMETER_PORT 'a'
 	 * #define SMART_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Potentiometer potentiometer ({{ SMART_PORT , ADI_POTENTIOMETER_PORT }});
 	 *   while (true) {
@@ -1460,14 +1460,14 @@ class Potentiometer : public AnalogIn {
 
 	/**
 	 * This is the overload for the << operator for printing to streams
-	 * Potentiometer [value: (value), value calibrated: (calibrated value), 
+	 * Potentiometer [value: (value), value calibrated: (calibrated value),
 	 * angle: (angle)]
 	 * Prints in format(this below is all in one line with no new line):
-	 */ 
+	 */
 	friend std::ostream& operator<<(std::ostream& os, pros::adi::Potentiometer& potentiometer);
 
 	using Port::get_port;
-	
+
 };
 
 ///@}
@@ -1476,11 +1476,11 @@ class Led : protected Port {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{
-	 */	
+	 */
 	public:
 	/**
 	 * @brief Configures an ADI port to act as a LED.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENXIO - Either the ADI port value or the smart port value is not within its
@@ -1490,12 +1490,12 @@ class Led : protected Port {
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param length
 	 *        The number of LEDs in the chain
-	 * 
-	 * \b Example: 
+	 *
+	 * \b Example:
 	 * \code
 	 * #define LED_PORT 'a'
 	 * #define LED_LENGTH 3
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::Led led (LED_PORT, LED_LENGTH);
 	 *   while (true) {
@@ -1505,13 +1505,13 @@ class Led : protected Port {
 	 * 	 }
 	 * }
 	* \endcode
-	 * 
+	 *
 	 */
 	explicit Led(std::uint8_t adi_port, std::uint32_t length);
 
 	/**
 	 * @brief Configures an ADI port on a adi_expander to act as a LED.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENXIO - Either the ADI port value or the smart port value is not within its
@@ -1522,15 +1522,15 @@ class Led : protected Port {
 	 *  	  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param length
 	 * 	  The number of LEDs in the chain
-	 * 
-	 * \b Example: 
+	 *
+	 * \b Example:
 	 * \code
 	 * #define LED_PORT 'a'
 	 * #define SMART_PORT 1
 	 * #define LED_LENGTH 3
-	 * 
+	 *
 	 * void opcontrol() {
-	 *   pros::Led led ({{ SMART_PORT , LED_PORT }}, LED_LENGTH);
+	 *   pros::Led led ({SMART_PORT, LED_PORT}, LED_LENGTH);
 	 *   while (true) {
 	 *     // Set entire LED strip to red
 	 *     led.set_all(0xFF0000);


### PR DESCRIPTION
#### Summary:
For some reason the adi docs shows `pros::adi::DigitalOut sensor ( {{ EXT_ADI_SMART_PORT , ADI_PORT }});` and that create a std::initializer_list of pairs, so uhh yep. 
