### PR TITLE
:bug: allow creating vexlink devices on empty ports

### DIFF
--- a/src/devices/vdml_link.c
+++ b/src/devices/vdml_link.c
@@ -39,7 +39,7 @@ static uint32_t _link_init(uint8_t port, const char* link_id, link_type_e_t type
             return PROS_ERR;
     }
     v5_device_e_t plugged_type = registry_get_plugged_type(port);
-    if (plugged_type == E_DEVICE_RADIO) {
+    if (plugged_type == E_DEVICE_RADIO || plugged_type == E_DEVICE_NONE) {
         if (!VALIDATE_PORT_NO(port)) {
 		    errno = ENXIO;
 		    return PROS_ERR;


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
See title.
#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
Only the highest port radio is detected as a radio by the brain, and lower port radios are not detected, until the highest port radio disconnects, or it is configured as a vexlink device. Empty ports can be configured as vexlink ports just fine, they will just always report status as disconnected, unless a radio is plugged into the port, after which it behaves as expected of a vexlink radio. Thus, allowing creation of vexlink devices on ports with no device detected is perfectly fine.
##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
#620 
#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [ ] test item
