### PR TITLE
:rotating_light: fix rtos compiler warnings

### DIFF
--- a/src/rtos/rtos.cpp
+++ b/src/rtos/rtos.cpp
@@ -18,8 +18,12 @@
 #include <system_error>
 
 #include "kapi.h"
-#include "rtos/task.h"
 #include "system/optimizers.h"
+
+/* definitions needed from task.h, since directly including it conflicts with definitions in pros/rtos.h */
+
+#define taskENTER_CRITICAL()		portENTER_CRITICAL()
+#define taskEXIT_CRITICAL()			portEXIT_CRITICAL()
 
 namespace pros {
 using namespace pros::c;

--- a/src/rtos/tasks.c
+++ b/src/rtos/tasks.c
@@ -4752,6 +4752,7 @@ uint32_t uxReturn;
 	void task_join(task_t task) {
 		if(!task) return;
 		TaskStatus_t xTaskDetails;
+		extern void task_notify_when_deleting(task_t, task_t, uint32_t, notify_action_e_t);
 		task_notify_when_deleting(task, NULL, 1, E_NOTIFY_ACTION_INCR);
 		do
 		{

--- a/src/system/newlib_stubs.c
+++ b/src/system/newlib_stubs.c
@@ -70,9 +70,12 @@ int getentropy(void *_buffer, size_t _length) {
 
 // HACK: this helps confused libc++ functions call the right instruction. for
 // info see https://github.com/purduesigbots/pros/issues/153#issuecomment-519335375
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winfinite-recursion"
 void __sync_synchronize(void) {
 	__sync_synchronize();
 }
+#pragma GCC diagnostic pop
 
 // These variables are used to store the user-set time.
 // When user_time_set is false, the realtime clock will use the timestamp as the


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
PR #677 introduced some compiler warnings to `rtos/rtos.cpp`. This fixes those issues, and additionally also fixes a compiler warning in `rtos/task.c` due to calling `task_notify_when_deleting` without declaring it.
#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->
