### PR TITLE
:bookmark: Release 4.2.0

### DIFF
--- a/include/pros/adi.hpp
+++ b/include/pros/adi.hpp
@@ -12,7 +12,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
+ *
  * \defgroup cpp-adi ADI (TriPort) C++ API
  * \note The external ADI API can be found [here.](@ref ext-adi)
  * \note Additional example code for this module can be found in its [Tutorial.](@ref adi)
@@ -22,25 +22,24 @@
 #define _PROS_ADI_HPP_
 
 #include <cstdint>
-#include <vector>
+#include <iostream>
 #include <tuple>
 #include <utility>
-#include <iostream>
+#include <vector>
 
 #include "pros/adi.h"
 
-#define LEGACY_TYPEDEF(old_name, new_name) \
-    using old_name [[deprecated("use " #new_name " instead")]] = new_name
+#define LEGACY_TYPEDEF(old_name, new_name) using old_name [[deprecated("use " #new_name " instead")]] = new_name
 
 namespace pros {
 namespace adi {
-  
+
 /** type definition for the pair of smart port and adi port for the basic adi devices */
 using ext_adi_port_pair_t = std::pair<std::uint8_t, std::uint8_t>;
 
 /** type definition for the triplet of smart port and two adi ports for the two wire adi devices*/
 using ext_adi_port_tuple_t = std::tuple<std::uint8_t, std::uint8_t, std::uint8_t>;
- 
+
 /**
  * \ingroup cpp-adi
  */
@@ -63,12 +62,12 @@ class Port {
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param type
 	 *        The configuration type for the port
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define POTENTIOMETER_PORT 1
 	 * #define POTENTIOMETER_TYPE pros::E_ADI_POT_EDR
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::ADIPotentiometer potentiometer (POTENTIOMETER_PORT, POTENTIOMETER_TYPE);
 	 *   while (true) {
@@ -94,14 +93,14 @@ class Port {
 	 * 		  (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param type
 	 * 		  The configuration type for the port
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 'a'
 	 * #define EXT_ADI_SMART_PORT 1
-	 * 
+	 *
 	 * void initialize() {
-	 *   pros::adi::Port sensor ({ EXT_ADI_SMART_PORT , ANALOG_SENSOR_PORT }, E_ADI_ANALOG_IN);
+	 *   pros::adi::Port sensor ({EXT_ADI_SMART_PORT, ANALOG_SENSOR_PORT}, E_ADI_ANALOG_IN);
 	 *   // Displays the value of E_ADI_ANALOG_IN
 	 *   std::cout << "Port Type: " << sensor.get_config();
 	 * }
@@ -113,7 +112,7 @@ class Port {
 	 * Gets the configuration for the given ADI port.
 	 *
 	 * \return The ADI configuration for the given port
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 1
@@ -130,11 +129,11 @@ class Port {
 	 * Gets the value for the given ADI port.
 	 *
 	 * \return The value stored for the given port
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Port sensor (ANALOG_SENSOR_PORT, E_ADI_ANALOG_IN);
 	 *   std::cout << "Port Value: " << sensor.get_value();
@@ -151,11 +150,11 @@ class Port {
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 1
-	 * 
+	 *
 	 * void initialize() {
 	 *   pros::adi::Port sensor (ANALOG_SENSOR_PORT, E_ADI_DIGITAL_IN);
 	 *   // Do things as a digital sensor
@@ -177,11 +176,11 @@ class Port {
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define DIGITAL_SENSOR_PORT 1
-	 * 
+	 *
 	 * void initialize() {
 	 *   pros::adi::Port sensor (DIGITAL_SENSOR_PORT, E_ADI_DIGITAL_OUT);
 	 *   sensor.set_value(DIGITAL_SENSOR_PORT, HIGH);
@@ -194,24 +193,24 @@ class Port {
 	 * Gets the port of the sensor.
 	 *
 	 * \return returns a tuple of integer ports.
-	 * 
-	 * \note The parts of the tuple are {smart port, adi port, second adi port (when applicable)}. 
-	 * 
-	 * 
+	 *
+	 * \note The parts of the tuple are {smart port, adi port, second adi port (when applicable)}.
+	 *
+	 *
 	 * \b Example
 	 * \code
 	 * #define DIGITAL_SENSOR_PORT 1 // 'A'
-	 * 
+	 *
 	 * void initialize() {
 	 *   pros::adi::AnalogIn sensor (DIGITAL_SENSOR_PORT);
-	 *   
-	 * 	 // Getting values from the tuple using std::get<index> 
+	 *
+	 * 	 // Getting values from the tuple using std::get<index>
 	 * 	 int sensorSmartPort = std::get<0>(sensor.get_port()); // First value
 	 *   int sensorAdiPort = std::get<1>(sensor.get_port()); // Second value
-	 * 
+	 *
 	 * 	 // Prints the first and second value from the port tuple (The Adi Port. The first value is the Smart Port)
 	 *   printf("Sensor Smart Port: %d\n", sensorSmartPort);
-	 *   printf("Sensor Adi Port: %d\n", sensorAdiPort);	
+	 *   printf("Sensor Adi Port: %d\n", sensorAdiPort);
 	 * }
 	 * \endcode
 	 */
@@ -242,11 +241,11 @@ class AnalogIn : protected Port {
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::ADIAnalogIn sensor (ANALOG_SENSOR_PORT);
 	 *   while (true) {
@@ -270,14 +269,14 @@ class AnalogIn : protected Port {
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define EXT_ADI_SENSOR_PORT 1
 	 * #define ADI_PORT 'a'
-	 * 
+	 *
 	 * void opcontrol() {
-	 *   pros::ADIAnalogIn sensor ({{EXT_ADI_SMART_PORT, ADI_PORT}});
+	 *   pros::ADIAnalogIn sensor ({EXT_ADI_SMART_PORT, ADI_PORT});
 	 *   while (true) {
 	 *     // Use the sensor
 	 *   }
@@ -301,20 +300,20 @@ class AnalogIn : protected Port {
 	 *
 	 * Do not use this function when the sensor value might be unstable (gyro
 	 * rotation, accelerometer movement).
-	 * 
+	 *
 	 * \note The ADI currently returns data at 10ms intervals, in contrast to the
-	 * calibrate function’s 1ms sample rate. 
+	 * calibrate function’s 1ms sample rate.
 	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENODEV - The port is not configured as an analog input
 	 *
 	 * \return The average sensor value computed by this function
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 1
-	 * 
+	 *
 	 * void initialize() {
 	 *   pros::adi::AnalogIn sensor (ANALOG_SENSOR_PORT);
 	 *   sensor.calibrate(ANALOG_SENSOR_PORT);
@@ -339,11 +338,11 @@ class AnalogIn : protected Port {
 	 *
 	 * \return The difference of the sensor value from its calibrated default from
 	 * -4095 to 4095
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 1
-	 * 
+	 *
 	 * void initialize() {
 	 *   pros::adi::AnalogIn sensor (ANALOG_SENSOR_PORT);
 	 *   sensor.calibrate(ANALOG_SENSOR_PORT);
@@ -373,11 +372,11 @@ class AnalogIn : protected Port {
 	 *
 	 * \return The difference of the sensor value from its calibrated default from
 	 * -16384 to 16384
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 1
-	 * 
+	 *
 	 * void initialize() {
 	 *   pros::adi::AnalogIn sensor (ANALOG_SENSOR_PORT);
 	 *   sensor.calibrate(ANALOG_SENSOR_PORT);
@@ -390,22 +389,23 @@ class AnalogIn : protected Port {
 
 	/**
 	 * Reads an analog input channel and returns the 12-bit value.
-	 * 
-	 * The value returned is undefined if the analog pin has been switched to a different mode. The meaning of the returned value varies depending on the sensor attached.
-	 * 
+	 *
+	 * The value returned is undefined if the analog pin has been switched to a different mode. The meaning of the
+	 * returned value varies depending on the sensor attached.
+	 *
 	 * Inherited from ADIPort::get_value.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is reached:
 	 * EADDRINUSE - The port is not configured as an analog input (e.g. the port has been reconfigured)
-	 * 
+	 *
 	 * \return The analog sensor value, where a value of 0 reflects an input
 	 * voltage of nearly 0 V and a value of 4095 reflects an input voltage of
 	 * nearly 5 V
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 1
-	 * 
+	 *
 	 * void initialize() {
 	 *   pros::adi::AnalogIn sensor (ANALOG_SENSOR_PORT);
 	 *   std::cout << "Sensor Reading:" << sensor.get_value();
@@ -415,11 +415,11 @@ class AnalogIn : protected Port {
 	using Port::get_value;
 
 	/**
-     * This is the overload for the << operator for printing to streams
-     *
-     * Prints in format(this below is all in one line with no new line):
+	 * This is the overload for the << operator for printing to streams
+	 *
+	 * Prints in format(this below is all in one line with no new line):
 	 * AnalogIn [smart_port: analog_in._smart_port, adi_port: analog_in._adi_port,
-	 * value calibrated: (12 bit calibrated value), 
+	 * value calibrated: (12 bit calibrated value),
 	 * value calibrated HR: (16 bit calibrated value), value: (12 bit value)]
 	 */
 	friend std::ostream& operator<<(std::ostream& os, pros::adi::AnalogIn& analog_in);
@@ -450,11 +450,11 @@ class AnalogOut : private Port {
 	 *
 	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::AnalogOut sensor (ANALOG_SENSOR_PORT);
 	 *   // Use the sensor
@@ -474,14 +474,14 @@ class AnalogOut : private Port {
 	 * \param port_pair
 	 *        The pair of the smart port number (from 1-22) and the
 	 * 		  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define EXT_ADI_SMART_PORT 1
 	 * #define ADI_PORT 'a'
-	 * 
+	 *
 	 * void opcontrol() {
-	 *   pros::AnalogOut sensor ({{EXT_ADI_SMART_PORT, ADI_PORT}});
+	 *   pros::AnalogOut sensor ({EXT_ADI_SMART_PORT, ADI_PORT});
 	 *   // Use the sensor
 	 * }
 	 * \endcode
@@ -492,7 +492,7 @@ class AnalogOut : private Port {
 	 * Sets the output for the Analog Output from 0 (0V) to 4095 (5V).
 	 *
 	 * Inherited from ADIPort::set_value.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is reached:
 	 * EACCES - Another resource is currently trying to access the ADI.
 	 *
@@ -501,11 +501,11 @@ class AnalogOut : private Port {
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ANALOG_SENSOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::AnalogOut sensor (ANALOG_SENSOR_PORT);
 	 *   sensor.set_value(4095); // Set the port to 5V
@@ -513,13 +513,13 @@ class AnalogOut : private Port {
 	 * \endcode
 	 */
 	using Port::set_value;
-	
+
 	using Port::get_port;
 
 	/**
 	 * This is the overload for the << operator for printing to streams
-     *
-     * Prints in format(this below is all in one line with no new line):
+	 *
+	 * Prints in format(this below is all in one line with no new line):
 	 * AnalogOut [smart_port: analog_out._smart_port, adi_port: analog_out._adi_port,
 	 * value: (value)]
 	 */
@@ -545,11 +545,11 @@ class DigitalOut : private Port {
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param init_state
 	 *        The initial state for the port
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * 	#define DIGITAL_SENSOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   bool state = LOW;
 	 *   pros::adi::DigitalOut sensor (DIGITAL_SENSOR_PORT, state);
@@ -576,15 +576,15 @@ class DigitalOut : private Port {
 	 * 		  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param init_state
 	 *        The initial state for the port
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define EXT_ADI_SMART_PORT 1
 	 * #define ADI_PORT 'a'
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   bool state = LOW;
-	 *   pros::adi::DigitalOut sensor ( {{ EXT_ADI_SMART_PORT , ADI_PORT }});
+	 *   pros::adi::DigitalOut sensor ({EXT_ADI_SMART_PORT , ADI_PORT});
 	 *   while (true) {
 	 *     state != state;
 	 *     sensor.set_value(state);
@@ -599,7 +599,7 @@ class DigitalOut : private Port {
 	 * Sets the digital value (1 or 0) of a pin.
 	 *
 	 * Inherited from ADIPort::set_value.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * EADDRINUSE - The port is not configured as a digital output (e.g. the port has been reconfigured)
@@ -608,11 +608,11 @@ class DigitalOut : private Port {
 	 *        The value to set the ADI port to
 	 *
 	 * \return if the operation was successful or PROS_ERR if the operation failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define DIGITAL_SENSOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   bool state = LOW;
 	 *   pros::adi::DigitalOut sensor (DIGITAL_SENSOR_PORT);
@@ -634,7 +634,7 @@ class DigitalOut : private Port {
 	 * Prints in format(this below is all in one line with no new line):
 	 * DigitalOut [smart_port: digital_out._smart_port, adi_port: digital_out._adi_port,
 	 * value: (value)]
-	 */  
+	 */
 	friend std::ostream& operator<<(std::ostream& os, pros::adi::DigitalOut& digital_out);
 };
 ///@}
@@ -643,7 +643,7 @@ class DigitalIn : private Port {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{
-	 */	
+	 */
 	public:
 	/**
 	 * Configures an ADI port to act as a Digital Input.
@@ -655,11 +655,11 @@ class DigitalIn : private Port {
 	 *
 	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define DIGITAL_SENSOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::DigitalIn sensor (ANALOG_SENSOR_PORT);
 	 *   // Use the sensor
@@ -679,14 +679,14 @@ class DigitalIn : private Port {
 	 * \param port_pair
 	 *        The pair of the smart port number (from 1-22) and the
 	 *  	  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define EXT_ADI_SMART_PORT 1
 	 * #define ADI_PORT 'a'
-	 * 
+	 *
 	 * void opcontrol() {
-	 *   pros::adi::DigitalIn sensor ({{EXT_ADI_SMART_PORT, ADI_PORT}});
+	 *   pros::adi::DigitalIn sensor ({EXT_ADI_SMART_PORT, ADI_PORT});
 	 *   // Use the sensor
 	 * }
 	 * \endcode
@@ -710,11 +710,11 @@ class DigitalIn : private Port {
 	 *
 	 * \return 1 if the button is pressed and had not been pressed the last time
 	 * this function was called, 0 otherwise.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define DIGITAL_SENSOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::DigitalIn sensor (DIGITAL_SENSOR_PORT);
 	 *   while (true) {
@@ -730,21 +730,21 @@ class DigitalIn : private Port {
 
 	/**
 	 * Gets the digital value (1 or 0) of a pin.
-	 * 
+	 *
 	 * Inherited from ADIPort::get_value.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is reached:
-	 * 
+	 *
 	 * EADDRINUSE - The port is not configured as a digital input (e.g. the port has been reconfigured)
-	 * 
+	 *
 	 * Analogous to adi_digital_read.
 	 *
 	 * \return The value stored for the given port
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define DIGITAL_SENSOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::DigitalIn sensor (DIGITAL_SENSOR_PORT);
 	 *   while (true) {
@@ -770,14 +770,14 @@ class DigitalIn : private Port {
 
 ///@}
 
-//Derived Class(es) from DigitalIn
+// Derived Class(es) from DigitalIn
 using Button = DigitalIn;
 
 class Motor : private Port {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{
-	 */	
+	 */
 	public:
 	/**
 	 * Configures an ADI port to act as a Motor.
@@ -789,11 +789,11 @@ class Motor : private Port {
 	 *
 	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define MOTOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Motor motor (MOTOR_PORT);
 	 *   motor.set_value(127); // Go full speed forward
@@ -816,14 +816,14 @@ class Motor : private Port {
 	 * \param port_pair
 	 *        The pair of the smart port number (from 1-22) and the
 	 *  	  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define EXT_ADI_SMART_PORT 1
 	 * #define ADI_MOTOR_PORT 'a'
-	 * 
+	 *
 	 * void opcontrol() {
-	 *   pros::adi::Motor motor ( {{ EXT_ADI_SMART_PORT ,  ADI_MOTOR_PORT}} );
+	 *   pros::adi::Motor motor ({EXT_ADI_SMART_PORT, ADI_MOTOR_PORT});
 	 *   motor.set_value(127); // Go full speed forward
 	 *   std::cout << "Commanded Motor Power: " << motor.get_value(); // Will display 127
 	 *   delay(1000);
@@ -842,11 +842,11 @@ class Motor : private Port {
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define MOTOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Motor motor (MOTOR_PORT);
 	 *   motor.set_value(127); // Go full speed forward
@@ -871,11 +871,11 @@ class Motor : private Port {
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define MOTOR_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Motor motor (MOTOR_PORT);
 	 *   motor.set_value(127); // Go full speed forward
@@ -894,13 +894,13 @@ class Motor : private Port {
 	 * reached:
 	 * ENODEV - The port is not configured as a motor
 	 *
-	 * \return The last set speed of the motor on the given 
-	 * 
+	 * \return The last set speed of the motor on the given
+	 *
 	 * \b Example
 	 * \code
 	 * #define MOTOR_PORT 1
-	 * 
-	 * void opcontrol() { 
+	 *
+	 * void opcontrol() {
 	 *   pros::adi::Motor motor (MOTOR_PORT);
 	 *   motor.set_value(127); // Go full speed forward
 	 *   std::cout << "Commanded Motor Power: " << motor.get_value(); // Will display 127
@@ -920,7 +920,7 @@ class Encoder : private Port {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{
-	 */	
+	 */
 	public:
 	/**
 	 * Configures a set of ADI ports to act as an Encoder.
@@ -936,12 +936,12 @@ class Encoder : private Port {
 	 *       The "bottom" wire from the encoder sensor
 	 * \param reverse
 	 *        If "true", the sensor will count in the opposite direction
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define PORT_TOP 1
 	 * #define PORT_BOTTOM 2
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Encoder sensor (PORT_TOP, PORT_BOTTOM, false);
 	 *   // Use the sensor
@@ -964,13 +964,13 @@ class Encoder : private Port {
 	 * 		  the encoder sensor
 	 * \param reverse
 	 *        If "true", the sensor will count in theopposite direction
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define PORT_TOP 'A'
 	 * #define PORT_BOTTOM 'B'
 	 * #define SMART_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Encoder sensor ({ SMART_PORT, PORT_TOP, PORT_BOTTOM }, false);
 	 *   // Use the sensor
@@ -991,12 +991,12 @@ class Encoder : private Port {
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define PORT_TOP 1
 	 * #define PORT_BOTTOM 2
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Encoder sensor (PORT_TOP, PORT_BOTTOM, false);
 	 *   delay(1000); // Move the encoder around in this time
@@ -1016,12 +1016,12 @@ class Encoder : private Port {
 	 * ENODEV - The port is not configured as a motor
 	 *
 	 * \return The signed and cumulative number of counts since the last start or
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define PORT_TOP 1
 	 * #define PORT_BOTTOM 2
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Encoder sensor (PORT_TOP, PORT_BOTTOM, false);
 	 *   while (true) {
@@ -1039,13 +1039,12 @@ class Encoder : private Port {
 	 * Prints in format(this below is all in one line with no new line):
 	 * Encoder [smart_port: encoder._smart_port, adi_port: encoder._adi_port,
 	 * value: (value)]
-	 */ 
+	 */
 	friend std::ostream& operator<<(std::ostream& os, pros::adi::Encoder& encoder);
 	ext_adi_port_tuple_t get_port() const override;
 
 	private:
 	ext_adi_port_pair_t _port_pair;
-
 };
 
 ///@}
@@ -1054,7 +1053,7 @@ class Ultrasonic : private Port {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{
-	 */	
+	 */
 	public:
 	/**
 	 * Configures a set of ADI ports to act as an Ultrasonic sensor.
@@ -1070,12 +1069,12 @@ class Ultrasonic : private Port {
 	 * \param port_echo
 	 *        The port connected to the yellow INPUT cable. This should be in the
 	 *        next highest port following port_ping.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define PORT_PING 1
 	 * #define PORT_ECHO 2
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Ultrasonic sensor (PORT_PING, PORT_ECHO);
 	 *   while (true) {
@@ -1101,13 +1100,13 @@ class Ultrasonic : private Port {
 	 * 		  OUTPUT cable (1, 3, 5, 7 or 'A', 'C', 'E', 'G'), and the port
 	 * 		  connected to the yellow INPUT cable (the next) highest port
 	 * 		  following port_ping).
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define PORT_PING 'A'
 	 * #define PORT_ECHO 'B'
 	 * #define SMART_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Ultrasonic sensor ( {{ SMART_PORT, PORT_PING, PORT_ECHO }} );
 	 *   while (true) {
@@ -1133,12 +1132,12 @@ class Ultrasonic : private Port {
 	 *
 	 * \return The distance to the nearest object in m^-4 (10000 indicates 1
 	 * meter), measured from the sensor's mounting points.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define PORT_PING 1
 	 * #define PORT_ECHO 2
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Ultrasonic sensor (PORT_PING, PORT_ECHO);
 	 *   while (true) {
@@ -1160,7 +1159,7 @@ class Gyro : private Port {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{
-	 */	
+	 */
 	public:
 	/**
 	 * Initializes a gyroscope on the given port. If the given port has not
@@ -1182,12 +1181,12 @@ class Gyro : private Port {
 	 *        The ADI port to initialize as a gyro (from 1-8, 'a'-'h', 'A'-'H')
 	 * \param multiplier
 	 *        A scalar value that will be multiplied by the gyro heading value
-	 *        supplied by the 
-	 * 
+	 *        supplied by the
+	 *
 	 * \b Example
 	 * \code
 	 * #define GYRO_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Gyro gyro (GYRO_PORT);
 	 *   while (true) {
@@ -1221,15 +1220,15 @@ class Gyro : private Port {
 	 *  	  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param multiplier
 	 *        A scalar value that will be multiplied by the gyro heading value
-	 *        supplied by the 
-	 * 
+	 *        supplied by the
+	 *
 	 * \b Example
 	 * \code
 	 * #define ADI_GYRO_PORT 'a'
 	 * #define SMART_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
-	 *   pros::adi::Gyro gyro ({{ SMART_PORT , ADI_GYRO_PORT }});
+	 *   pros::adi::Gyro gyro ({SMART_PORT ,ADI_GYRO_PORT});
 	 *   while (true) {
 	 *     // Get the gyro heading
 	 *   std::cout << "Distance: " << gyro.get_value();
@@ -1239,7 +1238,7 @@ class Gyro : private Port {
 	 * \endcode
 	 */
 	explicit Gyro(ext_adi_port_pair_t port_pair, double multiplier = 1);
-  
+
 	/**
 	 * Gets the current gyro angle in tenths of a degree. Unless a multiplier is
 	 * applied to the gyro, the return value will be a whole number representing
@@ -1253,11 +1252,11 @@ class Gyro : private Port {
 	 * ENODEV - The port is not configured as a gyro
 	 *
 	 * \return The gyro angle in degrees.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define GYRO_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Gyro gyro (GYRO_PORT);
 	 *   while (true) {
@@ -1279,24 +1278,24 @@ class Gyro : private Port {
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define GYRO_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Gyro gyro (GYRO_PORT);
 	 *   std::uint32_t now = pros::millis();
 	 *   while (true) {
 	 *     // Get the gyro heading
 	 *     std::cout << "Distance: " << gyro.get_value();
-	 * 
+	 *
 	 *   if (pros::millis() - now > 2000) {
 	 *     // Reset the gyro every 2 seconds
 	 *     gyro.reset();
 	 *     now = pros::millis();
 	 *   }
-	 * 
+	 *
 	 *   pros::delay(10);
 	 *   }
 	 * }
@@ -1313,7 +1312,7 @@ class Potentiometer : public AnalogIn {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{
-	 */	
+	 */
 	public:
 	/**
 	 * Configures an ADI port to act as a Potentiometer.
@@ -1326,22 +1325,22 @@ class Potentiometer : public AnalogIn {
 	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param potentiometer_type
- 	 *        An adi_potentiometer_type_e_t enum value specifying the potentiometer version type
-	  * 
-	  * \b Example
-	  * \code
-	  * #define POTENTIOMETER_PORT 1
-	  * #define POTENTIOMETER_TYPE pros::E_ADI_POT_EDR
-	  * 
-	  * void opcontrol() {
-	  *   pros::adi::Potentiometer potentiometer (POTENTIOMETER_PORT, POTENTIOMETER_TYPE);
-	  *   while (true) {
-	  *     // Get the potentiometer angle
-	  *     std::cout << "Angle: " << potentiometer.get_angle();
-	  *     pros::delay(10);
-	  *   }
-	  * }
-	  * \endcode
+	 *        An adi_potentiometer_type_e_t enum value specifying the potentiometer version type
+	 *
+	 * \b Example
+	 * \code
+	 * #define POTENTIOMETER_PORT 1
+	 * #define POTENTIOMETER_TYPE pros::E_ADI_POT_EDR
+	 *
+	 * void opcontrol() {
+	 *   pros::adi::Potentiometer potentiometer (POTENTIOMETER_PORT, POTENTIOMETER_TYPE);
+	 *   while (true) {
+	 *     // Get the potentiometer angle
+	 *     std::cout << "Angle: " << potentiometer.get_angle();
+	 *     pros::delay(10);
+	 *   }
+	 * }
+	 * \endcode
 	 */
 	explicit Potentiometer(std::uint8_t adi_port, adi_potentiometer_type_e_t potentiometer_type = E_ADI_POT_EDR);
 
@@ -1357,15 +1356,15 @@ class Potentiometer : public AnalogIn {
 	 *        The pair of the smart port number (from 1-22) and the
 	 *  	  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param potentiometer_type
- 	 *        An adi_potentiometer_type_e_t enum value specifying the potentiometer version type
-	 * 
+	 *        An adi_potentiometer_type_e_t enum value specifying the potentiometer version type
+	 *
 	 * \b Example
 	 * \code
 	 * #define ADI_POTENTIOMETER_PORT 'a'
 	 * #define SMART_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
-	 *   pros::adi::Potentiometer potentiometer ({{ SMART_PORT , ADI_POTENTIOMETER_PORT }});
+	 *   pros::adi::Potentiometer potentiometer ({SMART_PORT, ADI_POTENTIOMETER_PORT});
 	 *   while (true) {
 	 *     // Get the potentiometer angle
 	 *     std::cout << "Angle: " << potentiometer.get_angle();
@@ -1386,14 +1385,14 @@ class Potentiometer : public AnalogIn {
 	 * reached:
 	 * ENXIO - The given value is not within the range of ADI Ports
 	 * EADDRINUSE - The port is not configured as a potentiometer
-	 * 
+	 *
 	 * \return The potentiometer angle in degrees.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ADI_POTENTIOMETER_PORT 'a'
 	 * #define SMART_PORT 1
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::adi::Potentiometer potentiometer ({{ SMART_PORT , ADI_POTENTIOMETER_PORT }});
 	 *   while (true) {
@@ -1460,14 +1459,13 @@ class Potentiometer : public AnalogIn {
 
 	/**
 	 * This is the overload for the << operator for printing to streams
-	 * Potentiometer [value: (value), value calibrated: (calibrated value), 
+	 * Potentiometer [value: (value), value calibrated: (calibrated value),
 	 * angle: (angle)]
 	 * Prints in format(this below is all in one line with no new line):
-	 */ 
+	 */
 	friend std::ostream& operator<<(std::ostream& os, pros::adi::Potentiometer& potentiometer);
 
 	using Port::get_port;
-	
 };
 
 ///@}
@@ -1476,11 +1474,11 @@ class Led : protected Port {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{
-	 */	
+	 */
 	public:
 	/**
 	 * @brief Configures an ADI port to act as a LED.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENXIO - Either the ADI port value or the smart port value is not within its
@@ -1490,12 +1488,12 @@ class Led : protected Port {
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param length
 	 *        The number of LEDs in the chain
-	 * 
-	 * \b Example: 
+	 *
+	 * \b Example:
 	 * \code
 	 * #define LED_PORT 'a'
 	 * #define LED_LENGTH 3
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::Led led (LED_PORT, LED_LENGTH);
 	 *   while (true) {
@@ -1504,14 +1502,14 @@ class Led : protected Port {
 	 * 	   pros::delay(20);
 	 * 	 }
 	 * }
-	* \endcode
-	 * 
+	 * \endcode
+	 *
 	 */
 	explicit Led(std::uint8_t adi_port, std::uint32_t length);
 
 	/**
 	 * @brief Configures an ADI port on a adi_expander to act as a LED.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENXIO - Either the ADI port value or the smart port value is not within its
@@ -1522,15 +1520,15 @@ class Led : protected Port {
 	 *  	  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param length
 	 * 	  The number of LEDs in the chain
-	 * 
-	 * \b Example: 
+	 *
+	 * \b Example:
 	 * \code
 	 * #define LED_PORT 'a'
 	 * #define SMART_PORT 1
 	 * #define LED_LENGTH 3
-	 * 
+	 *
 	 * void opcontrol() {
-	 *   pros::Led led ({{ SMART_PORT , LED_PORT }}, LED_LENGTH);
+	 *   pros::Led led ({SMART_PORT, LED_PORT}, LED_LENGTH);
 	 *   while (true) {
 	 *     // Set entire LED strip to red
 	 *     led.set_all(0xFF0000);
@@ -1542,17 +1540,17 @@ class Led : protected Port {
 	explicit Led(ext_adi_port_pair_t port_pair, std::uint32_t length);
 
 	/**
-	 * @brief Operator overload to access the buffer in the ADILed class, it is 
+	 * @brief Operator overload to access the buffer in the ADILed class, it is
 	 * recommended that you call .update(); after doing any operations with this.
-	 * 
+	 *
 	 * @param i 0 indexed pixel of the lED
 	 * @return uint32_t& the address of the buffer at i to modify
-	 * 
-	 * \b Example: 
+	 *
+	 * \b Example:
 	 * \code
 	 * #define LED_PORT 'a'
 	 * #define LED_LENGTH 3
-	 * 
+	 *
 	 * void opcontrol() {
 	 *   pros::Led led (LED_PORT, LED_LENGTH);
 	 *   while (true) {
@@ -1561,7 +1559,7 @@ class Led : protected Port {
 	 * 	   led.set_pixel(0x00FF00, 1);
 	 * 	   led.set_pixel(0x0000FF, 2);
 	 * 	   pros::delay(20);
-	 * 
+	 *
 	 * 	   // Use the [] operator to set the first pixel to black
 	 * 	   led.operator[](0) = 0x000000;
 	 * 	   led.update();
@@ -1569,194 +1567,194 @@ class Led : protected Port {
 	 *   }
 	 * }
 	 */
-	std::uint32_t& operator[] (size_t i);
+	std::uint32_t& operator[](size_t i);
 
 	/**
-	* @brief Clear the entire led strip of color
-	*
-	* This function uses the following values of errno when an error state is
-	* reached:
-	* ENXIO - The given value is not within the range of ADI Ports
-	* EINVAL - A parameter is out of bounds/incorrect
-	* EADDRINUSE - The port is not configured for ADI output
-	*
-	* @return PROS_SUCCESS if successful, PROS_ERR if not
-	*
-	* \b Example:
-	* \code
-	* #define LED_PORT 'a'
-	* #define LED_LENGTH 3
-	*
-	* void opcontrol() {
-	*   pros::Led led (LED_PORT, LED_LENGTH);
-	*   while (true) {
-	* 	   // Set the first 3 pixels to red, green, and blue
-	* 	   led.set_pixel(0xFF0000, 0);
-	* 	   led.set_pixel(0x00FF00, 1);
-	* 	   led.set_pixel(0x0000FF, 2);
-	* 	   pros::delay(20);
-	*
-	* 	   // Clear the led strip of color
-	* 	   led.clear();
-	* 	   pros::delay(20);
-	*  }
-	* }
-	* \endcode
-	*/
+	 * @brief Clear the entire led strip of color
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENXIO - The given value is not within the range of ADI Ports
+	 * EINVAL - A parameter is out of bounds/incorrect
+	 * EADDRINUSE - The port is not configured for ADI output
+	 *
+	 * @return PROS_SUCCESS if successful, PROS_ERR if not
+	 *
+	 * \b Example:
+	 * \code
+	 * #define LED_PORT 'a'
+	 * #define LED_LENGTH 3
+	 *
+	 * void opcontrol() {
+	 *   pros::Led led (LED_PORT, LED_LENGTH);
+	 *   while (true) {
+	 * 	   // Set the first 3 pixels to red, green, and blue
+	 * 	   led.set_pixel(0xFF0000, 0);
+	 * 	   led.set_pixel(0x00FF00, 1);
+	 * 	   led.set_pixel(0x0000FF, 2);
+	 * 	   pros::delay(20);
+	 *
+	 * 	   // Clear the led strip of color
+	 * 	   led.clear();
+	 * 	   pros::delay(20);
+	 *  }
+	 * }
+	 * \endcode
+	 */
 	std::int32_t clear_all();
 	std::int32_t clear();
-	
+
 	/**
-	* @brief Force the LED strip to update with the current buffered values, this
-	* should be called after any changes to the buffer using the [] operator.
-	*
-	* This function uses the following values of errno when an error state is
-	* reached:
-	* EINVAL - A parameter is out of bounds/incorrect
-	* EADDRINUSE - The port is not configured for ADI output
-	*
-	* @return PROS_SUCCESS if successful, PROS_ERR if not
-	* 
-	* \b Example:
-	* \code
-	* #define LED_PORT 'a'
-	* #define LED_LENGTH 3
-	*
-	* void opcontrol() {
-	*   pros::Led led (LED_PORT, LED_LENGTH);
-	*   while (true) {
-	* 	   // Set the first 3 pixels to red, green, and blue
-	* 	   led.set_pixel(0xFF0000, 0);
-	* 	   led.set_pixel(0x00FF00, 1);
-	* 	   led.set_pixel(0x0000FF, 2);
-	* 	   pros::delay(20);
-	*
-	* 	   // Use the [] operator to set the first pixel to black
-	* 	   led.operator[](0) = 0x000000;
-	*      // Update the led strip with the new values
-	* 	   led.update();
-	* 	   pros::delay(20);
-	*   }
-	* }
-	* \endcode
-	*/
+	 * @brief Force the LED strip to update with the current buffered values, this
+	 * should be called after any changes to the buffer using the [] operator.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * EINVAL - A parameter is out of bounds/incorrect
+	 * EADDRINUSE - The port is not configured for ADI output
+	 *
+	 * @return PROS_SUCCESS if successful, PROS_ERR if not
+	 *
+	 * \b Example:
+	 * \code
+	 * #define LED_PORT 'a'
+	 * #define LED_LENGTH 3
+	 *
+	 * void opcontrol() {
+	 *   pros::Led led (LED_PORT, LED_LENGTH);
+	 *   while (true) {
+	 * 	   // Set the first 3 pixels to red, green, and blue
+	 * 	   led.set_pixel(0xFF0000, 0);
+	 * 	   led.set_pixel(0x00FF00, 1);
+	 * 	   led.set_pixel(0x0000FF, 2);
+	 * 	   pros::delay(20);
+	 *
+	 * 	   // Use the [] operator to set the first pixel to black
+	 * 	   led.operator[](0) = 0x000000;
+	 *      // Update the led strip with the new values
+	 * 	   led.update();
+	 * 	   pros::delay(20);
+	 *   }
+	 * }
+	 * \endcode
+	 */
 	std::int32_t update() const;
 
 	/**
-	* @brief Set the entire led strip to one color
-	*
-	* This function uses the following values of errno when an error state is
-	* reached:
-	* EINVAL - A parameter is out of bounds/incorrect
-	* EADDRINUSE - The port is not configured for ADI output
-	*
-	* @param color color to set all the led strip value to
-	* @return PROS_SUCCESS if successful, PROS_ERR if not
-	*
-	* \b Example:
-	* \code
-	* #define LED_PORT 'a'
-	* #define LED_LENGTH 3
-	*
-	* void opcontrol() {
-	*   pros::Led led (LED_PORT, LED_LENGTH);
-	*   while (true) {
-	* 	   // Set the entire led strip to blue
-	* 	   led.set_all(0x0000FF);
-	* 	   pros::delay(20);
-	* 	 }
-	* }
-	* \endcode
-	*/
+	 * @brief Set the entire led strip to one color
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * EINVAL - A parameter is out of bounds/incorrect
+	 * EADDRINUSE - The port is not configured for ADI output
+	 *
+	 * @param color color to set all the led strip value to
+	 * @return PROS_SUCCESS if successful, PROS_ERR if not
+	 *
+	 * \b Example:
+	 * \code
+	 * #define LED_PORT 'a'
+	 * #define LED_LENGTH 3
+	 *
+	 * void opcontrol() {
+	 *   pros::Led led (LED_PORT, LED_LENGTH);
+	 *   while (true) {
+	 * 	   // Set the entire led strip to blue
+	 * 	   led.set_all(0x0000FF);
+	 * 	   pros::delay(20);
+	 * 	 }
+	 * }
+	 * \endcode
+	 */
 	std::int32_t set_all(uint32_t color);
 
 	/**
-	* @brief Set one pixel on the led strip
-	*
-	* This function uses the following values of errno when an error state is
-	* reached:
-	* EINVAL - A parameter is out of bounds/incorrect
-	* EADDRINUSE - The port is not configured for ADI output
-	*
-	* @param color color to clear all the led strip to
-	* @param pixel_position position of the pixel to clear
-	* @return PROS_SUCCESS if successful, PROS_ERR if not
-	*
-	* \b Example:
-	* \code
-	* #define LED_PORT 'a'
-	* #define LED_LENGTH 3
-	*
-	* void opcontrol() {
-	*   pros::Led led (LED_PORT, LED_LENGTH);
-	*   while (true) {
-	* 	   // Set the first pixel to blue
-	* 	   led.set_pixel(0x0000FF, 0);
-	* 	   pros::delay(20);
-	* 	 }
-	* }
-	* \endcode
-	*/
+	 * @brief Set one pixel on the led strip
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * EINVAL - A parameter is out of bounds/incorrect
+	 * EADDRINUSE - The port is not configured for ADI output
+	 *
+	 * @param color color to clear all the led strip to
+	 * @param pixel_position position of the pixel to clear
+	 * @return PROS_SUCCESS if successful, PROS_ERR if not
+	 *
+	 * \b Example:
+	 * \code
+	 * #define LED_PORT 'a'
+	 * #define LED_LENGTH 3
+	 *
+	 * void opcontrol() {
+	 *   pros::Led led (LED_PORT, LED_LENGTH);
+	 *   while (true) {
+	 * 	   // Set the first pixel to blue
+	 * 	   led.set_pixel(0x0000FF, 0);
+	 * 	   pros::delay(20);
+	 * 	 }
+	 * }
+	 * \endcode
+	 */
 	std::int32_t set_pixel(uint32_t color, uint32_t pixel_position);
 
 	/**
-	* @brief Clear one pixel on the led strip
-	*
-	* This function uses the following values of errno when an error state is
-	* reached:
-	* EINVAL - A parameter is out of bounds/incorrect
-	* EADDRINUSE - The port is not configured for ADI output
-	*
-	* @param pixel_position position of the pixel to clear
-	* @return PROS_SUCCESS if successful, PROS_ERR if not
-	*
-	* \b Example:
-	* \code
-	* #define LED_PORT 'a'
-	* #define LED_LENGTH 3
-	*
-	* void opcontrol() {
-	*   pros::Led led (LED_PORT, LED_LENGTH);
-	*   while (true) {
-	* 	   // Set the first pixel to blue
-	* 	   led.set_pixel(0x0000FF, 0);
-	* 	   pros::delay(20);
-	*
-	* 	   // Clear the first pixel
-	* 	   led.clear_pixel(0);
-	* 	   pros::delay(20);
-	* 	}
-	* }
-	* \endcode
-	*/
+	 * @brief Clear one pixel on the led strip
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * EINVAL - A parameter is out of bounds/incorrect
+	 * EADDRINUSE - The port is not configured for ADI output
+	 *
+	 * @param pixel_position position of the pixel to clear
+	 * @return PROS_SUCCESS if successful, PROS_ERR if not
+	 *
+	 * \b Example:
+	 * \code
+	 * #define LED_PORT 'a'
+	 * #define LED_LENGTH 3
+	 *
+	 * void opcontrol() {
+	 *   pros::Led led (LED_PORT, LED_LENGTH);
+	 *   while (true) {
+	 * 	   // Set the first pixel to blue
+	 * 	   led.set_pixel(0x0000FF, 0);
+	 * 	   pros::delay(20);
+	 *
+	 * 	   // Clear the first pixel
+	 * 	   led.clear_pixel(0);
+	 * 	   pros::delay(20);
+	 * 	}
+	 * }
+	 * \endcode
+	 */
 	std::int32_t clear_pixel(uint32_t pixel_position);
 
 	/**
-	* @brief Get the length of the led strip
-	*
-	* This function uses the following values of errno when an error state is
-	* reached:
-	* EINVAL - A parameter is out of bounds/incorrect
-	* EADDRINUSE - The port is not configured for ADI output
-	*
-	* @return The length (in pixels) of the LED strip
-	*
-	* \b Example:
-	* \code
-	* #define LED_PORT 'a'
-	* #define LED_LENGTH 3
-	*
-	* void opcontrol() {
-	*   pros::Led led (LED_PORT, LED_LENGTH);
-	*   while (true) {
-	* 	   // Get the length of the led strip
-	* 	   int length = led.length();
-	* 	   pros::lcd::print(1, "Length: %d", length);
-	* 	   pros::delay(20);
-	* 	 }
-	* }
-	* \endcode
-	*/
+	 * @brief Get the length of the led strip
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * EINVAL - A parameter is out of bounds/incorrect
+	 * EADDRINUSE - The port is not configured for ADI output
+	 *
+	 * @return The length (in pixels) of the LED strip
+	 *
+	 * \b Example:
+	 * \code
+	 * #define LED_PORT 'a'
+	 * #define LED_LENGTH 3
+	 *
+	 * void opcontrol() {
+	 *   pros::Led led (LED_PORT, LED_LENGTH);
+	 *   while (true) {
+	 * 	   // Get the length of the led strip
+	 * 	   int length = led.length();
+	 * 	   pros::lcd::print(1, "Length: %d", length);
+	 * 	   pros::delay(20);
+	 * 	 }
+	 * }
+	 * \endcode
+	 */
 	std::int32_t length();
 
 	using Port::get_port;
@@ -1773,35 +1771,34 @@ class Pneumatics : public DigitalOut {
 	/**
 	 * \addtogroup cpp-adi
 	 *  @{
-	 */	
+	 */
 	public:
-
 	/**
 	 * Creates a Pneumatics object for the given port.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENXIO - The given value is not within the range of ADI Ports
-	 * 
+	 *
 	 * \param adi_port
 	 *        The ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
 	 * \param start_extended
 	 * 		  If true, the pneumatic will start extended when the program starts.
 	 *		  By default, the piston starts retracted when the program starts.
 	 * \param extended_is_low
-	 * 		  A flag to set whether the the pneumatic is extended when the ADI 
+	 * 		  A flag to set whether the the pneumatic is extended when the ADI
 	 * 		  it receives a high or a low value. When true, the extended state
-	 * 		  corresponds to a output low on the ADI port. This allows the user 
+	 * 		  corresponds to a output low on the ADI port. This allows the user
 	 * 		  to reverse the behavior of the pneumatics if needed.
-	 * 
+	 *
 	 * /b Example:
 	 * \code
 	 * void opcontrol() {
 	 * 	 pros::adi::Pneumatics left_piston('a', false);			// Starts retracted, extends when the ADI port is high
-	 *   pros::adi::Pneumatics right_piston('b', false, true);	// Starts retracted, extends when the ADI port is low 
-	 *   
+	 *   pros::adi::Pneumatics right_piston('b', false, true);	// Starts retracted, extends when the ADI port is low
+	 *
 	 *   pros::Controller master(pros::E_CONTROLLER_MASTER);
-	 * 
+	 *
 	 *   while (true) {
 	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_L1)) {
 	 *       left_piston.extend();
@@ -1809,31 +1806,28 @@ class Pneumatics : public DigitalOut {
 	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_L2)) {
 	 *       left_piston.retract();
 	 *     }
-	 *     
+	 *
 	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_R1)) {
 	 *       left_piston.extend();
 	 *     }
 	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_2)) {
 	 *       left_piston.retract();
 	 *     }
-	 * 
+	 *
 	 *     pros::delay(10);
 	 *   }
-	 * 
+	 *
 	 * \endcode
 	 */
-	explicit Pneumatics(std::uint8_t adi_port, 
-		bool start_extended, 
-		bool extended_is_low = false
-	);
+	explicit Pneumatics(std::uint8_t adi_port, bool start_extended, bool extended_is_low = false);
 
 	/**
 	 * Creates a Pneumatics object for the given port pair.
-	 * 
+	 *
 	 * This function uses the following values of errno when an error state is
 	 * reached:
 	 * ENXIO - The given value is not within the range of ADI Ports
-	 * 
+	 *
 	 * \param port_pair
 	 *        The pair of the smart port number (from 1-22) and the
 	 *  	  ADI port number (from 1-8, 'a'-'h', 'A'-'H') to configure
@@ -1841,19 +1835,20 @@ class Pneumatics : public DigitalOut {
 	 * 		  If true, the pneumatic will start extended when the program starts.
 	 *		  By default, the piston starts retracted when the program starts.
 	 * \param extended_is_low
-	 * 		  A flag to set whether the the pneumatic is extended when the ADI 
+	 * 		  A flag to set whether the the pneumatic is extended when the ADI
 	 * 		  it receives a high or a low value. When true, the extended state
-	 * 		  corresponds to a output low on the ADI port. This allows the user 
+	 * 		  corresponds to a output low on the ADI port. This allows the user
 	 * 		  to reverse the behavior of the pneumatics if needed.
-	 * 
+	 *
 	 * /b Example:
 	 * \code
 	 * void opcontrol() {
 	 * 	 pros::adi::Pneumatics left_piston({1, 'a'}, false);			// Starts retracted, extends when the ADI port is high
-	 *   pros::adi::Pneumatics right_piston({1, 'b'}, false, true);	    // Starts retracted, extends when the ADI port is low 
-	 *   
+	 *   pros::adi::Pneumatics right_piston({1, 'b'}, false, true);	    // Starts retracted, extends when the ADI port is
+	 *low
+	 *
 	 *   pros::Controller master(pros::E_CONTROLLER_MASTER);
-	 * 
+	 *
 	 *   while (true) {
 	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_L1)) {
 	 *       left_piston.extend();
@@ -1861,37 +1856,34 @@ class Pneumatics : public DigitalOut {
 	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_L2)) {
 	 *       left_piston.retract();
 	 *     }
-	 *     
+	 *
 	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_R1)) {
 	 *       left_piston.extend();
 	 *     }
 	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_R2)) {
 	 *       left_piston.retract();
 	 *     }
-	 * 
+	 *
 	 *     pros::delay(10);
 	 *   }
 	 * }
 	 * \endcode
 	 */
-	explicit Pneumatics(ext_adi_port_pair_t port_pair, 
-		bool start_extended, 
-		bool extended_is_low = false
-	);
+	explicit Pneumatics(ext_adi_port_pair_t port_pair, bool start_extended, bool extended_is_low = false);
 
 	/**
 	 * Extends the piston, if not already extended.
-	 * 
+	 *
 	 * \return 1 if the piston newly extended, 0 if the piston was already
-	 *         extended, or PROS_ERR is the operation failed, setting errno. 
-	 * 
+	 *         extended, or PROS_ERR is the operation failed, setting errno.
+	 *
 	 * \b Example:
 	 * \code
 	 * void opcontrol() {
 	 * 	 pros::adi::Pneumatics piston({1, 'a'}, false);            // Starts retracted, extends when the ADI port is high
-	 *   
+	 *
 	 *   pros::Controller master(pros::E_CONTROLLER_MASTER);
-	 * 
+	 *
 	 *   while (true) {
 	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_X)) {
 	 *       left_piston.extend();
@@ -1902,7 +1894,7 @@ class Pneumatics : public DigitalOut {
 	 *     if(mastetr.get_digital(pros::E_CONTROLLER_DIGITAL_A)) {
 	 *       left_piston.toggle();
 	 *     }
-	 * 
+	 *
 	 *     pros::delay(10);
 	 *   }
 	 * }
@@ -1914,15 +1906,15 @@ class Pneumatics : public DigitalOut {
 	 * Retracts the piston, if not already retracted.
 	 *
 	 * \return 1 if the piston newly retracted, 0 if the piston was already
-	 *         retracted, or PROS_ERR is the operation failed, setting errno. 
+	 *         retracted, or PROS_ERR is the operation failed, setting errno.
 	 *
 	 * \b Example:
 	 * \code
 	 * void opcontrol() {
 	 * 	 pros::adi::Pneumatics piston({1, 'a'}, false);            // Starts retracted, extends when the ADI port is high
-	 *   
+	 *
 	 *   pros::Controller master(pros::E_CONTROLLER_MASTER);
-	 * 
+	 *
 	 *   while (true) {
 	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_X)) {
 	 *       left_piston.extend();
@@ -1933,7 +1925,7 @@ class Pneumatics : public DigitalOut {
 	 *     if(mastetr.get_digital(pros::E_CONTROLLER_DIGITAL_A)) {
 	 *       left_piston.toggle();
 	 *     }
-	 * 
+	 *
 	 *     pros::delay(10);
 	 *   }
 	 * }
@@ -1947,17 +1939,17 @@ class Pneumatics : public DigitalOut {
 	 *
 	 * \return 1 if the operation was successful or PROS_ERR if the operation
 	 * failed, setting errno.
-	 * 
-	 * \return 1 if the piston successfully toggled, or PROS_ERR if the 
+	 *
+	 * \return 1 if the piston successfully toggled, or PROS_ERR if the
 	 *         operation failed, setting errno.
 	 *
 	 *\b Example:
 	 * \code
 	 * void opcontrol() {
 	 * 	 pros::adi::Pneumatics piston({1, 'a'}, false);            // Starts retracted, extends when the ADI port is high
-	 *   
+	 *
 	 *   pros::Controller master(pros::E_CONTROLLER_MASTER);
-	 * 
+	 *
 	 *   while (true) {
 	 *     if(master.get_digital(pros::E_CONTROLLER_DIGITAL_X)) {
 	 *       left_piston.extend();
@@ -1968,7 +1960,7 @@ class Pneumatics : public DigitalOut {
 	 *     if(mastetr.get_digital(pros::E_CONTROLLER_DIGITAL_A)) {
 	 *       left_piston.toggle();
 	 *     }
-	 * 
+	 *
 	 *     pros::delay(10);
 	 *   }
 	 * }
@@ -1977,10 +1969,10 @@ class Pneumatics : public DigitalOut {
 	std::int32_t toggle();
 
 	/**
-	 * Returns whether the piston is extended or not. 
-	 * 
+	 * Returns whether the piston is extended or not.
+	 *
 	 * \return true if the piston is extended, false if it is retracted.
-	 * 
+	 *
 	 * \b Example
 	 * \code
 	 * #define ADI_PNEUMATICS_PORT 'a'
@@ -1995,20 +1987,18 @@ class Pneumatics : public DigitalOut {
 	 *     else {
 	 *       printf("The pneumatic is not extended\n");
 	 *     }
-	 * 
+	 *
 	 *     pros::delay(10);
 	 *   }
 	 * }
 	 * \endcode
 	 */
-	bool is_extended() const; 
+	bool is_extended() const;
 
-private: 
-	bool state; 			// Holds the physical state of the ADI port
-	bool extended_is_low;	// A flag that sets whether extended corresponds to
-							// a low signal
-
-	
+	private:
+	bool state;            // Holds the physical state of the ADI port
+	bool extended_is_low;  // A flag that sets whether extended corresponds to
+	                       // a low signal
 };
 ///@}
 
@@ -2017,7 +2007,7 @@ private:
 /*
 Pros4 upgrade backwards compatibility for ADI api.
 
-Prints a deprecated warning when user uses old pros::ADIDevice style API. 
+Prints a deprecated warning when user uses old pros::ADIDevice style API.
 Remove when and if fully removing old API.
 */
 LEGACY_TYPEDEF(ADIPort, pros::adi::Port);
@@ -2032,12 +2022,12 @@ LEGACY_TYPEDEF(ADIUltrasonic, pros::adi::Ultrasonic);
 LEGACY_TYPEDEF(LED, pros::adi::Led);
 
 // Backwards Compatibility for Derived Classes
-LEGACY_TYPEDEF(ADIPotentiometer,pros::adi::Potentiometer);
-LEGACY_TYPEDEF(ADILineSensor,pros::adi::LineSensor);
-LEGACY_TYPEDEF(ADILightSensor,pros::adi::LightSensor);
-LEGACY_TYPEDEF(ADIAccelerometer,pros::adi::Accelerometer);
-LEGACY_TYPEDEF(ADIButton,pros::adi::Button);
-LEGACY_TYPEDEF(ADIPneumatics,pros::adi::Pneumatics);
+LEGACY_TYPEDEF(ADIPotentiometer, pros::adi::Potentiometer);
+LEGACY_TYPEDEF(ADILineSensor, pros::adi::LineSensor);
+LEGACY_TYPEDEF(ADILightSensor, pros::adi::LightSensor);
+LEGACY_TYPEDEF(ADIAccelerometer, pros::adi::Accelerometer);
+LEGACY_TYPEDEF(ADIButton, pros::adi::Button);
+LEGACY_TYPEDEF(ADIPneumatics, pros::adi::Pneumatics);
 LEGACY_TYPEDEF(ADILED, pros::adi::Led);
 LEGACY_TYPEDEF(ADILed, pros::adi::Led);
 

--- a/include/pros/optical.h
+++ b/include/pros/optical.h
@@ -472,7 +472,7 @@ int32_t optical_disable_gesture(uint8_t port);
  * \param port
  *        The V5 Optical Sensor port number from 1-21
  * \return Integration time in milliseconds if the operation is successful 
- * or PROS_ERR if the operation failed, setting errno.
+ * or PROS_ERR_F if the operation failed, setting errno.
  */
 double optical_get_integration_time(uint8_t port);
 

--- a/include/pros/optical.hpp
+++ b/include/pros/optical.hpp
@@ -399,21 +399,6 @@ class Optical : public Device {
 	virtual std::int32_t disable_gesture();
 
 	/**
-	 * Set integration time (update rate) of the optical sensor in milliseconds, with
-	 * minimum time being 3 ms and maximum time being 712 ms. Default is 100 ms, with the 
-	 * optical sensor communciating with the V5 brain every 20 ms. 
-	 *
-	 * This function uses the following values of errno when an error state is
-	 * reached:
-	 * ENXIO - The given value is not within the range of V5 ports (1-21).
-	 * ENODEV - The port cannot be configured as an Optical Sensor
- 	 *
-	 * \return 1 if the operation is successful or PROS_ERR_F if the operation failed,
-	 * setting errno.
-	 */
-	double get_integration_time();
-
-	/**
 	 * Get integration time (update rate) of the optical sensor in milliseconds.
 	 *
 	 * This function uses the following values of errno when an error state is
@@ -421,10 +406,24 @@ class Optical : public Device {
 	 * ENXIO - The given value is not within the range of V5 ports (1-21).
 	 * ENODEV - The port cannot be configured as an Optical Sensor
 	 *
-	 * \param time
-	 *        The desired integration time in milliseconds
-	 * \return Integration time in milliseconds if the operation is successful 
-	 *  or PROS_ERR if the operation failed, setting errno.
+	 * \return Integration time in milliseconds if the operation is successful
+	 *  or PROS_ERR_F if the operation failed, setting errno.
+	 */
+	double get_integration_time();
+
+	/**
+	 * Set integration time (update rate) of the optical sensor in milliseconds, with
+	 * minimum time being 3 ms and maximum time being 712 ms. Default is 100 ms, with the
+	 * optical sensor communciating with the V5 brain every 20 ms.
+	 *
+	 * This function uses the following values of errno when an error state is
+	 * reached:
+	 * ENXIO - The given value is not within the range of V5 ports (1-21).
+	 * ENODEV - The port cannot be configured as an Optical Sensor
+ 	 *
+	 * \param time The desired integration time in milliseconds
+	 * \return 1 if the operation is successful or PROS_ERR if the operation failed,
+	 * setting errno.
 	 */
 	std::int32_t set_integration_time(double time);
 

--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -42,20 +42,18 @@ static controller_data_s_t data[2] = {
 };
 
 static bool get_button_pressed(int port, int button) {
-	return ((controller_data_s_t*)registry_get_device_internal(port)->pad)->button_pressed[button];
+	return data[port - V5_PORT_CONTROLLER_1].button_pressed[button];
 }
 
 static void set_button_pressed(int port, int button, bool state) {
-	data[port - V5_PORT_CONTROLLER_1] = *(controller_data_s_t*)registry_get_device_internal(port)->pad;
 	data[port - V5_PORT_CONTROLLER_1].button_pressed[button] = state;
 }
 
 static bool get_button_released(int port, int button) {
-	return ((controller_data_s_t*)registry_get_device_internal(port)->pad)->button_released[button];
+	return data[port - V5_PORT_CONTROLLER_1].button_released[button];
 }
 
 static void set_button_released(int port, int button, bool state) {
-	data[port - V5_PORT_CONTROLLER_1] = *(controller_data_s_t*)registry_get_device_internal(port)->pad;
 	data[port - V5_PORT_CONTROLLER_1].button_released[button] = state;
 }
 

--- a/src/devices/controller.c
+++ b/src/devices/controller.c
@@ -33,11 +33,11 @@ typedef struct __attribute__((__may_alias__)) controller_data {
 static controller_data_s_t data[2] = {
         {
                 .button_pressed = {false},
-                .button_released = {true},
+                .button_released = {true, true, true, true, true, true, true, true, true, true, true, true, true},
         },
         {
                 .button_pressed = {false},
-                .button_released = {true},
+                .button_released = {true, true, true, true, true, true, true, true, true, true, true, true, true},
         }
 };
 


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
Changes:
- switch to hard float ABI (#703)
- move version info (#709)
- print stack trace to brain screen on data abort (#651)
- fix exit implementation (#671)
- add more weak symbols to llemu (#674)
- add RecursiveMutex class (#677)
- deprecate LLEMU if liblvgl not present (#692)
- motor type getter (#723)
- AI Vision Sensor (#729, #764)
- get state of controllers' power button (#737)
- fix `is_installed` using negative port motors (#741)
- fix rotation sensor set_position (#747)
- increase max text length for controller text setting (#683)
- allow disabling pros banner (#748)
- implement controller get_digital_new_release (#726)
#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [x] test stack trace printed to brain screen on data abort
- [x] test RecursiveMutex
- [x] test getting motor type
- [x] test AI Vision Sensor
- [x] test getting state of controller's power button
- [x] test rotation sensor set_position
- [x] test disabling pros banner
- [x] test controller get_digital_new_release
